### PR TITLE
feat: switch user profile avatar to presigned upload flow

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/controller/UserController.java
+++ b/smart-rent/src/main/java/com/smartrent/controller/UserController.java
@@ -404,9 +404,36 @@ public class UserController {
         .build();
   }
 
+  @PatchMapping(value = "/profile", consumes = {"application/json"})
+  @Operation(
+      summary = "Update user profile (JSON)",
+      description = """
+          Updates the authenticated user's profile fields in JSON format. Avatar updates go
+          through the presigned upload flow: client calls POST /v1/media/upload-url with
+          purpose=AVATAR, PUTs the file to R2, calls POST /v1/media/{mediaId}/confirm, then
+          passes the resulting mediaId as `avatarMediaId` here.
+
+          Replacing the avatar soft-deletes the previous avatar media record; the cleanup job
+          will later reclaim the underlying R2 object.
+          """,
+      security = @SecurityRequirement(name = "Bearer Authentication")
+  )
+  public ApiResponse<GetUserResponse> updateUserProfileJson(
+      @Valid @RequestBody UserProfileUpdateRequest request
+  ) {
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    String userId = authentication.getName();
+
+    GetUserResponse response = userService.updateUserProfile(userId, request);
+    return ApiResponse.<GetUserResponse>builder()
+        .data(response)
+        .build();
+  }
+
+  @Deprecated
   @PatchMapping(value = "/profile", consumes = {"multipart/form-data"})
   @Operation(
-      summary = "Update user profile",
+      summary = "Update user profile (multipart — DEPRECATED)",
       description = """
           Updates the authenticated user's profile information including avatar.
 

--- a/smart-rent/src/main/java/com/smartrent/dto/request/UserProfileUpdateRequest.java
+++ b/smart-rent/src/main/java/com/smartrent/dto/request/UserProfileUpdateRequest.java
@@ -47,5 +47,12 @@ public class UserProfileUpdateRequest {
       example = "0912345678"
   )
   String contactPhoneNumber;
+
+  @Schema(
+      description = "Media ID of a confirmed avatar upload (generated via /v1/media/upload-url with purpose=AVATAR). "
+          + "Send null to keep current avatar, send a valid ID to replace it.",
+      example = "12345"
+  )
+  Long avatarMediaId;
 }
 

--- a/smart-rent/src/main/java/com/smartrent/dto/response/GetUserResponse.java
+++ b/smart-rent/src/main/java/com/smartrent/dto/response/GetUserResponse.java
@@ -86,4 +86,10 @@ public class GetUserResponse implements Serializable {
       example = "https://lh3.googleusercontent.com/a/example"
   )
   String avatarUrl;
+
+  @Schema(
+      description = "Media record ID backing the avatar (null for legacy avatars or external OAuth avatars)",
+      example = "12345"
+  )
+  Long avatarMediaId;
 }

--- a/smart-rent/src/main/java/com/smartrent/infra/repository/entity/User.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/entity/User.java
@@ -51,4 +51,7 @@ public class User extends AbstractUser{
   @Column(name = "avatar_url")
   String avatarUrl;
 
+  @Column(name = "avatar_media_id")
+  Long avatarMediaId;
+
 }

--- a/smart-rent/src/main/java/com/smartrent/mapper/impl/UserMapperImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/mapper/impl/UserMapperImpl.java
@@ -75,6 +75,7 @@ public class UserMapperImpl implements UserMapper {
         .contactPhoneNumber(user.getContactPhoneNumber())
         .contactPhoneVerified(user.getContactPhoneVerified())
         .avatarUrl(user.getAvatarUrl())
+        .avatarMediaId(user.getAvatarMediaId())
         .build();
   }
 }

--- a/smart-rent/src/main/java/com/smartrent/service/user/UserService.java
+++ b/smart-rent/src/main/java/com/smartrent/service/user/UserService.java
@@ -24,6 +24,8 @@ public interface UserService {
 
   GetUserResponse updateUserProfile(String userId, UserProfileUpdateRequest request, MultipartFile avatarFile);
 
+  GetUserResponse updateUserProfile(String userId, UserProfileUpdateRequest request);
+
   GetUserResponse updateUser(String userId, UserUpdateRequest request);
 
   void deleteUser(String userId);

--- a/smart-rent/src/main/java/com/smartrent/service/user/impl/UserServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/user/impl/UserServiceImpl.java
@@ -23,6 +23,8 @@ import com.smartrent.service.authentication.OtpCacheService;
 import com.smartrent.service.authentication.domain.OtpData;
 import com.smartrent.infra.exception.AppException;
 import com.smartrent.infra.exception.model.DomainCode;
+import com.smartrent.infra.repository.MediaRepository;
+import com.smartrent.infra.repository.entity.Media;
 import com.smartrent.infra.storage.R2StorageService;
 import com.smartrent.service.email.VerificationEmailService;
 import com.smartrent.service.user.UserService;
@@ -63,6 +65,8 @@ public class UserServiceImpl implements UserService {
   OtpCacheService otpCacheService;
 
   R2StorageService storageService;
+
+  MediaRepository mediaRepository;
 
   @Override
   @Transactional
@@ -236,6 +240,94 @@ public class UserServiceImpl implements UserService {
     log.info("Successfully updated profile for user {}", userId);
 
     return userMapper.mapFromUserEntityToGetUserResponse(user);
+  }
+
+  @Override
+  @Transactional
+  @CacheEvict(cacheNames = Constants.CacheNames.USER_DETAILS, key = "#userId")
+  public GetUserResponse updateUserProfile(String userId, UserProfileUpdateRequest request) {
+    log.info("Updating profile (JSON) for user {}", userId);
+
+    User user = userRepository.findById(userId)
+        .orElseThrow(UserNotFoundException::new);
+
+    if (request != null) {
+      if (request.getFirstName() != null) {
+        user.setFirstName(request.getFirstName());
+      }
+      if (request.getLastName() != null) {
+        user.setLastName(request.getLastName());
+      }
+      if (request.getIdDocument() != null && !request.getIdDocument().equals(user.getIdDocument())) {
+        if (userRepository.existsByIdDocument(request.getIdDocument())) {
+          throw new DocumentExistingException();
+        }
+        user.setIdDocument(request.getIdDocument());
+      }
+      if (request.getTaxNumber() != null && !request.getTaxNumber().equals(user.getTaxNumber())) {
+        if (userRepository.existsByTaxNumber(request.getTaxNumber())) {
+          throw new TaxNumberExisting();
+        }
+        user.setTaxNumber(request.getTaxNumber());
+      }
+      if (request.getContactPhoneNumber() != null) {
+        user.setContactPhoneNumber(request.getContactPhoneNumber());
+        user.setContactPhoneVerified(false);
+      }
+      if (request.getAvatarMediaId() != null) {
+        applyAvatarMedia(user, request.getAvatarMediaId());
+      }
+    }
+
+    user = userRepository.saveAndFlush(user);
+    log.info("Successfully updated profile (JSON) for user {}", userId);
+
+    return userMapper.mapFromUserEntityToGetUserResponse(user);
+  }
+
+  /**
+   * Resolve an avatarMediaId coming from the presigned upload flow, verify ownership and
+   * media type, soft-delete the previous avatar media record if any, and copy the public URL
+   * onto the user entity.
+   */
+  private void applyAvatarMedia(User user, Long avatarMediaId) {
+    Media media = mediaRepository.findByMediaIdAndUserId(avatarMediaId, user.getUserId())
+        .orElseThrow(() -> new AppException(DomainCode.UNAUTHORIZED,
+            "Avatar media not found or not owned by user"));
+
+    if (media.getStatus() != Media.MediaStatus.ACTIVE || !Boolean.TRUE.equals(media.getUploadConfirmed())) {
+      throw new AppException(DomainCode.BAD_REQUEST_ERROR,
+          "Avatar media is not confirmed. Call /v1/media/" + avatarMediaId + "/confirm first.");
+    }
+    if (media.getMediaType() != Media.MediaType.IMAGE) {
+      throw new AppException(DomainCode.BAD_REQUEST_ERROR, "Avatar media must be an IMAGE");
+    }
+    if (media.getSourceType() != Media.MediaSourceType.UPLOAD) {
+      throw new AppException(DomainCode.BAD_REQUEST_ERROR, "Avatar media must be an uploaded file");
+    }
+
+    // Replace the previous avatar: mark DB record DELETED and best-effort remove the R2 object
+    // inline so storage doesn't accumulate orphaned avatars. Inline delete must fail silently
+    // — the new avatar is already active and the user-facing operation must not be blocked by
+    // a transient storage error.
+    Long previousMediaId = user.getAvatarMediaId();
+    if (previousMediaId != null && !previousMediaId.equals(avatarMediaId)) {
+      mediaRepository.findById(previousMediaId).ifPresent(previous -> {
+        previous.setStatus(Media.MediaStatus.DELETED);
+        mediaRepository.save(previous);
+        if (previous.getStorageKey() != null) {
+          try {
+            storageService.deleteObject(previous.getStorageKey());
+          } catch (Exception e) {
+            log.warn("Failed to delete previous avatar object from R2 (key={}). "
+                + "Cleanup job will retry later.", previous.getStorageKey(), e);
+          }
+        }
+      });
+    }
+
+    user.setAvatarMediaId(media.getMediaId());
+    user.setAvatarUrl(media.getUrl());
   }
 
   /**

--- a/smart-rent/src/main/resources/db/migration/V65__Add_avatar_media_id_to_users.sql
+++ b/smart-rent/src/main/resources/db/migration/V65__Add_avatar_media_id_to_users.sql
@@ -1,0 +1,46 @@
+-- Add avatar_media_id FK on users so avatars can reference a media record uploaded via the
+-- presigned URL flow. ON DELETE SET NULL: if the media record is hard-deleted we keep the user
+-- but clear the reference. avatar_url is kept so existing clients that only read the string URL
+-- keep working during the transition.
+
+SET @col_exists := (
+    SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'users'
+      AND COLUMN_NAME = 'avatar_media_id'
+);
+
+SET @sql := IF(@col_exists = 0,
+    'ALTER TABLE users ADD COLUMN avatar_media_id BIGINT NULL',
+    'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @idx_exists := (
+    SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'users'
+      AND INDEX_NAME = 'idx_users_avatar_media_id'
+);
+
+SET @sql := IF(@idx_exists = 0,
+    'CREATE INDEX idx_users_avatar_media_id ON users(avatar_media_id)',
+    'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @fk_exists := (
+    SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'users'
+      AND CONSTRAINT_NAME = 'fk_users_avatar_media'
+);
+
+SET @sql := IF(@fk_exists = 0,
+    'ALTER TABLE users ADD CONSTRAINT fk_users_avatar_media FOREIGN KEY (avatar_media_id) REFERENCES media(media_id) ON DELETE SET NULL',
+    'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;


### PR DESCRIPTION
Move avatar updates off the multipart upload path so users can attach avatars larger than Vercel's 4.5MB limit. The new flow is: client calls POST /v1/media/upload-url with purpose=AVATAR, PUTs the file to R2, calls POST /v1/media/{id}/confirm, then PATCHes /v1/users/profile with the resulting avatarMediaId.

- V65 migration: add users.avatar_media_id BIGINT FK -> media(media_id) ON DELETE SET NULL, with idempotent guards
- Add avatarMediaId to User entity, UserProfileUpdateRequest, GetUserResponse, and UserMapperImpl
- New PATCH /v1/users/profile endpoint consuming application/json that accepts avatarMediaId. Omitting or sending null leaves the current avatar untouched
- applyAvatarMedia verifies the media record is owned by the user, ACTIVE, uploadConfirmed, IMAGE, and sourced from UPLOAD before applying it. Replacing an avatar soft-deletes the previous media record and best-effort inline-deletes the R2 object (failures only log a warning so the user-facing update is not blocked)
- Legacy multipart PATCH /v1/users/profile is kept as @Deprecated for backward compatibility; schedule removal ~1 week after the frontend ships the JSON flow to production