### PR TITLE
fix: exclude listings with passed expiryDate from public search

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/cronjob/ListingPushScheduler.java
+++ b/smart-rent/src/main/java/com/smartrent/cronjob/ListingPushScheduler.java
@@ -1,5 +1,6 @@
 package com.smartrent.cronjob;
 
+import com.smartrent.infra.repository.ListingRepository;
 import com.smartrent.service.push.PushService;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +26,7 @@ import java.time.LocalDateTime;
 public class ListingPushScheduler {
 
     PushService pushService;
+    ListingRepository listingRepository;
 
     /**
      * Execute scheduled pushes at the start of every hour.
@@ -47,6 +49,18 @@ public class ListingPushScheduler {
             log.info("=== Completed scheduled push execution. Pushed {} listings ===", pushedCount);
         } catch (Exception e) {
             log.error("=== Error during scheduled push execution: {} ===", e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Mark listings whose expiryDate has passed as expired.
+     * Runs every hour, aligned with the push scheduler.
+     */
+    @Scheduled(cron = "0 0 * * * *")
+    public void expireListings() {
+        int count = listingRepository.markExpiredListings(LocalDateTime.now());
+        if (count > 0) {
+            log.info("Marked {} listings as expired", count);
         }
     }
 

--- a/smart-rent/src/main/java/com/smartrent/infra/repository/ListingRepository.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/ListingRepository.java
@@ -10,9 +10,11 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 @Repository
 public interface ListingRepository extends JpaRepository<Listing, Long>, JpaSpecificationExecutor<Listing> {
@@ -333,6 +335,12 @@ public interface ListingRepository extends JpaRepository<Listing, Long>, JpaSpec
         AND l.expired = false
     """)
     Page<Listing> findPublicListings(Pageable pageable);
+
+    @Modifying
+    @Transactional
+    @Query("UPDATE listings l SET l.expired = true " +
+           "WHERE l.expiryDate IS NOT NULL AND l.expiryDate < :now AND l.expired = false")
+    int markExpiredListings(@Param("now") LocalDateTime now);
 
     @Query(value = "SELECT DATE(l.created_at) AS label, COUNT(*) AS cnt " +
             "FROM listings l WHERE l.created_at BETWEEN :start AND :end " +

--- a/smart-rent/src/main/java/com/smartrent/infra/repository/specification/ListingSpecification.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/specification/ListingSpecification.java
@@ -80,8 +80,14 @@ public class ListingSpecification {
             if (filter.getExpired() != null) {
                 predicates.add(criteriaBuilder.equal(root.get("expired"), filter.getExpired()));
             } else if (Boolean.TRUE.equals(filter.getExcludeExpired())) {
-                // Exclude expired by default if not explicitly filtered
-                predicates.add(criteriaBuilder.equal(root.get("expired"), false));
+                LocalDateTime now = LocalDateTime.now();
+                predicates.add(criteriaBuilder.and(
+                    criteriaBuilder.equal(root.get("expired"), false),
+                    criteriaBuilder.or(
+                        criteriaBuilder.isNull(root.get("expiryDate")),
+                        criteriaBuilder.greaterThan(root.get("expiryDate"), now)
+                    )
+                ));
             }
 
             // Listing Status filter (owner-specific computed status)
@@ -818,8 +824,15 @@ public class ListingSpecification {
                 predicates.add(criteriaBuilder.equal(root.get("verified"), true));
             }
 
-            // Exclude expired listings
-            predicates.add(criteriaBuilder.equal(root.get("expired"), false));
+            // Exclude expired listings (flag AND date check)
+            LocalDateTime mapNow = LocalDateTime.now();
+            predicates.add(criteriaBuilder.and(
+                criteriaBuilder.equal(root.get("expired"), false),
+                criteriaBuilder.or(
+                    criteriaBuilder.isNull(root.get("expiryDate")),
+                    criteriaBuilder.greaterThan(root.get("expiryDate"), mapNow)
+                )
+            ));
 
             // Optional category filter
             if (categoryId != null) {


### PR DESCRIPTION
- Add expiryDate > NOW() check alongside expired flag in ListingSpecification for both main search (fromFilterRequest) and map bounds (withinMapBounds)
- Add markExpiredListings bulk-update query to ListingRepository
- Add hourly @Scheduled job in ListingPushScheduler to flip expired=true for listings whose expiryDate has passed, keeping all existing queries correct