### PR TITLE
feat: add flat contactName and contactPhone fields to ListingResponse

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/dto/response/ListingResponse.java
+++ b/smart-rent/src/main/java/com/smartrent/dto/response/ListingResponse.java
@@ -113,6 +113,12 @@ public class ListingResponse {
     @Schema(description = "Whether contact information is available")
     Boolean contactAvailable;
 
+    @Schema(description = "Contact person name (owner's full name)", example = "Nguyễn Văn A")
+    String contactName;
+
+    @Schema(description = "Contact phone number", example = "0901234567")
+    String contactPhone;
+
     @Schema(description = "List of amenities associated with this listing")
     List<AmenityResponse> amenities;
 

--- a/smart-rent/src/main/java/com/smartrent/mapper/impl/ListingMapperImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/mapper/impl/ListingMapperImpl.java
@@ -103,6 +103,15 @@ public class ListingMapperImpl implements ListingMapper {
         String ownerZaloLink = ownerContactPhone != null ? "https://zalo.me/" + ownerContactPhone : null;
         Boolean contactAvailable = ownerContactPhone != null && !ownerContactPhone.isBlank();
 
+        // Flat contact fields for AI service consumption
+        String contactName = null;
+        if (user != null) {
+            String first = user.getFirstName() != null ? user.getFirstName() : "";
+            String last = user.getLastName() != null ? user.getLastName() : "";
+            contactName = (last + " " + first).trim();
+        }
+        String contactPhone = ownerContactPhone;
+
         return ListingResponse.builder()
                 .listingId(entity.getListingId())
                 .title(entity.getTitle())
@@ -135,6 +144,8 @@ public class ListingMapperImpl implements ListingMapper {
                 .ownerContactPhoneVerified(ownerContactVerified)
                 .ownerZaloLink(ownerZaloLink)
                 .contactAvailable(contactAvailable)
+                .contactName(contactName)
+                .contactPhone(contactPhone)
                 .amenities(amenityResponses)
                 .media(mediaResponses)
                 .createdAt(entity.getCreatedAt())


### PR DESCRIPTION
This pull request adds new contact information fields to the listing response and updates the mapping logic to populate these fields. The main goal is to provide flat contact fields for easier consumption by AI services.

**API response enhancements:**

* Added `contactName` (owner's full name) and `contactPhone` (owner's phone number) fields to the `ListingResponse` DTO, including schema descriptions and example values.

**Mapping logic updates:**

* Updated `ListingMapperImpl` to compute and set the new `contactName` and `contactPhone` fields when mapping from entity to response, ensuring these values are correctly populated for each listing. [[1]](diffhunk://#diff-49db0bab99279c6460358fcbbe7fb3bc9546d67b13796ac3cada468a065d44e9R106-R114) [[2]](diffhunk://#diff-49db0bab99279c6460358fcbbe7fb3bc9546d67b13796ac3cada468a065d44e9R147-R148)