### PR TITLE
feat: add AdminMediaController for admin media upload

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/controller/AdminMediaController.java
+++ b/smart-rent/src/main/java/com/smartrent/controller/AdminMediaController.java
@@ -1,0 +1,244 @@
+package com.smartrent.controller;
+
+import com.smartrent.dto.response.ApiResponse;
+import com.smartrent.dto.response.MediaResponse;
+import com.smartrent.service.media.MediaService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.FieldDefaults;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/v1/admin/media")
+@RequiredArgsConstructor
+@FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
+@Tag(name = "Admin - Media", description = "Admin APIs for managing media uploads")
+@SecurityRequirement(name = "Bearer Authentication")
+@PreAuthorize("hasAnyAuthority('ROLE_SA', 'ROLE_UA', 'ROLE_SPA')")
+@Slf4j
+public class AdminMediaController {
+
+    MediaService mediaService;
+
+    @PostMapping("/upload")
+    @Operation(
+            summary = "Upload media (Admin)",
+            description = """
+                    Admin uploads a media file directly to cloud storage.
+                    No user ownership check is performed.
+                    The admin's ID is stored as the media owner.
+                    Optionally associate with a listing (no ownership required).
+                    """
+    )
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "Media uploaded successfully",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "Upload Success",
+                                    value = """
+                                            {
+                                              "code": "999999",
+                                              "message": "Media uploaded successfully by admin.",
+                                              "data": {
+                                                "mediaId": 456,
+                                                "listingId": 123,
+                                                "userId": "admin-uuid-123",
+                                                "mediaType": "IMAGE",
+                                                "sourceType": "UPLOAD",
+                                                "status": "ACTIVE",
+                                                "url": "https://pub-xxx.r2.dev/media/admin-uuid-123/456-photo.jpg",
+                                                "thumbnailUrl": null,
+                                                "title": "Banner Image",
+                                                "description": "Homepage banner",
+                                                "altText": "Banner photo",
+                                                "isPrimary": true,
+                                                "sortOrder": 1,
+                                                "fileSize": 2048576,
+                                                "mimeType": "image/jpeg",
+                                                "originalFilename": "banner.jpg",
+                                                "durationSeconds": null,
+                                                "uploadConfirmed": true,
+                                                "createdAt": "2024-01-15T10:30:00",
+                                                "updatedAt": "2024-01-15T10:30:00"
+                                              }
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "Invalid file type or size",
+                    content = @Content(mediaType = "application/json")
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "Unauthorized - Invalid or missing authentication",
+                    content = @Content(mediaType = "application/json")
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "403",
+                    description = "Forbidden - Requires admin role (SA, UA, SPA)",
+                    content = @Content(mediaType = "application/json")
+            )
+    })
+    public ResponseEntity<ApiResponse<MediaResponse>> uploadMedia(
+            @Parameter(description = "Media file to upload", required = true)
+            @RequestParam("file") MultipartFile file,
+
+            @Parameter(description = "Type of media: IMAGE or VIDEO", required = true)
+            @RequestParam("mediaType") String mediaType,
+
+            @Parameter(description = "Listing ID to associate with (optional, no ownership check)")
+            @RequestParam(value = "listingId", required = false) Long listingId,
+
+            @Parameter(description = "Media title")
+            @RequestParam(value = "title", required = false) String title,
+
+            @Parameter(description = "Media description")
+            @RequestParam(value = "description", required = false) String description,
+
+            @Parameter(description = "Alt text for accessibility")
+            @RequestParam(value = "altText", required = false) String altText,
+
+            @Parameter(description = "Set as primary media")
+            @RequestParam(value = "isPrimary", required = false, defaultValue = "false") Boolean isPrimary,
+
+            @Parameter(description = "Display order")
+            @RequestParam(value = "sortOrder", required = false, defaultValue = "0") Integer sortOrder) {
+
+        String adminId = extractAdminId();
+        log.info("POST /v1/admin/media/upload - admin: {}, filename: {}, type: {}",
+                adminId, file.getOriginalFilename(), mediaType);
+
+        MediaResponse response = mediaService.adminUploadMedia(
+                file, mediaType, listingId, title, description,
+                altText, isPrimary, sortOrder, adminId
+        );
+
+        return ResponseEntity.ok(ApiResponse.<MediaResponse>builder()
+                .data(response)
+                .message("Media uploaded successfully by admin.")
+                .build());
+    }
+
+    @DeleteMapping("/{mediaId}")
+    @Operation(
+            summary = "Delete any media (Admin)",
+            description = "Admin can delete any media regardless of ownership."
+    )
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "Media deleted successfully",
+                    content = @Content(mediaType = "application/json")
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "Media not found",
+                    content = @Content(mediaType = "application/json")
+            )
+    })
+    public ResponseEntity<ApiResponse<Void>> deleteMedia(
+            @Parameter(description = "Media ID") @PathVariable Long mediaId) {
+
+        String adminId = extractAdminId();
+        log.info("DELETE /v1/admin/media/{} - admin: {}", mediaId, adminId);
+
+        mediaService.adminDeleteMedia(mediaId);
+
+        return ResponseEntity.ok(ApiResponse.<Void>builder()
+                .message("Media deleted successfully by admin.")
+                .build());
+    }
+
+    @GetMapping
+    @Operation(
+            summary = "List all media (Admin)",
+            description = "Admin can list all media with optional status filter and pagination."
+    )
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "Media list retrieved successfully",
+                    content = @Content(mediaType = "application/json")
+            )
+    })
+    public ResponseEntity<ApiResponse<List<MediaResponse>>> getAllMedia(
+            @Parameter(description = "Filter by status: PENDING, ACTIVE, ARCHIVED, DELETED")
+            @RequestParam(value = "status", required = false) String status,
+
+            @Parameter(description = "Page number (0-based)")
+            @RequestParam(value = "page", required = false, defaultValue = "0") int page,
+
+            @Parameter(description = "Page size")
+            @RequestParam(value = "size", required = false, defaultValue = "20") int size) {
+
+        String adminId = extractAdminId();
+        log.info("GET /v1/admin/media - admin: {}, status: {}, page: {}, size: {}", adminId, status, page, size);
+
+        List<MediaResponse> media = mediaService.adminGetAllMedia(status, page, size);
+
+        return ResponseEntity.ok(ApiResponse.<List<MediaResponse>>builder()
+                .data(media)
+                .message("Media retrieved successfully")
+                .build());
+    }
+
+    @GetMapping("/{mediaId}")
+    @Operation(
+            summary = "Get media by ID (Admin)",
+            description = "Admin can view any media details regardless of ownership."
+    )
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "Media retrieved successfully",
+                    content = @Content(mediaType = "application/json")
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "Media not found",
+                    content = @Content(mediaType = "application/json")
+            )
+    })
+    public ResponseEntity<ApiResponse<MediaResponse>> getMediaById(
+            @Parameter(description = "Media ID") @PathVariable Long mediaId) {
+
+        log.info("GET /v1/admin/media/{}", mediaId);
+
+        MediaResponse media = mediaService.getMediaById(mediaId);
+
+        return ResponseEntity.ok(ApiResponse.<MediaResponse>builder()
+                .data(media)
+                .message("Media retrieved successfully")
+                .build());
+    }
+
+    private String extractAdminId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || authentication.getName() == null) {
+            throw new IllegalStateException("Admin is not authenticated");
+        }
+        return authentication.getName();
+    }
+}

--- a/smart-rent/src/main/java/com/smartrent/infra/repository/MediaRepository.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/MediaRepository.java
@@ -1,6 +1,8 @@
 package com.smartrent.infra.repository;
 
 import com.smartrent.infra.repository.entity.Media;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -95,6 +97,11 @@ public interface MediaRepository extends JpaRepository<Media, Long> {
      * Check if user owns media
      */
     boolean existsByMediaIdAndUserId(Long mediaId, String userId);
+
+    /**
+     * Find media by status with pagination (for admin)
+     */
+    Page<Media> findByStatus(Media.MediaStatus status, Pageable pageable);
 
     /**
      * Batch-load active media for multiple listings (avoids N+1)

--- a/smart-rent/src/main/java/com/smartrent/service/media/MediaService.java
+++ b/smart-rent/src/main/java/com/smartrent/service/media/MediaService.java
@@ -82,4 +82,32 @@ public interface MediaService {
      * Cleanup expired pending uploads (scheduled job)
      */
     void cleanupExpiredPendingUploads();
+
+    // ==================== Admin Methods ====================
+
+    /**
+     * Admin: Upload media directly (no user ownership check).
+     * Stores adminId as the media owner.
+     */
+    MediaResponse adminUploadMedia(
+            MultipartFile file,
+            String mediaType,
+            Long listingId,
+            String title,
+            String description,
+            String altText,
+            Boolean isPrimary,
+            Integer sortOrder,
+            String adminId
+    );
+
+    /**
+     * Admin: Delete any media by ID (no ownership check)
+     */
+    void adminDeleteMedia(Long mediaId);
+
+    /**
+     * Admin: Get all media (paginated) for moderation
+     */
+    List<MediaResponse> adminGetAllMedia(String status, int page, int size);
 }

--- a/smart-rent/src/main/java/com/smartrent/service/media/MediaServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/media/MediaServiceImpl.java
@@ -7,6 +7,7 @@ import com.smartrent.dto.response.GenerateUploadUrlResponse;
 import com.smartrent.dto.response.MediaResponse;
 import com.smartrent.infra.exception.AppException;
 import com.smartrent.infra.exception.model.DomainCode;
+import com.smartrent.infra.repository.AdminRepository;
 import com.smartrent.infra.repository.ListingRepository;
 import com.smartrent.infra.repository.MediaRepository;
 import com.smartrent.infra.repository.UserRepository;
@@ -17,6 +18,8 @@ import com.smartrent.infra.storage.R2StorageService;
 import com.smartrent.mapper.MediaMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -34,6 +37,7 @@ public class MediaServiceImpl implements MediaService {
 
     private final MediaRepository mediaRepository;
     private final UserRepository userRepository;
+    private final AdminRepository adminRepository;
     private final ListingRepository listingRepository;
     private final R2StorageService storageService;
     private final MediaMapper mediaMapper;
@@ -131,97 +135,22 @@ public class MediaServiceImpl implements MediaService {
                 userId, file.getOriginalFilename(), mediaType);
 
         // Validate user exists
-        User user = userRepository.findById(userId)
+        userRepository.findById(userId)
                 .orElseThrow(() -> new AppException(DomainCode.USER_NOT_FOUND, "User not found"));
 
-        // Validate file is not empty
-        if (file.isEmpty()) {
-            throw new AppException(DomainCode.BAD_REQUEST_ERROR, "File is empty");
-        }
-
-        // Validate file size
-        if (!storageService.isValidFileSize(file.getSize())) {
-            throw new AppException(DomainCode.INVALID_FILE_TYPE,
-                    String.format("File size exceeds maximum allowed: %d MB", file.getSize() / (1024 * 1024)));
-        }
-
-        // Determine if image or video
-        boolean isImage = "IMAGE".equalsIgnoreCase(mediaType);
-        Media.MediaType mediaTypeEnum = isImage ? Media.MediaType.IMAGE : Media.MediaType.VIDEO;
-
-        // Validate content type
-        String contentType = file.getContentType();
-        if (contentType == null || !storageService.isValidContentType(contentType, isImage)) {
-            throw new AppException(DomainCode.INVALID_FILE_TYPE,
-                    String.format("Invalid content type: %s for media type: %s", contentType, mediaType));
-        }
-
-        // Validate listing if provided
+        // Validate listing ownership if provided
         Listing listing = null;
         if (listingId != null) {
             listing = listingRepository.findById(listingId)
                     .orElseThrow(() -> new AppException(DomainCode.LISTING_NOT_FOUND, "Listing not found"));
 
-            // Validate user owns the listing
             if (!listing.getUserId().equals(userId)) {
                 throw new AppException(DomainCode.UNAUTHORIZED,
                         "You don't have permission to add media to this listing");
             }
         }
 
-        // Generate storage key
-        String storageKey = storageService.generateStorageKey(userId, file.getOriginalFilename());
-
-        try {
-            // Upload file directly to R2/S3
-            log.info("Uploading file to cloud storage: {}", storageKey);
-            storageService.uploadFile(
-                    storageKey,
-                    file.getInputStream(),
-                    contentType,
-                    file.getSize()
-            );
-            log.info("File uploaded successfully to cloud storage: {}", storageKey);
-
-            // Generate public URL
-            String publicUrl = storageService.getPublicUrl(storageKey);
-
-            // Create media entity in ACTIVE status (already uploaded)
-            Media media = Media.builder()
-                    .userId(userId)
-                    .listing(listing)
-                    .mediaType(mediaTypeEnum)
-                    .sourceType(Media.MediaSourceType.UPLOAD)
-                    .status(Media.MediaStatus.ACTIVE)
-                    .storageKey(storageKey)
-                    .url(publicUrl)
-                    .originalFilename(file.getOriginalFilename())
-                    .mimeType(contentType)
-                    .fileSize(file.getSize())
-                    .title(title)
-                    .description(description)
-                    .altText(altText)
-                    .isPrimary(isPrimary != null && isPrimary)
-                    .sortOrder(sortOrder != null ? sortOrder : 0)
-                    .uploadConfirmed(true)
-                    .confirmedAt(LocalDateTime.now())
-                    .build();
-
-            media = mediaRepository.save(media);
-
-            log.info("Media saved successfully with ID: {}", media.getMediaId());
-
-            return mediaMapper.toResponse(media);
-
-        } catch (IOException e) {
-            log.error("Failed to read file content: {}", file.getOriginalFilename(), e);
-            throw new AppException(DomainCode.FILE_READ_ERROR,
-                    e.getMessage());
-        } catch (RuntimeException e) {
-            log.error("Failed to upload file to cloud storage: {}", storageKey, e);
-            throw new AppException(DomainCode.FILE_UPLOAD_ERROR,
-                    e.getMessage());
-        }
+        return doUploadMedia(file, mediaType, listing, title, description, altText, isPrimary, sortOrder, userId);
     }
 
     @Override
@@ -498,7 +427,167 @@ public class MediaServiceImpl implements MediaService {
         log.info("Orphan media cleanup completed. Processed {} items", orphanMedia.size());
     }
 
-    // Helper methods
+    // ==================== Admin Methods ====================
+
+    @Override
+    @Transactional
+    public MediaResponse adminUploadMedia(
+            MultipartFile file,
+            String mediaType,
+            Long listingId,
+            String title,
+            String description,
+            String altText,
+            Boolean isPrimary,
+            Integer sortOrder,
+            String adminId) {
+
+        log.info("Admin upload - admin: {}, filename: {}, type: {}",
+                adminId, file.getOriginalFilename(), mediaType);
+
+        // Validate admin exists
+        adminRepository.findById(adminId)
+                .orElseThrow(() -> new AppException(DomainCode.USER_NOT_FOUND, "Admin not found"));
+
+        // Validate listing if provided (no ownership check for admin)
+        Listing listing = null;
+        if (listingId != null) {
+            listing = listingRepository.findById(listingId)
+                    .orElseThrow(() -> new AppException(DomainCode.LISTING_NOT_FOUND, "Listing not found"));
+        }
+
+        return doUploadMedia(file, mediaType, listing, title, description, altText, isPrimary, sortOrder, adminId);
+    }
+
+    @Override
+    @Transactional
+    public void adminDeleteMedia(Long mediaId) {
+        log.info("Admin deleting media ID: {}", mediaId);
+
+        Media media = mediaRepository.findById(mediaId)
+                .orElseThrow(() -> new AppException(DomainCode.ADDRESS_NOT_FOUND, "Media not found"));
+
+        media.setStatus(Media.MediaStatus.DELETED);
+        mediaRepository.save(media);
+
+        if (media.isUploaded() && media.getStorageKey() != null) {
+            try {
+                storageService.deleteObject(media.getStorageKey());
+                log.info("File deleted from storage: {}", media.getStorageKey());
+            } catch (Exception e) {
+                log.error("Failed to delete file from storage: {}", media.getStorageKey(), e);
+            }
+        }
+
+        log.info("Admin deleted media successfully: {}", mediaId);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<MediaResponse> adminGetAllMedia(String status, int page, int size) {
+        log.info("Admin fetching media - status: {}, page: {}, size: {}", status, page, size);
+
+        PageRequest pageRequest = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+
+        List<Media> mediaList;
+        if (status != null && !status.isBlank()) {
+            Media.MediaStatus mediaStatus = Media.MediaStatus.valueOf(status.toUpperCase());
+            mediaList = mediaRepository.findByStatus(mediaStatus, pageRequest).getContent();
+        } else {
+            mediaList = mediaRepository.findAll(pageRequest).getContent();
+        }
+
+        return mediaList.stream()
+                .map(mediaMapper::toResponse)
+                .collect(Collectors.toList());
+    }
+
+    // ==================== Core Upload Logic ====================
+
+    private MediaResponse doUploadMedia(
+            MultipartFile file,
+            String mediaType,
+            Listing listing,
+            String title,
+            String description,
+            String altText,
+            Boolean isPrimary,
+            Integer sortOrder,
+            String ownerId) {
+
+        // Validate file is not empty
+        if (file.isEmpty()) {
+            throw new AppException(DomainCode.BAD_REQUEST_ERROR, "File is empty");
+        }
+
+        // Validate file size
+        if (!storageService.isValidFileSize(file.getSize())) {
+            throw new AppException(DomainCode.INVALID_FILE_TYPE,
+                    String.format("File size exceeds maximum allowed: %d MB", file.getSize() / (1024 * 1024)));
+        }
+
+        // Determine if image or video
+        boolean isImage = "IMAGE".equalsIgnoreCase(mediaType);
+        Media.MediaType mediaTypeEnum = isImage ? Media.MediaType.IMAGE : Media.MediaType.VIDEO;
+
+        // Validate content type
+        String contentType = file.getContentType();
+        if (contentType == null || !storageService.isValidContentType(contentType, isImage)) {
+            throw new AppException(DomainCode.INVALID_FILE_TYPE,
+                    String.format("Invalid content type: %s for media type: %s", contentType, mediaType));
+        }
+
+        // Generate storage key
+        String storageKey = storageService.generateStorageKey(ownerId, file.getOriginalFilename());
+
+        try {
+            log.info("Uploading file to cloud storage: {}", storageKey);
+            storageService.uploadFile(
+                    storageKey,
+                    file.getInputStream(),
+                    contentType,
+                    file.getSize()
+            );
+            log.info("File uploaded successfully to cloud storage: {}", storageKey);
+
+            String publicUrl = storageService.getPublicUrl(storageKey);
+
+            Media media = Media.builder()
+                    .userId(ownerId)
+                    .listing(listing)
+                    .mediaType(mediaTypeEnum)
+                    .sourceType(Media.MediaSourceType.UPLOAD)
+                    .status(Media.MediaStatus.ACTIVE)
+                    .storageKey(storageKey)
+                    .url(publicUrl)
+                    .originalFilename(file.getOriginalFilename())
+                    .mimeType(contentType)
+                    .fileSize(file.getSize())
+                    .title(title)
+                    .description(description)
+                    .altText(altText)
+                    .isPrimary(isPrimary != null && isPrimary)
+                    .sortOrder(sortOrder != null ? sortOrder : 0)
+                    .uploadConfirmed(true)
+                    .confirmedAt(LocalDateTime.now())
+                    .build();
+
+            media = mediaRepository.save(media);
+
+            log.info("Media saved successfully with ID: {}", media.getMediaId());
+
+            return mediaMapper.toResponse(media);
+
+        } catch (IOException e) {
+            log.error("Failed to read file content: {}", file.getOriginalFilename(), e);
+            throw new AppException(DomainCode.FILE_READ_ERROR, e.getMessage());
+        } catch (RuntimeException e) {
+            log.error("Failed to upload file to cloud storage: {}", storageKey, e);
+            throw new AppException(DomainCode.FILE_UPLOAD_ERROR, e.getMessage());
+        }
+    }
+
+    // ==================== Helper Methods ====================
 
     private Media.MediaSourceType detectSourceType(String url) {
         if (url.contains("youtube.com") || url.contains("youtu.be")) {


### PR DESCRIPTION
- Add /v1/admin/media/upload endpoint (no user ownership check)
- Add /v1/admin/media/{id} DELETE (admin can delete any media)
- Add /v1/admin/media GET (list all media with status filter + pagination)
- Add /v1/admin/media/{id} GET (view any media details)
- Refactor MediaServiceImpl: extract shared doUploadMedia() core logic
- Add adminUploadMedia, adminDeleteMedia, adminGetAllMedia to service
- Secured with @PreAuthorize for SA, UA, SPA roles
- Full Swagger docs with response examples for FE integration