### PR TITLE
feat: harden presigned upload flow for Cloudflare R2

### DIFF
--- a/smart-rent/.env.sample
+++ b/smart-rent/.env.sample
@@ -26,13 +26,18 @@ RESET_PASSWORD_DURATION=900
 # Google Auth Configuration
 GOOGLE_AUTH_CLIENT_REDIRECT_URI=http://localhost:3000/auth/callback/google
 
-# S3 Storage Configuration
-S3_ENDPOINT=https://your-s3-endpoint.com
-S3_REGION=us-east-1
-S3_ACCESS_KEY=your-access-key
-S3_SECRET_KEY=your-secret-key
-S3_BUCKET=your-bucket-name
-S3_PUBLIC_URL=https://your-public-url.com
+# Cloudflare R2 Storage Configuration
+R2_ENDPOINT=https://<account-id>.r2.cloudflarestorage.com
+R2_REGION=auto
+R2_ACCESS_KEY_ID=your-r2-access-key-id
+R2_SECRET_ACCESS_KEY=your-r2-secret-access-key
+R2_BUCKET_NAME=smart-rent
+# Phase 1: R2 public dev URL, Phase 2: https://cdn.smartrent.io.vn
+R2_PUBLIC_BASE_URL=https://pub-<hash>.r2.dev
+R2_MAX_IMAGE_SIZE_MB=10
+R2_MAX_VIDEO_SIZE_MB=100
+R2_UPLOAD_URL_TTL_MINUTES=10
+R2_DOWNLOAD_URL_TTL_MINUTES=60
 
 # VNPay Configuration
 VNPAY_TMN_CODE=YOUR_TMN_CODE

--- a/smart-rent/src/main/java/com/smartrent/config/S3StorageConfig.java
+++ b/smart-rent/src/main/java/com/smartrent/config/S3StorageConfig.java
@@ -8,7 +8,7 @@ import org.springframework.context.annotation.Configuration;
 import java.util.List;
 
 @Configuration
-@ConfigurationProperties(prefix = "open.storage.s3")
+@ConfigurationProperties(prefix = "open.storage.r2")
 @Getter
 @Setter
 public class S3StorageConfig {
@@ -17,12 +17,13 @@ public class S3StorageConfig {
     private String accessKey;
     private String secretKey;
     private String bucketName;
-    private String publicUrl;
-    private Integer maxFileSizeMB;
+    private String publicBaseUrl;
+    private Integer maxImageSizeMB = 10;
+    private Integer maxVideoSizeMB = 100;
     private List<String> allowedImageTypes;
     private List<String> allowedVideoTypes;
 
     // Presigned URL TTL
-    private Integer uploadUrlTtlMinutes = 30;
+    private Integer uploadUrlTtlMinutes = 10;
     private Integer downloadUrlTtlMinutes = 60;
 }

--- a/smart-rent/src/main/java/com/smartrent/dto/request/GenerateUploadUrlRequest.java
+++ b/smart-rent/src/main/java/com/smartrent/dto/request/GenerateUploadUrlRequest.java
@@ -12,13 +12,16 @@ public class GenerateUploadUrlRequest {
     @NotNull(message = "Media type is required")
     private MediaType mediaType; // IMAGE or VIDEO
 
+    @NotNull(message = "Purpose is required")
+    private Purpose purpose; // LISTING or AVATAR
+
     @NotBlank(message = "Filename is required")
     @Size(max = 255, message = "Filename must not exceed 255 characters")
     private String filename;
 
     @NotBlank(message = "Content type is required")
-    @Pattern(regexp = "^(image/(jpeg|png|webp)|video/(mp4|quicktime))$",
-            message = "Invalid content type. Allowed: image/jpeg, image/png, image/webp, video/mp4, video/quicktime")
+    @Pattern(regexp = "^(image/(jpeg|png|webp)|video/(mp4|webm|quicktime))$",
+            message = "Invalid content type. Allowed: image/jpeg, image/png, image/webp, video/mp4, video/webm, video/quicktime")
     private String contentType;
 
     @NotNull(message = "File size is required")
@@ -26,7 +29,7 @@ public class GenerateUploadUrlRequest {
     @Max(value = 104857600, message = "File size must not exceed 100MB")
     private Long fileSize;
 
-    private Long listingId; // Optional: associate with listing
+    private Long listingId; // Required when purpose=LISTING, must be null otherwise
 
     @Size(max = 255, message = "Title must not exceed 255 characters")
     private String title;
@@ -45,5 +48,9 @@ public class GenerateUploadUrlRequest {
 
     public enum MediaType {
         IMAGE, VIDEO
+    }
+
+    public enum Purpose {
+        LISTING, AVATAR
     }
 }

--- a/smart-rent/src/main/java/com/smartrent/infra/repository/ListingDraftRepository.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/ListingDraftRepository.java
@@ -2,6 +2,7 @@ package com.smartrent.infra.repository;
 
 import com.smartrent.infra.repository.entity.ListingDraft;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -29,5 +30,13 @@ public interface ListingDraftRepository extends JpaRepository<ListingDraft, Long
      * Delete all drafts for a user
      */
     void deleteByUserId(String userId);
+
+    /**
+     * Return every non-empty media_ids string currently referenced by any draft. Used by the
+     * orphan media cleanup cron to avoid deleting media that is still attached to a long-lived
+     * draft. The strings are comma-separated media IDs; the caller parses them into a Set.
+     */
+    @Query("SELECT d.mediaIds FROM ListingDraft d WHERE d.mediaIds IS NOT NULL AND d.mediaIds <> ''")
+    List<String> findAllDraftMediaIdsStrings();
 }
 

--- a/smart-rent/src/main/java/com/smartrent/infra/repository/MediaRepository.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/MediaRepository.java
@@ -54,12 +54,14 @@ public interface MediaRepository extends JpaRepository<Media, Long> {
     List<Media> findExpiredPendingUploads(@Param("expiryTime") LocalDateTime expiryTime);
 
     /**
-     * Find orphan media (ACTIVE media without listing after expiry time)
-     * These are media that were uploaded but never attached to a listing
+     * Find orphan media (ACTIVE media without listing after expiry time).
+     * Avatar uploads live under users/{userId}/avatar/... and stay listing-less forever, so
+     * they must be excluded or the cron would delete every user's avatar 24h after upload.
      */
     @Query("SELECT m FROM media m WHERE m.status = 'ACTIVE' " +
            "AND m.listing IS NULL " +
            "AND m.sourceType = 'UPLOAD' " +
+           "AND (m.storageKey IS NULL OR m.storageKey NOT LIKE 'users/%/avatar/%') " +
            "AND m.createdAt < :expiryTime")
     List<Media> findOrphanActiveMedia(@Param("expiryTime") LocalDateTime expiryTime);
 

--- a/smart-rent/src/main/java/com/smartrent/infra/storage/R2StorageService.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/storage/R2StorageService.java
@@ -13,8 +13,12 @@ import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectResponse;
+import software.amazon.awssdk.services.s3.model.S3Exception;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
 import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest;
@@ -25,6 +29,7 @@ import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 import java.net.URI;
 import java.time.Duration;
+import java.util.Optional;
 import java.util.UUID;
 
 @Service
@@ -71,19 +76,24 @@ public class R2StorageService {
     }
 
     /**
-     * Generate pre-signed upload URL
+     * Generate pre-signed upload URL with Content-Type and Content-Length constraints.
+     * Note: Content-Length signing is best-effort; strict enforcement happens via HeadObject
+     * check after upload in confirmUpload.
      */
-    public PresignedUrlResponse generateUploadUrl(String key, String contentType) {
+    public PresignedUrlResponse generateUploadUrl(String key, String contentType, Long contentLength) {
         try {
-            PutObjectRequest putRequest = PutObjectRequest.builder()
+            PutObjectRequest.Builder putBuilder = PutObjectRequest.builder()
                     .bucket(config.getBucketName())
                     .key(key)
-                    .contentType(contentType)
-                    .build();
+                    .contentType(contentType);
+
+            if (contentLength != null && contentLength > 0) {
+                putBuilder.contentLength(contentLength);
+            }
 
             PutObjectPresignRequest presignRequest = PutObjectPresignRequest.builder()
                     .signatureDuration(Duration.ofMinutes(config.getUploadUrlTtlMinutes()))
-                    .putObjectRequest(putRequest)
+                    .putObjectRequest(putBuilder.build())
                     .build();
 
             PresignedPutObjectRequest presignedRequest = presigner.presignPutObject(presignRequest);
@@ -198,6 +208,28 @@ public class R2StorageService {
     }
 
     /**
+     * Call HeadObject to verify an object exists and inspect its metadata.
+     * Returns empty if the object does not exist.
+     */
+    public Optional<HeadObjectResponse> headObject(String key) {
+        try {
+            HeadObjectResponse response = s3Client.headObject(HeadObjectRequest.builder()
+                    .bucket(config.getBucketName())
+                    .key(key)
+                    .build());
+            return Optional.of(response);
+        } catch (NoSuchKeyException e) {
+            return Optional.empty();
+        } catch (S3Exception e) {
+            if (e.statusCode() == 404) {
+                return Optional.empty();
+            }
+            log.error("HeadObject failed for key: {}", key, e);
+            throw new RuntimeException("Failed to inspect object on storage", e);
+        }
+    }
+
+    /**
      * Delete object from storage
      */
     public void deleteObject(String key) {
@@ -216,35 +248,89 @@ public class R2StorageService {
     }
 
     /**
-     * Generate storage key for media
-     * @param userId User ID (UUID string)
-     * @param filename Original filename
-     * @return Storage key in format: media/{userId}/{uuid}_{sanitized_filename}
+     * Generate storage key for listing media.
+     * Format: listings/{listingId}/{userId}/{uuid}.{ext}
      */
-    public String generateStorageKey(String userId, String filename) {
-        // Sanitize filename: keep only alphanumeric, dots, underscores, and hyphens
-        String sanitized = filename.replaceAll("[^a-zA-Z0-9._-]", "_");
-        String uuid = UUID.randomUUID().toString();
-        return String.format("media/%s/%s_%s", userId, uuid, sanitized);
+    public String generateListingStorageKey(Long listingId, String userId, String filename, String contentType) {
+        String ext = resolveExtension(filename, contentType);
+        return String.format("listings/%d/%s/%s%s", listingId, userId, UUID.randomUUID(), ext);
     }
 
     /**
-     * Get public URL for a key (CDN URL)
+     * Generate storage key for avatar.
+     * Format: users/{userId}/avatar/{uuid}.{ext}
+     */
+    public String generateAvatarStorageKey(String userId, String filename, String contentType) {
+        String ext = resolveExtension(filename, contentType);
+        return String.format("users/%s/avatar/%s%s", userId, UUID.randomUUID(), ext);
+    }
+
+    /**
+     * Generate a generic storage key for uploads without a specific purpose context.
+     * Format: media/{userId}/{uuid}.{ext}
+     */
+    public String generateGenericStorageKey(String userId, String filename, String contentType) {
+        String ext = resolveExtension(filename, contentType);
+        return String.format("media/%s/%s%s", userId, UUID.randomUUID(), ext);
+    }
+
+    private String resolveExtension(String filename, String contentType) {
+        if (filename != null) {
+            int dot = filename.lastIndexOf('.');
+            if (dot >= 0 && dot < filename.length() - 1) {
+                String raw = filename.substring(dot + 1).toLowerCase();
+                String sanitized = raw.replaceAll("[^a-z0-9]", "");
+                if (!sanitized.isEmpty() && sanitized.length() <= 8) {
+                    return "." + sanitized;
+                }
+            }
+        }
+        if (contentType != null) {
+            switch (contentType.toLowerCase()) {
+                case "image/jpeg": return ".jpg";
+                case "image/png": return ".png";
+                case "image/webp": return ".webp";
+                case "video/mp4": return ".mp4";
+                case "video/webm": return ".webm";
+                case "video/quicktime": return ".mov";
+                default: return "";
+            }
+        }
+        return "";
+    }
+
+    /**
+     * Get public URL for a key (public R2 URL or CDN)
      */
     public String getPublicUrl(String key) {
-        if (config.getPublicUrl() != null && !config.getPublicUrl().isEmpty()) {
-            return config.getPublicUrl() + "/" + key;
+        if (config.getPublicBaseUrl() != null && !config.getPublicBaseUrl().isEmpty()) {
+            String base = config.getPublicBaseUrl();
+            if (base.endsWith("/")) {
+                base = base.substring(0, base.length() - 1);
+            }
+            return base + "/" + key;
         }
         // Fallback to endpoint URL if no public URL configured
         return config.getEndpoint() + "/" + config.getBucketName() + "/" + key;
     }
 
     /**
-     * Validate file size
+     * Validate file size against per-media-type limits.
+     *
+     * @param fileSize file size in bytes
+     * @param isImage  true for images, false for videos
      */
-    public boolean isValidFileSize(Long fileSize) {
-        long maxSizeBytes = config.getMaxFileSizeMB() * 1024L * 1024L;
-        return fileSize > 0 && fileSize <= maxSizeBytes;
+    public boolean isValidFileSize(Long fileSize, boolean isImage) {
+        if (fileSize == null || fileSize <= 0) {
+            return false;
+        }
+        int maxMB = isImage ? config.getMaxImageSizeMB() : config.getMaxVideoSizeMB();
+        long maxBytes = maxMB * 1024L * 1024L;
+        return fileSize <= maxBytes;
+    }
+
+    public int getMaxSizeMB(boolean isImage) {
+        return isImage ? config.getMaxImageSizeMB() : config.getMaxVideoSizeMB();
     }
 
     /**

--- a/smart-rent/src/main/java/com/smartrent/service/media/MediaServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/media/MediaServiceImpl.java
@@ -74,19 +74,26 @@ public class MediaServiceImpl implements MediaService {
         String storageKey;
 
         if (purpose == GenerateUploadUrlRequest.Purpose.LISTING) {
-            if (request.getListingId() == null) {
-                throw new AppException(DomainCode.BAD_REQUEST_ERROR,
-                        "listingId is required when purpose is LISTING");
-            }
-            listing = listingRepository.findById(request.getListingId())
-                    .orElseThrow(() -> new AppException(DomainCode.LISTING_NOT_FOUND, "Listing not found"));
+            // listingId is optional on LISTING uploads to support the create-post flow,
+            // where the client uploads media before the listing record exists. When a
+            // listingId is provided (edit flow), verify ownership and use a listing-scoped
+            // storage key. Otherwise fall back to a generic user-scoped key; the media will
+            // be associated to a listing later (via the listing create/update endpoint) and
+            // the cleanupOrphanMedia job sweeps unassociated ACTIVE media after 24 hours.
+            if (request.getListingId() != null) {
+                listing = listingRepository.findById(request.getListingId())
+                        .orElseThrow(() -> new AppException(DomainCode.LISTING_NOT_FOUND, "Listing not found"));
 
-            if (!listing.getUserId().equals(userId)) {
-                throw new AppException(DomainCode.UNAUTHORIZED,
-                        "You don't have permission to add media to this listing");
+                if (!listing.getUserId().equals(userId)) {
+                    throw new AppException(DomainCode.UNAUTHORIZED,
+                            "You don't have permission to add media to this listing");
+                }
+                storageKey = storageService.generateListingStorageKey(
+                        listing.getListingId(), userId, request.getFilename(), request.getContentType());
+            } else {
+                storageKey = storageService.generateGenericStorageKey(
+                        userId, request.getFilename(), request.getContentType());
             }
-            storageKey = storageService.generateListingStorageKey(
-                    listing.getListingId(), userId, request.getFilename(), request.getContentType());
         } else if (purpose == GenerateUploadUrlRequest.Purpose.AVATAR) {
             if (request.getListingId() != null) {
                 throw new AppException(DomainCode.BAD_REQUEST_ERROR,

--- a/smart-rent/src/main/java/com/smartrent/service/media/MediaServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/media/MediaServiceImpl.java
@@ -24,10 +24,12 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
 
 import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -45,47 +47,66 @@ public class MediaServiceImpl implements MediaService {
     @Override
     @Transactional
     public GenerateUploadUrlResponse generateUploadUrl(GenerateUploadUrlRequest request, String userId) {
-        log.info("Generating upload URL for user: {}, type: {}", userId, request.getMediaType());
+        log.info("Generating upload URL for user: {}, type: {}, purpose: {}",
+                userId, request.getMediaType(), request.getPurpose());
 
         // Validate user exists
-        User user = userRepository.findById(userId)
+        userRepository.findById(userId)
                 .orElseThrow(() -> new AppException(DomainCode.USER_NOT_FOUND, "User not found"));
 
-        // Validate content type
+        // Validate content type against media type
         boolean isImage = request.getMediaType() == GenerateUploadUrlRequest.MediaType.IMAGE;
         if (!storageService.isValidContentType(request.getContentType(), isImage)) {
             throw new AppException(DomainCode.INVALID_FILE_TYPE,
-                    String.format("Invalid content type: %s", request.getContentType()));
+                    String.format("Invalid content type %s for %s", request.getContentType(), request.getMediaType()));
         }
 
-        // Validate file size
-        if (!storageService.isValidFileSize(request.getFileSize())) {
-            throw new AppException(DomainCode.INVALID_FILE_TYPE,
-                    "File size exceeds maximum allowed");
+        // Validate file size against per-type limit
+        if (!storageService.isValidFileSize(request.getFileSize(), isImage)) {
+            throw new AppException(DomainCode.FILE_TOO_LARGE,
+                    String.format("File size exceeds maximum allowed for %s: %d MB",
+                            request.getMediaType(), storageService.getMaxSizeMB(isImage)));
         }
 
-        // Validate listing if provided
+        // Cross-validate purpose <-> listingId + mediaType constraints
+        GenerateUploadUrlRequest.Purpose purpose = request.getPurpose();
         Listing listing = null;
-        if (request.getListingId() != null) {
+        String storageKey;
+
+        if (purpose == GenerateUploadUrlRequest.Purpose.LISTING) {
+            if (request.getListingId() == null) {
+                throw new AppException(DomainCode.BAD_REQUEST_ERROR,
+                        "listingId is required when purpose is LISTING");
+            }
             listing = listingRepository.findById(request.getListingId())
                     .orElseThrow(() -> new AppException(DomainCode.LISTING_NOT_FOUND, "Listing not found"));
 
-            // Validate user owns the listing
             if (!listing.getUserId().equals(userId)) {
                 throw new AppException(DomainCode.UNAUTHORIZED,
                         "You don't have permission to add media to this listing");
             }
+            storageKey = storageService.generateListingStorageKey(
+                    listing.getListingId(), userId, request.getFilename(), request.getContentType());
+        } else if (purpose == GenerateUploadUrlRequest.Purpose.AVATAR) {
+            if (request.getListingId() != null) {
+                throw new AppException(DomainCode.BAD_REQUEST_ERROR,
+                        "listingId must not be provided when purpose is AVATAR");
+            }
+            if (!isImage) {
+                throw new AppException(DomainCode.BAD_REQUEST_ERROR,
+                        "Avatar upload requires mediaType=IMAGE");
+            }
+            storageKey = storageService.generateAvatarStorageKey(
+                    userId, request.getFilename(), request.getContentType());
+        } else {
+            throw new AppException(DomainCode.BAD_REQUEST_ERROR, "Unsupported purpose");
         }
-
-        // Generate storage key
-        String storageKey = storageService.generateStorageKey(userId, request.getFilename());
 
         // Create media entity in PENDING status
         Media media = Media.builder()
                 .userId(userId)
                 .listing(listing)
-                .mediaType(request.getMediaType() == GenerateUploadUrlRequest.MediaType.IMAGE ?
-                        Media.MediaType.IMAGE : Media.MediaType.VIDEO)
+                .mediaType(isImage ? Media.MediaType.IMAGE : Media.MediaType.VIDEO)
                 .sourceType(Media.MediaSourceType.UPLOAD)
                 .status(Media.MediaStatus.PENDING)
                 .storageKey(storageKey)
@@ -102,9 +123,9 @@ public class MediaServiceImpl implements MediaService {
 
         media = mediaRepository.save(media);
 
-        // Generate pre-signed upload URL
+        // Generate pre-signed upload URL with content-type + content-length constraints
         R2StorageService.PresignedUrlResponse presignedUrl =
-                storageService.generateUploadUrl(storageKey, request.getContentType());
+                storageService.generateUploadUrl(storageKey, request.getContentType(), request.getFileSize());
 
         log.info("Upload URL generated successfully for media ID: {}", media.getMediaId());
 
@@ -173,6 +194,54 @@ public class MediaServiceImpl implements MediaService {
         if (media.getUploadConfirmed()) {
             log.warn("Upload already confirmed for media ID: {}", mediaId);
             return mediaMapper.toResponse(media);
+        }
+
+        // Verify the file actually exists on R2 and its metadata matches the PENDING record.
+        // This guards against clients calling /confirm without uploading, and against
+        // Content-Length abuse (since SigV4 does not hard-enforce contentLength on PUT).
+        Optional<HeadObjectResponse> headOpt = storageService.headObject(media.getStorageKey());
+        if (headOpt.isEmpty()) {
+            log.warn("Confirm failed: file not found on storage. mediaId={}, key={}",
+                    mediaId, media.getStorageKey());
+            throw new AppException(DomainCode.BAD_REQUEST_ERROR,
+                    "Upload not found on storage. Please upload the file before confirming.");
+        }
+        HeadObjectResponse head = headOpt.get();
+
+        // Content-Length must match what we recorded pre-sign
+        long expectedSize = media.getFileSize() != null ? media.getFileSize() : -1L;
+        long actualSize = head.contentLength() != null ? head.contentLength() : -1L;
+        if (expectedSize > 0 && actualSize != expectedSize) {
+            log.warn("Confirm failed: file size mismatch. mediaId={}, expected={}, actual={}",
+                    mediaId, expectedSize, actualSize);
+            // Cleanup: delete the rogue object + mark record DELETED
+            try {
+                storageService.deleteObject(media.getStorageKey());
+            } catch (Exception e) {
+                log.error("Failed to delete mismatched object: {}", media.getStorageKey(), e);
+            }
+            media.setStatus(Media.MediaStatus.DELETED);
+            mediaRepository.save(media);
+            throw new AppException(DomainCode.FILE_TOO_LARGE,
+                    String.format("Uploaded file size (%d bytes) does not match declared size (%d bytes)",
+                            actualSize, expectedSize));
+        }
+
+        // Content-Type sanity check (R2 already rejects PUT if mismatched, so this is a safety net)
+        String actualContentType = head.contentType();
+        String expectedContentType = media.getMimeType();
+        if (actualContentType != null && expectedContentType != null
+                && !actualContentType.equalsIgnoreCase(expectedContentType)) {
+            log.warn("Content-Type mismatch on confirm. mediaId={}, expected={}, actual={}",
+                    mediaId, expectedContentType, actualContentType);
+        }
+
+        // Reconcile metadata from R2 (in case anything drifted)
+        if (actualContentType != null) {
+            media.setMimeType(actualContentType);
+        }
+        if (actualSize > 0) {
+            media.setFileSize(actualSize);
         }
 
         // Update media status
@@ -353,8 +422,8 @@ public class MediaServiceImpl implements MediaService {
     public void cleanupExpiredPendingUploads() {
         log.info("Starting cleanup of expired pending uploads");
 
-        // Find uploads pending for more than 2 hours
-        LocalDateTime expiryTime = LocalDateTime.now().minusHours(2);
+        // Find uploads pending for more than 1 hour
+        LocalDateTime expiryTime = LocalDateTime.now().minusHours(1);
         List<Media> expiredMedia = mediaRepository.findExpiredPendingUploads(expiryTime);
 
         if (expiredMedia.isEmpty()) {
@@ -520,15 +589,16 @@ public class MediaServiceImpl implements MediaService {
             throw new AppException(DomainCode.BAD_REQUEST_ERROR, "File is empty");
         }
 
-        // Validate file size
-        if (!storageService.isValidFileSize(file.getSize())) {
-            throw new AppException(DomainCode.INVALID_FILE_TYPE,
-                    String.format("File size exceeds maximum allowed: %d MB", file.getSize() / (1024 * 1024)));
-        }
-
         // Determine if image or video
         boolean isImage = "IMAGE".equalsIgnoreCase(mediaType);
         Media.MediaType mediaTypeEnum = isImage ? Media.MediaType.IMAGE : Media.MediaType.VIDEO;
+
+        // Validate file size against per-type limit
+        if (!storageService.isValidFileSize(file.getSize(), isImage)) {
+            throw new AppException(DomainCode.FILE_TOO_LARGE,
+                    String.format("File size exceeds maximum allowed for %s: %d MB",
+                            mediaType, storageService.getMaxSizeMB(isImage)));
+        }
 
         // Validate content type
         String contentType = file.getContentType();
@@ -537,8 +607,12 @@ public class MediaServiceImpl implements MediaService {
                     String.format("Invalid content type: %s for media type: %s", contentType, mediaType));
         }
 
-        // Generate storage key
-        String storageKey = storageService.generateStorageKey(ownerId, file.getOriginalFilename());
+        // Generate storage key: listing-scoped when we have a listing, otherwise generic
+        String storageKey = (listing != null)
+                ? storageService.generateListingStorageKey(
+                        listing.getListingId(), ownerId, file.getOriginalFilename(), contentType)
+                : storageService.generateGenericStorageKey(
+                        ownerId, file.getOriginalFilename(), contentType);
 
         try {
             log.info("Uploading file to cloud storage: {}", storageKey);

--- a/smart-rent/src/main/java/com/smartrent/service/media/MediaServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/media/MediaServiceImpl.java
@@ -8,6 +8,7 @@ import com.smartrent.dto.response.MediaResponse;
 import com.smartrent.infra.exception.AppException;
 import com.smartrent.infra.exception.model.DomainCode;
 import com.smartrent.infra.repository.AdminRepository;
+import com.smartrent.infra.repository.ListingDraftRepository;
 import com.smartrent.infra.repository.ListingRepository;
 import com.smartrent.infra.repository.MediaRepository;
 import com.smartrent.infra.repository.UserRepository;
@@ -28,8 +29,11 @@ import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
 
 import java.io.IOException;
 import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Service
@@ -41,6 +45,7 @@ public class MediaServiceImpl implements MediaService {
     private final UserRepository userRepository;
     private final AdminRepository adminRepository;
     private final ListingRepository listingRepository;
+    private final ListingDraftRepository listingDraftRepository;
     private final R2StorageService storageService;
     private final MediaMapper mediaMapper;
 
@@ -461,21 +466,41 @@ public class MediaServiceImpl implements MediaService {
     }
 
     /**
-     * Cleanup orphan media (ACTIVE media without listing after 24 hours)
-     * This handles cases where user uploaded media but never created a listing
-     * Runs every 6 hours
+     * Cleanup orphan media (ACTIVE media without listing after 24 hours).
+     *
+     * A media record is only a true orphan if it is neither attached to a listing nor
+     * referenced by any draft. Drafts can be long-lived (users save a draft and come back
+     * days or weeks later to publish), so media IDs that appear in any listing_drafts.media_ids
+     * string must be preserved even if the media row itself has listing_id = NULL.
      */
     @Transactional
     @Scheduled(cron = "0 0 */6 * * *") // Run every 6 hours
     public void cleanupOrphanMedia() {
         log.info("Starting cleanup of orphan media (ACTIVE media without listing)");
 
-        // Find ACTIVE media without listing, older than 24 hours
         LocalDateTime expiryTime = LocalDateTime.now().minusHours(24);
-        List<Media> orphanMedia = mediaRepository.findOrphanActiveMedia(expiryTime);
+        List<Media> candidates = mediaRepository.findOrphanActiveMedia(expiryTime);
+
+        if (candidates.isEmpty()) {
+            log.info("No orphan media found");
+            return;
+        }
+
+        Set<Long> draftReferencedIds = loadDraftReferencedMediaIds();
+        List<Media> orphanMedia = draftReferencedIds.isEmpty()
+                ? candidates
+                : candidates.stream()
+                    .filter(m -> !draftReferencedIds.contains(m.getMediaId()))
+                    .collect(Collectors.toList());
+
+        int protectedByDraft = candidates.size() - orphanMedia.size();
+        if (protectedByDraft > 0) {
+            log.info("Protected {} orphan candidate(s) from cleanup because they are still referenced by drafts",
+                    protectedByDraft);
+        }
 
         if (orphanMedia.isEmpty()) {
-            log.info("No orphan media found");
+            log.info("All orphan candidates are referenced by drafts; nothing to clean up");
             return;
         }
 
@@ -501,6 +526,36 @@ public class MediaServiceImpl implements MediaService {
         }
 
         log.info("Orphan media cleanup completed. Processed {} items", orphanMedia.size());
+    }
+
+    /**
+     * Parse every listing_drafts.media_ids string into a single Set of media IDs. Entries are
+     * stored as comma-separated strings, so this walks each row once and ignores malformed
+     * tokens rather than failing the cron over a single bad draft.
+     */
+    private Set<Long> loadDraftReferencedMediaIds() {
+        List<String> raw = listingDraftRepository.findAllDraftMediaIdsStrings();
+        if (raw == null || raw.isEmpty()) {
+            return Collections.emptySet();
+        }
+        Set<Long> ids = new HashSet<>();
+        for (String csv : raw) {
+            if (csv == null || csv.isBlank()) {
+                continue;
+            }
+            for (String token : csv.split(",")) {
+                String trimmed = token.trim();
+                if (trimmed.isEmpty()) {
+                    continue;
+                }
+                try {
+                    ids.add(Long.parseLong(trimmed));
+                } catch (NumberFormatException e) {
+                    log.warn("Ignoring malformed draft media id token: '{}'", trimmed);
+                }
+            }
+        }
+        return ids;
     }
 
     // ==================== Admin Methods ====================

--- a/smart-rent/src/main/resources/application.yml
+++ b/smart-rent/src/main/resources/application.yml
@@ -267,24 +267,26 @@ open:
       description: "Local Server."
     group:
       package-to-scan: "com.smartrent.controller"
-  # S3-compatible storage config (Cloudflare R2, DigitalOcean Spaces, AWS S3, etc.)
+  # Cloudflare R2 storage config (S3-compatible)
   storage:
-    s3:
-      endpoint: ${S3_ENDPOINT}
-      region: ${S3_REGION:auto}
-      accessKey: ${S3_ACCESS_KEY}
-      secretKey: ${S3_SECRET_KEY}
-      bucketName: ${S3_BUCKET}
-      publicUrl: ${S3_PUBLIC_URL}
-      maxFileSizeMB: ${S3_MAX_FILE_SIZE_MB:100}
-      uploadUrlTtlMinutes: ${S3_UPLOAD_URL_TTL_MINUTES:30}
-      downloadUrlTtlMinutes: ${S3_DOWNLOAD_URL_TTL_MINUTES:60}
+    r2:
+      endpoint: ${R2_ENDPOINT}
+      region: ${R2_REGION:auto}
+      accessKey: ${R2_ACCESS_KEY_ID}
+      secretKey: ${R2_SECRET_ACCESS_KEY}
+      bucketName: ${R2_BUCKET_NAME}
+      publicBaseUrl: ${R2_PUBLIC_BASE_URL}
+      maxImageSizeMB: ${R2_MAX_IMAGE_SIZE_MB:10}
+      maxVideoSizeMB: ${R2_MAX_VIDEO_SIZE_MB:100}
+      uploadUrlTtlMinutes: ${R2_UPLOAD_URL_TTL_MINUTES:10}
+      downloadUrlTtlMinutes: ${R2_DOWNLOAD_URL_TTL_MINUTES:60}
       allowedImageTypes:
         - image/jpeg
         - image/png
         - image/webp
       allowedVideoTypes:
         - video/mp4
+        - video/webm
         - video/quicktime
 
 # VNPay Payment Gateway Configuration

--- a/smart-rent/src/test/resources/application-test.yml
+++ b/smart-rent/src/test/resources/application-test.yml
@@ -42,12 +42,12 @@ SENDER_NAME: "Test Sender"
 CLIENT_ID: "test-client-id"
 CLIENT_SECRET: "test-client-secret"
 GOOGLE_AUTH_CLIENT_REDIRECT_URI: "http://localhost:8080/v1/auth/google"
-S3_ENDPOINT: "https://test-endpoint.com"
-S3_REGION: "us-east-1"
-S3_ACCESS_KEY: "test-access-key"
-S3_SECRET_KEY: "test-secret-key"
-S3_BUCKET: "test-bucket"
-S3_PUBLIC_URL: "https://test-public-url.com"
+R2_ENDPOINT: "https://test-endpoint.com"
+R2_REGION: "auto"
+R2_ACCESS_KEY_ID: "test-access-key"
+R2_SECRET_ACCESS_KEY: "test-secret-key"
+R2_BUCKET_NAME: "test-bucket"
+R2_PUBLIC_BASE_URL: "https://test-public-url.com"
 VNPAY_TMN_CODE: "TESTCODE"
 VNPAY_HASH_SECRET: "TESTSECRET"
 VNPAY_PAYMENT_URL: "https://sandbox.vnpayment.vn/paymentv2/vpcpay.html"
@@ -143,10 +143,22 @@ logging:
 
 open:
   storage:
-    s3:
+    r2:
       endpoint: "https://test-endpoint.com"
-      region: "us-east-1"
+      region: "auto"
       accessKey: "test-access-key"
       secretKey: "test-secret-key"
       bucketName: "test-bucket"
-      publicUrl: "https://test-public-url.com"
+      publicBaseUrl: "https://test-public-url.com"
+      maxImageSizeMB: 10
+      maxVideoSizeMB: 100
+      uploadUrlTtlMinutes: 10
+      downloadUrlTtlMinutes: 60
+      allowedImageTypes:
+        - image/jpeg
+        - image/png
+        - image/webp
+      allowedVideoTypes:
+        - video/mp4
+        - video/webm
+        - video/quicktime


### PR DESCRIPTION
Close the gaps that made the client-side upload flow unusable for large media: the client needs to upload directly to R2 to bypass Vercel's 4.5MB body size limit, and the backend must enforce limits and verify the file actually landed.

- Add required purpose enum (LISTING | AVATAR) with cross-validation against listingId and mediaType
- Split file size limits per media type (10MB image / 100MB video) and add video/webm to the allowed content-type whitelist
- Purpose-aware storage keys: listings/{id}/{userId}/{uuid}.{ext}, users/{userId}/avatar/{uuid}.{ext}, plus generic fallback
- Presigned PUT now carries Content-Length (best-effort SigV4 binding)
- confirmUpload verifies the object via HeadObject: missing file -> 400, size mismatch -> delete R2 object + mark DELETED + throw. Reconcile mimeType and fileSize from R2 metadata on success
- Lower presigned URL TTL default from 30 to 10 minutes
- Lower pending-upload cleanup threshold from 2h to 1h
- Rename env vars S3_* -> R2_* and config prefix open.storage.s3 -> open.storage.r2. Introduce R2_PUBLIC_BASE_URL so the public URL can switch between the R2 dev domain (phase 1) and the custom CDN domain (phase 2) without a code change.

Ops tasks before merge: create the R2 API token, apply the CORS policy on the smart-rent bucket, and migrate deployment env vars from S3_* to R2_*.