### PR TITLE
feat: add minimal ListingCardResponse DTO for public listing card dis…

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/controller/ListingSearchController.java
+++ b/smart-rent/src/main/java/com/smartrent/controller/ListingSearchController.java
@@ -2,6 +2,7 @@ package com.smartrent.controller;
 
 import com.smartrent.dto.request.ListingFilterRequest;
 import com.smartrent.dto.request.MapBoundsRequest;
+import com.smartrent.dto.response.ListingCardListResponse;
 import com.smartrent.dto.response.*;
 import com.smartrent.service.listing.ListingService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -147,7 +148,7 @@ public class ListingSearchController {
             )
         }
     )
-    public ApiResponse<ListingListResponse> searchListings(
+    public ApiResponse<ListingCardListResponse> searchListings(
             @RequestBody(required = false) ListingFilterRequest filter,
             Authentication authentication) {
 
@@ -164,8 +165,8 @@ public class ListingSearchController {
             }
         }
 
-        ListingListResponse response = listingService.searchListings(filter);
-        return ApiResponse.<ListingListResponse>builder().data(response).build();
+        ListingCardListResponse response = listingService.searchListings(filter);
+        return ApiResponse.<ListingCardListResponse>builder().data(response).build();
     }
 
     @GetMapping("/sellers/{userId}/diamond")
@@ -173,7 +174,7 @@ public class ListingSearchController {
         summary = "[PUBLIC API] Seller DIAMOND listings",
         description = "Get paginated DIAMOND listings for a public seller profile section."
     )
-    public ApiResponse<ListingListResponse> getSellerDiamondListings(
+    public ApiResponse<ListingCardListResponse> getSellerDiamondListings(
             @PathVariable String userId,
             @RequestParam(defaultValue = "1") Integer page,
             @RequestParam(defaultValue = "12") Integer size,
@@ -186,7 +187,7 @@ public class ListingSearchController {
         summary = "[PUBLIC API] Seller GOLD listings",
         description = "Get paginated GOLD listings for a public seller profile section."
     )
-    public ApiResponse<ListingListResponse> getSellerGoldListings(
+    public ApiResponse<ListingCardListResponse> getSellerGoldListings(
             @PathVariable String userId,
             @RequestParam(defaultValue = "1") Integer page,
             @RequestParam(defaultValue = "12") Integer size,
@@ -199,7 +200,7 @@ public class ListingSearchController {
         summary = "[PUBLIC API] Seller SILVER listings",
         description = "Get paginated SILVER listings for a public seller profile section."
     )
-    public ApiResponse<ListingListResponse> getSellerSilverListings(
+    public ApiResponse<ListingCardListResponse> getSellerSilverListings(
             @PathVariable String userId,
             @RequestParam(defaultValue = "1") Integer page,
             @RequestParam(defaultValue = "12") Integer size,
@@ -212,7 +213,7 @@ public class ListingSearchController {
         summary = "[PUBLIC API] Seller NORMAL listings",
         description = "Get paginated NORMAL listings for a public seller profile section."
     )
-    public ApiResponse<ListingListResponse> getSellerNormalListings(
+    public ApiResponse<ListingCardListResponse> getSellerNormalListings(
             @PathVariable String userId,
             @RequestParam(defaultValue = "1") Integer page,
             @RequestParam(defaultValue = "12") Integer size,
@@ -225,15 +226,15 @@ public class ListingSearchController {
         summary = "[PUBLIC API] Seller top saved listings",
         description = "Get top listings with most saves for a public seller profile."
     )
-    public ApiResponse<ListingListResponse> getSellerTopSavedListings(
+    public ApiResponse<ListingCardListResponse> getSellerTopSavedListings(
             @PathVariable String userId,
             @RequestParam(defaultValue = "5") Integer limit) {
         int safeLimit = limit != null && limit > 0 ? Math.min(limit, 20) : 5;
-        ListingListResponse response = listingService.getTopSavedListingsByUser(userId, safeLimit);
-        return ApiResponse.<ListingListResponse>builder().data(response).build();
+        ListingCardListResponse response = listingService.getTopSavedListingsByUser(userId, safeLimit);
+        return ApiResponse.<ListingCardListResponse>builder().data(response).build();
     }
 
-    private ApiResponse<ListingListResponse> searchSellerListingsByVipType(
+    private ApiResponse<ListingCardListResponse> searchSellerListingsByVipType(
             String userId,
             String vipType,
             Integer page,
@@ -247,8 +248,8 @@ public class ListingSearchController {
                 .sortBy(sortBy)
                 .build();
 
-        ListingListResponse response = listingService.searchListings(filter);
-        return ApiResponse.<ListingListResponse>builder().data(response).build();
+        ListingCardListResponse response = listingService.searchListings(filter);
+        return ApiResponse.<ListingCardListResponse>builder().data(response).build();
     }
 
     @GetMapping("/autocomplete")

--- a/smart-rent/src/main/java/com/smartrent/dto/response/ListingCardListResponse.java
+++ b/smart-rent/src/main/java/com/smartrent/dto/response/ListingCardListResponse.java
@@ -1,0 +1,30 @@
+package com.smartrent.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.FieldDefaults;
+
+import java.util.List;
+
+/**
+ * Paginated response for public-facing listing card display.
+ * Paired with ListingCardResponse — used by search and seller profile endpoints.
+ */
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class ListingCardListResponse {
+
+    List<ListingCardResponse> listings;
+    Long totalCount;
+    Integer currentPage;
+    Integer pageSize;
+    Integer totalPages;
+}

--- a/smart-rent/src/main/java/com/smartrent/dto/response/ListingCardResponse.java
+++ b/smart-rent/src/main/java/com/smartrent/dto/response/ListingCardResponse.java
@@ -1,0 +1,77 @@
+package com.smartrent.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.FieldDefaults;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * Minimal listing DTO for public-facing card display (home page, seller profile).
+ * Contains only the fields required by PropertyCard on the frontend.
+ * For full listing details, see ListingResponse.
+ */
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class ListingCardResponse {
+
+    Long listingId;
+    String title;
+    String description;
+    BigDecimal price;
+    String priceUnit;
+    Float area;
+    Integer bedrooms;
+    Integer bathrooms;
+    Boolean verified;
+    String vipType;
+    String productType;
+    String furnishing;
+    String direction;
+    Integer roomCapacity;
+    LocalDateTime postDate;
+
+    AddressCard address;
+    List<MediaCard> media;
+    UserCard user;
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @FieldDefaults(level = AccessLevel.PRIVATE)
+    public static class AddressCard {
+        String fullNewAddress;
+        String fullAddress;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @FieldDefaults(level = AccessLevel.PRIVATE)
+    public static class MediaCard {
+        String mediaType;
+        String url;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @FieldDefaults(level = AccessLevel.PRIVATE)
+    public static class UserCard {
+        String firstName;
+        String lastName;
+    }
+}

--- a/smart-rent/src/main/java/com/smartrent/mapper/ListingMapper.java
+++ b/smart-rent/src/main/java/com/smartrent/mapper/ListingMapper.java
@@ -2,6 +2,7 @@ package com.smartrent.mapper;
 
 import com.smartrent.dto.request.ListingCreationRequest;
 import com.smartrent.dto.response.AddressResponse;
+import com.smartrent.dto.response.ListingCardResponse;
 import com.smartrent.dto.response.ListingCreationResponse;
 import com.smartrent.dto.response.ListingResponse;
 import com.smartrent.dto.response.ListingResponseForOwner;
@@ -24,6 +25,12 @@ public interface ListingMapper {
      * @return ListingResponse
      */
     ListingResponse toResponse(Listing entity, UserCreationResponse user, AddressResponse address);
+
+    /**
+     * Map Listing entity to the minimal ListingCardResponse for public card display.
+     * Skips amenities, contact fields, and all detail-only fields.
+     */
+    ListingCardResponse toCardResponse(Listing entity, UserCreationResponse user, AddressResponse address);
 
     ListingCreationResponse toCreationResponse(Listing entity);
 

--- a/smart-rent/src/main/java/com/smartrent/mapper/impl/ListingMapperImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/mapper/impl/ListingMapperImpl.java
@@ -4,6 +4,7 @@ import com.smartrent.dto.request.ListingCreationRequest;
 import com.smartrent.dto.response.AddressResponse;
 import com.smartrent.dto.response.AdminVerificationInfo;
 import com.smartrent.dto.response.AmenityResponse;
+import com.smartrent.dto.response.ListingCardResponse;
 import com.smartrent.dto.response.ListingResponse;
 import com.smartrent.dto.response.ListingCreationResponse;
 import com.smartrent.dto.response.ListingResponseForOwner;
@@ -153,6 +154,62 @@ public class ListingMapperImpl implements ListingMapper {
                 .build();
     }
 
+
+    @Override
+    public ListingCardResponse toCardResponse(Listing entity, UserCreationResponse user, AddressResponse address) {
+        List<ListingCardResponse.MediaCard> mediaCards = null;
+        if (entity.getMedia() != null && !entity.getMedia().isEmpty()) {
+            mediaCards = entity.getMedia().stream()
+                    .filter(m -> m.getStatus() == Media.MediaStatus.ACTIVE)
+                    .sorted((m1, m2) -> {
+                        if (m1.getIsPrimary() && !m2.getIsPrimary()) return -1;
+                        if (!m1.getIsPrimary() && m2.getIsPrimary()) return 1;
+                        return m1.getSortOrder().compareTo(m2.getSortOrder());
+                    })
+                    .map(m -> ListingCardResponse.MediaCard.builder()
+                            .mediaType(m.getMediaType() != null ? m.getMediaType().name() : null)
+                            .url(m.getUrl())
+                            .build())
+                    .collect(Collectors.toList());
+        }
+
+        ListingCardResponse.AddressCard addressCard = null;
+        if (address != null) {
+            addressCard = ListingCardResponse.AddressCard.builder()
+                    .fullNewAddress(address.getFullNewAddress())
+                    .fullAddress(address.getFullAddress())
+                    .build();
+        }
+
+        ListingCardResponse.UserCard userCard = null;
+        if (user != null) {
+            userCard = ListingCardResponse.UserCard.builder()
+                    .firstName(user.getFirstName())
+                    .lastName(user.getLastName())
+                    .build();
+        }
+
+        return ListingCardResponse.builder()
+                .listingId(entity.getListingId())
+                .title(entity.getTitle())
+                .description(entity.getDescription())
+                .price(entity.getPrice())
+                .priceUnit(entity.getPriceUnit() != null ? entity.getPriceUnit().name() : null)
+                .area(entity.getArea())
+                .bedrooms(entity.getBedrooms())
+                .bathrooms(entity.getBathrooms())
+                .verified(entity.getVerified())
+                .vipType(entity.getVipType() != null ? entity.getVipType().name() : null)
+                .productType(entity.getProductType() != null ? entity.getProductType().name() : null)
+                .furnishing(entity.getFurnishing() != null ? entity.getFurnishing().name() : null)
+                .direction(entity.getDirection() != null ? entity.getDirection().name() : null)
+                .roomCapacity(entity.getRoomCapacity())
+                .postDate(entity.getPostDate())
+                .address(addressCard)
+                .media(mediaCards)
+                .user(userCard)
+                .build();
+    }
 
     @Override
     public ListingCreationResponse toCreationResponse(Listing entity) {

--- a/smart-rent/src/main/java/com/smartrent/service/listing/ListingService.java
+++ b/smart-rent/src/main/java/com/smartrent/service/listing/ListingService.java
@@ -10,6 +10,7 @@ import com.smartrent.dto.request.VipListingCreationRequest;
 import com.smartrent.dto.response.AdminListingListResponse;
 import com.smartrent.dto.response.CategoryListingStatsResponse;
 import com.smartrent.dto.response.DraftListingResponse;
+import com.smartrent.dto.response.ListingCardListResponse;
 import com.smartrent.dto.response.ListingCreationResponse;
 import com.smartrent.dto.response.ListingListResponse;
 import com.smartrent.dto.response.ListingResponse;
@@ -75,7 +76,7 @@ public interface ListingService {
      *               - If userId is provided: user's listings (includes drafts if isDraft filter allows)
      * @return Paginated listing response with total count
      */
-    ListingListResponse searchListings(ListingFilterRequest filter);
+    ListingCardListResponse searchListings(ListingFilterRequest filter);
 
     /**
      * Public endpoint data source: get top saved listings for a specific seller.
@@ -83,9 +84,9 @@ public interface ListingService {
      *
      * @param userId Seller user ID
      * @param limit Max listings to return (recommended default: 5)
-     * @return Listing list response for top saved listings
+     * @return Listing card list response for top saved listings
      */
-    ListingListResponse getTopSavedListingsByUser(String userId, int limit);
+    ListingCardListResponse getTopSavedListingsByUser(String userId, int limit);
 
     /**
      * Autocomplete listings by title prefix (normalized).

--- a/smart-rent/src/main/java/com/smartrent/service/listing/impl/ListingServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/listing/impl/ListingServiceImpl.java
@@ -17,6 +17,8 @@ import com.smartrent.dto.response.CategoryListingStatsResponse;
 import com.smartrent.dto.response.AddressConversionResponse;
 import com.smartrent.dto.response.DraftListingResponse;
 import com.smartrent.dto.response.ListingCreationResponse;
+import com.smartrent.dto.response.ListingCardListResponse;
+import com.smartrent.dto.response.ListingCardResponse;
 import com.smartrent.dto.response.ListingListResponse;
 import com.smartrent.dto.response.ListingResponse;
 import com.smartrent.dto.response.ListingResponseWithAdmin;
@@ -879,6 +881,41 @@ public class ListingServiceImpl implements ListingService {
                 .collect(Collectors.toList());
     }
 
+    private List<ListingCardResponse> batchMapCardListings(List<Listing> listings) {
+        if (listings.isEmpty()) return Collections.emptyList();
+
+        List<Listing> validListings = listings.stream()
+                .filter(l -> l.getListingId() != null)
+                .collect(Collectors.toList());
+        listings = validListings;
+
+        List<Long> listingIds = listings.stream()
+                .map(Listing::getListingId)
+                .collect(Collectors.toList());
+
+        // 1 query: batch-load users
+        Set<String> userIds = listings.stream()
+                .map(Listing::getUserId)
+                .filter(id -> id != null)
+                .collect(Collectors.toSet());
+        Map<String, User> userMap = userIds.isEmpty() ? Collections.emptyMap()
+                : userRepository.findAllById(userIds).stream()
+                        .collect(Collectors.toMap(User::getUserId, Function.identity()));
+
+        // 1 query: batch-load media (no amenities needed for cards)
+        listingRepository.findByIdsWithMedia(listingIds);
+
+        return listings.stream()
+                .map(listing -> {
+                    User user = userMap.get(listing.getUserId());
+                    com.smartrent.dto.response.UserCreationResponse userResponse =
+                            user != null ? userMapper.mapFromUserEntityToUserCreationResponse(user) : null;
+                    com.smartrent.dto.response.AddressResponse addressResponse = buildAddressResponse(listing.getAddress());
+                    return listingMapper.toCardResponse(listing, userResponse, addressResponse);
+                })
+                .collect(Collectors.toList());
+    }
+
     @Override
     @Transactional
     public ListingCreationResponse completeListingCreationAfterPayment(String transactionId) {
@@ -1195,7 +1232,7 @@ public class ListingServiceImpl implements ListingService {
     @Cacheable(cacheNames = com.smartrent.config.Constants.CacheNames.LISTING_SEARCH,
             key = "T(com.smartrent.util.CacheKeyBuilder).listingSearchKey(#filter)",
             unless = "#result == null")
-    public ListingListResponse searchListings(ListingFilterRequest filter) {
+    public ListingCardListResponse searchListings(ListingFilterRequest filter) {
         log.info("Unified search - UserId: {}, Category: {}, Province: {}/{}, isDraft: {}, Page: {}, Size: {}",
                 filter.getUserId(), filter.getCategoryId(), filter.getProvinceId(), filter.getProvinceCodes(),
                 filter.getIsDraft(), filter.getPage(), filter.getSize());
@@ -1203,13 +1240,12 @@ public class ListingServiceImpl implements ListingService {
         String normalizedKeyword = TextNormalizer.normalize(filter.getKeyword());
         if (filter.getKeyword() != null && !filter.getKeyword().trim().isEmpty()
                 && (normalizedKeyword == null || normalizedKeyword.length() < 3)) {
-            return ListingListResponse.builder()
+            return ListingCardListResponse.builder()
                     .listings(Collections.emptyList())
                     .totalCount(0L)
                     .currentPage(1)
                     .pageSize(filter.getSize() != null ? filter.getSize() : 20)
                     .totalPages(0)
-                    .filterCriteria(filter)
                     .build();
         }
 
@@ -1267,22 +1303,21 @@ public class ListingServiceImpl implements ListingService {
         // Execute query using shared query service
         Page<Listing> page = listingQueryService.executeQuery(filter);
 
-        // Batch-load all relationships and map to DTOs (4 queries total)
-        List<ListingResponse> listings = batchMapListings(page.getContent());
+        // Batch-load relationships and map to card DTOs (3 queries: users + media, no amenities)
+        List<ListingCardResponse> listings = batchMapCardListings(page.getContent());
 
-        return ListingListResponse.builder()
+        return ListingCardListResponse.builder()
                 .listings(listings)
                 .totalCount(page.getTotalElements())
-                .currentPage(page.getNumber() + 1)  // Convert from 0-based (Spring Data) to 1-based (frontend)
+                .currentPage(page.getNumber() + 1)
                 .pageSize(page.getSize())
                 .totalPages(page.getTotalPages())
-                .filterCriteria(filter)
                 .build();
     }
 
             @Override
             @Transactional(readOnly = true)
-            public ListingListResponse getTopSavedListingsByUser(String userId, int limit) {
+            public ListingCardListResponse getTopSavedListingsByUser(String userId, int limit) {
             int safeLimit = Math.min(Math.max(limit, 1), 20);
 
             List<Object[]> rows = savedListingRepository.findTopSavedListingIdsForOwner(
@@ -1291,13 +1326,12 @@ public class ListingServiceImpl implements ListingService {
             );
 
             if (rows.isEmpty()) {
-                return ListingListResponse.builder()
+                return ListingCardListResponse.builder()
                     .listings(Collections.emptyList())
                     .totalCount(0L)
                     .currentPage(1)
                     .pageSize(safeLimit)
                     .totalPages(0)
-                    .filterCriteria(Map.of("userId", userId, "sortBy", "MOST_SAVED"))
                     .build();
             }
 
@@ -1314,15 +1348,14 @@ public class ListingServiceImpl implements ListingService {
                 .filter(java.util.Objects::nonNull)
                 .collect(Collectors.toList());
 
-            List<ListingResponse> listingResponses = batchMapListings(orderedListings);
+            List<ListingCardResponse> listingResponses = batchMapCardListings(orderedListings);
 
-            return ListingListResponse.builder()
+            return ListingCardListResponse.builder()
                 .listings(listingResponses)
                 .totalCount((long) listingResponses.size())
                 .currentPage(1)
                 .pageSize(safeLimit)
                 .totalPages(listingResponses.isEmpty() ? 0 : 1)
-                .filterCriteria(Map.of("userId", userId, "sortBy", "MOST_SAVED"))
                 .build();
             }
 


### PR DESCRIPTION
…play

Replace ListingResponse (34 fields) with ListingCardResponse (14 fields + minimal nested address/media/user) on all public search endpoints.

- Add ListingCardResponse with static inner AddressCard, MediaCard, UserCard
- Add ListingCardListResponse pagination wrapper (drops recommendations/filterCriteria)
- Add ListingMapper.toCardResponse() and implement in ListingMapperImpl
- Add batchMapCardListings() in ListingServiceImpl: 3 DB queries (skip amenities)
- Update searchListings() and getTopSavedListingsByUser() to return ListingCardListResponse
- Update all 6 endpoints in ListingSearchController to return ListingCardListResponse
- Admin/owner endpoints retain full ListingResponse unchanged