### PR TITLE
chore: migrate hardcoded URLs to environment variables

### DIFF
--- a/smart-rent/.env.sample
+++ b/smart-rent/.env.sample
@@ -44,6 +44,8 @@ VNPAY_IPN_URL=http://localhost:8080/v1/payments/ipn/VNPAY
 
 # Client URL
 CLIENT_URL=http://localhost:3000
+ADMIN_URL=http://localhost:3000/admin
+CORS_ALLOWED_ORIGINS=http://localhost:3000
 
 # Admin Contact Configuration
 ADMIN_CONTACT_PHONE=0123456789

--- a/smart-rent/src/main/resources/application.yml
+++ b/smart-rent/src/main/resources/application.yml
@@ -146,10 +146,10 @@ spring:
         "[listing.detail]": 3m
 
 application:
-  client-url: "https://www.smartrent.io.vn"
-  admin-url: "https://smartrent-fe-admin.vercel.app"
+  client-url: "${CLIENT_URL:http://localhost:3000}"
+  admin-url: "${ADMIN_URL:http://localhost:3000/admin}"
   cors:
-    allowed-origins: "https://smartrent-fe.vercel.app"
+    allowed-origins: "${CORS_ALLOWED_ORIGINS:http://localhost:3000}"
   admin:
     contact-phone-number: "${ADMIN_CONTACT_PHONE}"
   authorize-ignored:


### PR DESCRIPTION
Move client-url, admin-url, and cors allowed-origins from hardcoded values in application.yml to environment variable references with sensible localhost defaults for local development.