### PR TITLE
feat: implement pricing history endpoints and local seed script

### DIFF
--- a/smart-rent/scripts/PRICING_HISTORY_FRONTEND_INTEGRATION.md
+++ b/smart-rent/scripts/PRICING_HISTORY_FRONTEND_INTEGRATION.md
@@ -1,0 +1,272 @@
+# Pricing History — Frontend Integration Guide
+
+## Base URL
+```
+http://localhost:8080
+```
+
+---
+
+## Endpoints
+
+### 1. GET full history
+```
+GET /v1/listings/:listingId/pricing-history
+Authorization: not required
+```
+
+Response — `ApiResponse<PriceHistory[]>` sorted **oldest → newest** (ASC):
+```json
+{
+  "code": "999999",
+  "message": null,
+  "data": [
+    {
+      "id": 1,
+      "listingId": 42,
+      "oldPrice": null,
+      "newPrice": 6500000,
+      "oldPriceUnit": null,
+      "newPriceUnit": "MONTH",
+      "changeType": "INITIAL",
+      "changePercentage": 0,
+      "changeAmount": 0,
+      "changedBy": "00000000-test-0001-0000-000000000001",
+      "changeReason": "Initial listing price",
+      "changedAt": "2022-03-01T08:00:00",
+      "current": false
+    },
+    {
+      "id": 2,
+      "listingId": 42,
+      "oldPrice": 6500000,
+      "newPrice": 7000000,
+      "oldPriceUnit": "MONTH",
+      "newPriceUnit": "MONTH",
+      "changeType": "INCREASE",
+      "changePercentage": 7.69,
+      "changeAmount": 500000,
+      "changedBy": "00000000-test-0001-0000-000000000001",
+      "changeReason": "Annual market rate adjustment Q1 2023",
+      "changedAt": "2023-01-10T09:00:00",
+      "current": true
+    }
+  ]
+}
+```
+
+---
+
+### 2. GET history by date range
+```
+GET /v1/listings/:listingId/pricing-history/date-range?startDate=&endDate=
+Authorization: not required
+```
+
+Query params — ISO 8601 datetime (no Z suffix needed):
+```
+startDate=2023-01-01T00:00:00
+endDate=2025-12-31T23:59:59
+```
+
+Response — same shape as `PriceHistory[]` above, filtered & sorted ASC.
+
+---
+
+### 3. GET current price
+```
+GET /v1/listings/:listingId/current-price
+Authorization: not required
+```
+
+Response — `ApiResponse<PriceHistory>` (the single row with `current: true`):
+```json
+{
+  "code": "999999",
+  "message": null,
+  "data": {
+    "id": 5,
+    "listingId": 42,
+    "oldPrice": 8000000,
+    "newPrice": 8500000,
+    "oldPriceUnit": "MONTH",
+    "newPriceUnit": "MONTH",
+    "changeType": "INCREASE",
+    "changePercentage": 6.25,
+    "changeAmount": 500000,
+    "changedBy": "00000000-test-0001-0000-000000000001",
+    "changeReason": "Mid-year 2024 adjustment",
+    "changedAt": "2024-07-01T08:00:00",
+    "current": true
+  }
+}
+```
+
+---
+
+### 4. GET price statistics
+```
+GET /v1/listings/:listingId/price-statistics
+Authorization: not required
+```
+
+Response — `ApiResponse<PriceStatistics>`:
+```json
+{
+  "code": "999999",
+  "message": null,
+  "data": {
+    "minPrice": 6500000,
+    "maxPrice": 8500000,
+    "avgPrice": 7480000,
+    "totalChanges": 4,
+    "priceIncreases": 4,
+    "priceDecreases": 0
+  }
+}
+```
+
+> **Note:** `totalChanges` = total records − 1 (excludes the INITIAL row).
+
+---
+
+### 5. PUT update price  *(owner only — requires JWT)*
+```
+PUT /v1/listings/:listingId/price
+Authorization: Bearer <token>
+Content-Type: application/json
+```
+
+Request body:
+```json
+{
+  "newPrice": 9000000,
+  "priceUnit": "MONTH",
+  "changeReason": "Q2 market adjustment",
+  "effectiveAt": "2025-04-15T10:00:00+07:00"
+}
+```
+
+- `priceUnit` — optional. If omitted, inherits the listing's current unit.
+- `effectiveAt` — optional ISO 8601 (with or without offset). If omitted, uses server time.
+
+Response — `ApiResponse<PriceHistory>` (the newly created record):
+```json
+{
+  "code": "999999",
+  "message": null,
+  "data": {
+    "id": 6,
+    "listingId": 42,
+    "oldPrice": 8500000,
+    "newPrice": 9000000,
+    "oldPriceUnit": "MONTH",
+    "newPriceUnit": "MONTH",
+    "changeType": "INCREASE",
+    "changePercentage": 5.88,
+    "changeAmount": 500000,
+    "changedBy": "user-uuid-here",
+    "changeReason": "Q2 market adjustment",
+    "changedAt": "2025-04-15T10:00:00",
+    "current": true
+  }
+}
+```
+
+---
+
+## Field reference
+
+| Field | Type | Notes |
+|---|---|---|
+| `id` | `number` | Auto-increment PK |
+| `listingId` | `number` | FK to listing |
+| `oldPrice` | `number \| null` | `null` for INITIAL record |
+| `newPrice` | `number` | Always present |
+| `oldPriceUnit` | `"MONTH" \| "DAY" \| "YEAR" \| null` | `null` for INITIAL |
+| `newPriceUnit` | `"MONTH" \| "DAY" \| "YEAR"` | Always present |
+| `changeType` | `string` | See values below |
+| `changePercentage` | `number` | `0` for INITIAL / UNIT_CHANGE |
+| `changeAmount` | `number` | `newPrice - oldPrice`, `0` for INITIAL |
+| `changedBy` | `string` | User UUID |
+| `changeReason` | `string \| null` | Free text |
+| `changedAt` | `string` | ISO 8601, no timezone (`"2024-07-01T08:00:00"`) |
+| `current` | `boolean` | `true` only on the most-recent record |
+
+### `changeType` values
+| Value | Meaning |
+|---|---|
+| `INITIAL` | First price when listing was created |
+| `INCREASE` | `newPrice > oldPrice`, same unit |
+| `DECREASE` | `newPrice < oldPrice`, same unit |
+| `UNIT_CHANGE` | Price unit changed (e.g. DAY → MONTH) |
+| `CORRECTION` | Same price, same unit (manual correction) |
+
+---
+
+## Error responses
+
+| HTTP | `code` | When |
+|---|---|---|
+| 404 / 500 | `"999998"` or Spring default | Listing not found |
+| 500 | Spring default | No pricing history exists for listing |
+| 400 | Spring validation | `newPrice` missing or ≤ 0 |
+| 401 | Spring security | PUT endpoint called without JWT |
+
+> If `price-statistics` returns an error (listing has no history), the frontend chart should fall back to computing stats from the history array directly.
+
+---
+
+## Quick curl tests
+
+```bash
+# 1. Full history (replace 1 with a real listingId from your DB)
+curl http://localhost:8080/v1/listings/1/pricing-history | jq .
+
+# 2. Date-range filter
+curl "http://localhost:8080/v1/listings/1/pricing-history/date-range?startDate=2023-01-01T00:00:00&endDate=2025-12-31T23:59:59" | jq .
+
+# 3. Current price
+curl http://localhost:8080/v1/listings/1/current-price | jq .
+
+# 4. Statistics
+curl http://localhost:8080/v1/listings/1/price-statistics | jq .
+
+# 5. Update price (needs real JWT)
+curl -X PUT http://localhost:8080/v1/listings/1/price \
+  -H "Authorization: Bearer <your-token>" \
+  -H "Content-Type: application/json" \
+  -d '{"newPrice": 9000000, "changeReason": "Test update"}'
+```
+
+---
+
+## How to get listing IDs with seeded pricing data
+
+Run this on your local DB after executing `populate_pricing_history_local.sql`:
+
+```sql
+SELECT
+    ph.listing_id,
+    COUNT(*) AS records,
+    MIN(ph.new_price) AS min_price,
+    MAX(ph.new_price) AS max_price,
+    MAX(ph.changed_at) AS last_changed
+FROM pricing_histories ph
+GROUP BY ph.listing_id
+HAVING COUNT(*) > 1
+ORDER BY records DESC
+LIMIT 10;
+```
+
+---
+
+## `changedAt` timezone note
+
+Backend stores and returns `LocalDateTime` (no timezone). Serialized as `"2024-07-01T08:00:00"` (no `Z`).  
+For chart display, treat as local time (UTC+7 / Vietnam time). If you need to parse to JS `Date`:
+```ts
+new Date(record.changedAt)          // works but assumes local TZ
+new Date(record.changedAt + 'Z')    // forces UTC parse — avoid unless backend changes to UTC
+new Date(record.changedAt + '+07:00') // explicit Vietnam time — safest for local env
+```

--- a/smart-rent/scripts/populate_pricing_history_local.sql
+++ b/smart-rent/scripts/populate_pricing_history_local.sql
@@ -1,0 +1,390 @@
+-- ============================================================================
+-- Script: populate_pricing_history_local.sql
+-- Purpose: Populate realistic multi-step pricing history for ALL non-draft
+--          listings based on the same CRC32-seeded approach as populate_listings.sql
+-- Usage:   Run manually via mysql client — NOT via Flyway
+--          mysql -u <user> -p smartrent < scripts/populate_pricing_history_local.sql
+--
+-- Design:
+--   Each listing gets 3 or 4 history records driven by CRC32(listing_id) seeds.
+--   Three scenarios, distributed by listing:
+--     50% UPWARD    — started cheaper, gradually rose to current price
+--     30% VOLATILE  — price moved up/down before settling at current
+--     20% DOWNWARD  — started expensive, owner kept dropping to current
+--
+--   Price change magnitude per step (by category):
+--     Room        : 4–10%   (1.5M–5M/month range)
+--     Apartment   : 5–13%   (5M–25M/month range)
+--     House       : 5–14%   (8M–30M/month range)
+--     Office      : 7–18%   (5M–50M/month range)
+--     Commercial  : 10–25%  (10M–100M/month range)
+--
+--   Date range:
+--     t0 (INITIAL) = listing post_date, or 30 months ago if older
+--     t3 (current) = 1–5 months ago, always after t0
+--     t1, t2 = evenly spaced between t0 and t3
+--
+-- Safe to re-run: TRUNCATEs pricing_histories first.
+-- Estimated runtime: ~5s for 1k listings, ~3–5 min for 50k listings.
+-- ============================================================================
+
+USE smartrent;
+
+-- ============================================================================
+-- Stored procedure
+-- ============================================================================
+DROP PROCEDURE IF EXISTS populate_pricing_history;
+
+DELIMITER //
+
+CREATE PROCEDURE populate_pricing_history()
+BEGIN
+    -- ---- Cursor fields ----
+    DECLARE done        INT DEFAULT FALSE;
+    DECLARE v_listing_id  BIGINT;
+    DECLARE v_user_id     VARCHAR(36);
+    DECLARE v_price       DECIMAL(15,0);
+    DECLARE v_price_unit  VARCHAR(10);
+    DECLARE v_category_id INT;
+    DECLARE v_post_date   DATETIME;
+
+    -- ---- CRC32 seeds ----
+    DECLARE h_main  BIGINT;   -- scenario / steps / reasons
+    DECLARE h_date  BIGINT;   -- date placement
+    DECLARE h_mag   BIGINT;   -- magnitude variation
+
+    -- ---- Scenario & structure ----
+    DECLARE v_scenario  INT;          -- 0=upward, 1=volatile, 2=downward
+    DECLARE v_steps     INT;          -- 3 or 4 records total
+    DECLARE v_pct       DECIMAL(5,2); -- per-step % magnitude
+
+    -- ---- Prices at each step ----
+    DECLARE v_p0  DECIMAL(15,0);  -- INITIAL price
+    DECLARE v_p1  DECIMAL(15,0);  -- after step 1
+    DECLARE v_p2  DECIMAL(15,0);  -- after step 2 (steps=4 only)
+    DECLARE v_p3  DECIMAL(15,0);  -- current price = l.price
+
+    -- ---- Timestamps ----
+    DECLARE v_t0        DATETIME;
+    DECLARE v_t1        DATETIME;
+    DECLARE v_t2        DATETIME;
+    DECLARE v_t3        DATETIME;
+    DECLARE v_span_days INT;
+
+    -- ---- INSERT helpers ----
+    DECLARE v_prev_price  DECIMAL(15,0);
+    DECLARE v_amt_val     DECIMAL(15,0);
+    DECLARE v_pct_val     DECIMAL(5,2);
+    DECLARE v_reason_idx  INT;
+
+    -- ---- Progress ----
+    DECLARE v_total INT DEFAULT 0;
+    DECLARE v_batch INT DEFAULT 0;
+
+    -- ---- Cursor ----
+    DECLARE cur CURSOR FOR
+        SELECT listing_id, user_id, price, price_unit, category_id, post_date
+        FROM   listings
+        WHERE  is_draft = FALSE;
+
+    DECLARE CONTINUE HANDLER FOR NOT FOUND SET done = TRUE;
+
+    -- ----------------------------------------------------------------
+    -- Clean slate
+    -- ----------------------------------------------------------------
+    TRUNCATE TABLE pricing_histories;
+
+    SET autocommit = 0;
+    OPEN cur;
+
+    read_loop: LOOP
+        FETCH cur INTO v_listing_id, v_user_id, v_price, v_price_unit,
+                       v_category_id, v_post_date;
+        IF done THEN LEAVE read_loop; END IF;
+
+        -- ---- Seeds (independent per attribute, same as populate_listings.sql style) ----
+        SET h_main = CRC32(CONCAT(v_listing_id, ':ph_main'));
+        SET h_date = CRC32(CONCAT(v_listing_id, ':ph_date'));
+        SET h_mag  = CRC32(CONCAT(v_listing_id, ':ph_mag'));
+
+        -- ----------------------------------------------------------------
+        -- Scenario: 0=upward (50%), 1=volatile (30%), 2=downward (20%)
+        -- ----------------------------------------------------------------
+        IF    h_main % 10 < 5 THEN SET v_scenario = 0;
+        ELSEIF h_main % 10 < 8 THEN SET v_scenario = 1;
+        ELSE                        SET v_scenario = 2;
+        END IF;
+
+        -- ----------------------------------------------------------------
+        -- Steps: 3 (60%) or 4 (40%)
+        -- ----------------------------------------------------------------
+        SET v_steps = IF((h_main >> 4) % 5 < 3, 3, 4);
+
+        -- ----------------------------------------------------------------
+        -- Per-step % magnitude, tied to category price range
+        -- ----------------------------------------------------------------
+        CASE v_category_id
+            WHEN 1 THEN SET v_pct = 4  + (h_mag % 7);   -- room:       4–10%
+            WHEN 2 THEN SET v_pct = 5  + (h_mag % 9);   -- apartment:  5–13%
+            WHEN 3 THEN SET v_pct = 5  + (h_mag % 10);  -- house:      5–14%
+            WHEN 4 THEN SET v_pct = 7  + (h_mag % 12);  -- office:     7–18%
+            WHEN 5 THEN SET v_pct = 10 + (h_mag % 16);  -- commercial: 10–25%
+            ELSE         SET v_pct = 5  + (h_mag % 8);
+        END CASE;
+
+        -- ----------------------------------------------------------------
+        -- Date range
+        --   t0 = listing's post_date (floored at 30 months ago)
+        --   t3 = 1–5 months ago (always in the past, always after t0)
+        -- ----------------------------------------------------------------
+        SET v_t0 = GREATEST(v_post_date, DATE_SUB(NOW(), INTERVAL 30 MONTH));
+        SET v_t3 = DATE_SUB(NOW(), INTERVAL (1 + h_date % 5) MONTH);
+
+        -- Ensure t3 is after t0 by at least 30 days
+        IF v_t3 <= DATE_ADD(v_t0, INTERVAL 30 DAY) THEN
+            SET v_t3 = DATE_ADD(v_t0, INTERVAL 30 DAY);
+        END IF;
+        -- Cap at yesterday so "current" record is never in the future
+        IF v_t3 >= NOW() THEN
+            SET v_t3 = DATE_SUB(NOW(), INTERVAL 1 DAY);
+        END IF;
+
+        SET v_span_days = GREATEST(1, DATEDIFF(v_t3, v_t0));
+
+        -- Intermediate timestamps
+        IF v_steps = 4 THEN
+            SET v_t1 = DATE_ADD(v_t0, INTERVAL ROUND(v_span_days / 3)     DAY);
+            SET v_t2 = DATE_ADD(v_t0, INTERVAL ROUND(v_span_days * 2 / 3) DAY);
+        ELSE
+            SET v_t1 = DATE_ADD(v_t0, INTERVAL ROUND(v_span_days / 2)     DAY);
+            SET v_t2 = v_t3; -- unused for steps=3 except as alias
+        END IF;
+
+        -- ----------------------------------------------------------------
+        -- Price trajectory (all prices rounded to nearest 100,000 VND)
+        -- ----------------------------------------------------------------
+        CASE v_scenario
+
+            WHEN 0 THEN -- UPWARD: started cheaper, each step is an increase
+                -- p0 = current / (1+pct)^(steps-1)
+                SET v_p0 = ROUND(v_price / POW(1 + v_pct / 100, v_steps - 1) / 100000) * 100000;
+                IF v_steps = 4 THEN
+                    SET v_p1 = ROUND(v_p0 * (1 + v_pct / 100) / 100000) * 100000;
+                    SET v_p2 = ROUND(v_p1 * (1 + v_pct / 100) / 100000) * 100000;
+                ELSE
+                    SET v_p1 = ROUND(v_p0 * (1 + v_pct / 100) / 100000) * 100000;
+                    SET v_p2 = v_price; -- unused
+                END IF;
+
+            WHEN 1 THEN -- VOLATILE: dip then recovery, or spike then pullback
+                IF (h_main >> 8) % 2 = 0 THEN
+                    -- Started higher → dropped → recovered to current
+                    SET v_p0 = ROUND(v_price * (1 + v_pct         / 100) / 100000) * 100000;
+                    SET v_p1 = ROUND(v_p0   * (1 - v_pct * 1.8   / 100) / 100000) * 100000;
+                    IF v_steps = 4 THEN
+                        SET v_p2 = ROUND(v_p1 * (1 + v_pct * 0.6 / 100) / 100000) * 100000;
+                    ELSE
+                        SET v_p2 = v_price;
+                    END IF;
+                ELSE
+                    -- Started lower → rose sharply → slight pullback to current
+                    SET v_p0 = ROUND(v_price * (1 - v_pct         / 100) / 100000) * 100000;
+                    SET v_p1 = ROUND(v_p0   * (1 + v_pct * 2     / 100) / 100000) * 100000;
+                    IF v_steps = 4 THEN
+                        SET v_p2 = ROUND(v_p1 * (1 - v_pct * 0.4 / 100) / 100000) * 100000;
+                    ELSE
+                        SET v_p2 = v_price;
+                    END IF;
+                END IF;
+
+            ELSE -- DOWNWARD: started high, owner progressively reduced to current
+                SET v_p0 = ROUND(v_price * POW(1 + v_pct / 100, v_steps - 1) / 100000) * 100000;
+                IF v_steps = 4 THEN
+                    SET v_p1 = ROUND(v_p0 * (1 - v_pct       / 100) / 100000) * 100000;
+                    SET v_p2 = ROUND(v_p1 * (1 - v_pct       / 100) / 100000) * 100000;
+                ELSE
+                    SET v_p1 = ROUND(v_p0 * (1 - v_pct * 1.5 / 100) / 100000) * 100000;
+                    SET v_p2 = v_price;
+                END IF;
+
+        END CASE;
+
+        SET v_p3 = v_price; -- final record always lands on the listing's stored price
+
+        -- Floor all prices at 100,000 VND
+        IF v_p0 < 100000 THEN SET v_p0 = 100000; END IF;
+        IF v_p1 < 100000 THEN SET v_p1 = 100000; END IF;
+        IF v_p2 < 100000 THEN SET v_p2 = 100000; END IF;
+
+        -- ----------------------------------------------------------------
+        -- INSERT — Record 1: INITIAL
+        -- ----------------------------------------------------------------
+        INSERT INTO pricing_histories (
+            listing_id, old_price, new_price,
+            old_price_unit, new_price_unit,
+            change_type, change_percentage, change_amount,
+            is_current, changed_by, change_reason, changed_at
+        ) VALUES (
+            v_listing_id, NULL, v_p0, NULL, v_price_unit,
+            'INITIAL', 0, 0,
+            FALSE, v_user_id, 'Giá ban đầu khi đăng tin',
+            v_t0
+        );
+
+        -- ----------------------------------------------------------------
+        -- INSERT — Record 2: p0 → p1
+        -- ----------------------------------------------------------------
+        SET v_amt_val = v_p1 - v_p0;
+        SET v_pct_val = GREATEST(-99.99, LEAST(99.99,
+                            ROUND(v_amt_val / NULLIF(v_p0, 0) * 100, 2)));
+
+        SET v_reason_idx = IF(v_p1 >= v_p0,
+            (h_main >> 12) % 5 + 1,
+            (h_main >> 12) % 4 + 6
+        );
+
+        INSERT INTO pricing_histories (
+            listing_id, old_price, new_price,
+            old_price_unit, new_price_unit,
+            change_type, change_percentage, change_amount,
+            is_current, changed_by, change_reason, changed_at
+        ) VALUES (
+            v_listing_id, v_p0, v_p1, v_price_unit, v_price_unit,
+            IF(v_p1 >= v_p0, 'INCREASE', 'DECREASE'),
+            v_pct_val, v_amt_val,
+            FALSE, v_user_id,
+            ELT(v_reason_idx,
+                'Điều chỉnh giá theo thị trường',
+                'Trang bị thêm nội thất mới',
+                'Nâng cấp tiện ích, cơ sở vật chất',
+                'Điều chỉnh theo chỉ số lạm phát',
+                'Khu vực tăng giá mạnh',
+                'Giảm giá để tìm khách nhanh hơn',
+                'Điều chỉnh cạnh tranh với khu xung quanh',
+                'Khuyến mãi hợp đồng dài hạn',
+                'Giảm do phòng trống quá lâu'
+            ),
+            v_t1
+        );
+
+        -- ----------------------------------------------------------------
+        -- INSERT — Record 3: p1 → p2  (only when steps = 4)
+        -- ----------------------------------------------------------------
+        IF v_steps = 4 THEN
+            SET v_amt_val = v_p2 - v_p1;
+            SET v_pct_val = GREATEST(-99.99, LEAST(99.99,
+                                ROUND(v_amt_val / NULLIF(v_p1, 0) * 100, 2)));
+
+            SET v_reason_idx = IF(v_p2 >= v_p1,
+                (h_date >> 12) % 5 + 1,
+                (h_date >> 12) % 4 + 6
+            );
+
+            INSERT INTO pricing_histories (
+                listing_id, old_price, new_price,
+                old_price_unit, new_price_unit,
+                change_type, change_percentage, change_amount,
+                is_current, changed_by, change_reason, changed_at
+            ) VALUES (
+                v_listing_id, v_p1, v_p2, v_price_unit, v_price_unit,
+                IF(v_p2 >= v_p1, 'INCREASE', 'DECREASE'),
+                v_pct_val, v_amt_val,
+                FALSE, v_user_id,
+                ELT(v_reason_idx,
+                    'Điều chỉnh giá theo thị trường',
+                    'Cải tạo, nâng cấp hoàn tất',
+                    'Điều chỉnh sau khi gia hạn hợp đồng',
+                    'Cập nhật theo giá thuê khu vực',
+                    'Lắp thêm điều hòa, nội thất cao cấp',
+                    'Giảm ưu đãi thêm 1 tháng miễn phí',
+                    'Điều chỉnh cạnh tranh',
+                    'Hỗ trợ khách thuê mùa thấp điểm',
+                    'Ưu đãi ký hợp đồng 12 tháng'
+                ),
+                v_t2
+            );
+        END IF;
+
+        -- ----------------------------------------------------------------
+        -- INSERT — Final record (is_current = TRUE): prev → v_p3
+        -- ----------------------------------------------------------------
+        SET v_prev_price = IF(v_steps = 4, v_p2, v_p1);
+        SET v_amt_val    = v_p3 - v_prev_price;
+        SET v_pct_val    = GREATEST(-99.99, LEAST(99.99,
+                               ROUND(v_amt_val / NULLIF(v_prev_price, 0) * 100, 2)));
+
+        INSERT INTO pricing_histories (
+            listing_id, old_price, new_price,
+            old_price_unit, new_price_unit,
+            change_type, change_percentage, change_amount,
+            is_current, changed_by, change_reason, changed_at
+        ) VALUES (
+            v_listing_id, v_prev_price, v_p3, v_price_unit, v_price_unit,
+            IF(v_p3 >= v_prev_price, 'INCREASE', 'DECREASE'),
+            v_pct_val, v_amt_val,
+            TRUE, v_user_id,
+            ELT((h_mag >> 8) % 5 + 1,
+                'Ổn định giá theo thị trường hiện tại',
+                'Điều chỉnh giá sau đợt cải tạo',
+                'Giá cạnh tranh nhất khu vực',
+                'Cập nhật giá tháng mới',
+                'Điều chỉnh lần cuối theo thực tế'
+            ),
+            v_t3
+        );
+
+        -- ---- Batch commit ----
+        SET v_total = v_total + 1;
+        SET v_batch = v_batch + 1;
+
+        IF v_batch >= 500 THEN
+            COMMIT;
+            SET v_batch = 0;
+
+            IF v_total % 5000 = 0 THEN
+                SELECT CONCAT('Progress: ', v_total, ' listings processed') AS progress;
+            END IF;
+        END IF;
+
+    END LOOP;
+
+    CLOSE cur;
+    COMMIT;
+    SET autocommit = 1;
+
+    SELECT CONCAT('Done. Pricing history populated for ', v_total, ' listings.') AS result;
+END //
+
+DELIMITER ;
+
+-- ============================================================================
+-- Execute
+-- ============================================================================
+CALL populate_pricing_history();
+
+DROP PROCEDURE IF EXISTS populate_pricing_history;
+
+-- ============================================================================
+-- Verification
+-- ============================================================================
+SELECT '=== SUMMARY ===' AS section;
+SELECT
+    COUNT(DISTINCT listing_id)          AS listings_with_history,
+    COUNT(*)                            AS total_rows,
+    SUM(is_current = TRUE)              AS current_rows,
+    SUM(change_type = 'INITIAL')        AS initial_rows,
+    SUM(change_type = 'INCREASE')       AS increase_rows,
+    SUM(change_type = 'DECREASE')       AS decrease_rows,
+    MIN(changed_at)                     AS earliest,
+    MAX(changed_at)                     AS latest
+FROM pricing_histories;
+
+SELECT '=== ROWS PER LISTING (distribution) ===' AS section;
+SELECT records, COUNT(*) AS listing_count
+FROM (
+    SELECT listing_id, COUNT(*) AS records
+    FROM   pricing_histories
+    GROUP  BY listing_id
+) t
+GROUP BY records
+ORDER BY records;

--- a/smart-rent/src/main/java/com/smartrent/controller/PricingHistoryController.java
+++ b/smart-rent/src/main/java/com/smartrent/controller/PricingHistoryController.java
@@ -7,7 +7,6 @@ import com.smartrent.dto.response.PricingHistoryResponse;
 import com.smartrent.service.pricing.PricingHistoryService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -23,7 +22,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -84,7 +82,7 @@ public class PricingHistoryController {
     @GetMapping("/{listingId}/pricing-history")
     @Operation(
         summary = "Get full pricing history for a listing",
-        description = "Returns pricing history for a listing with pagination",
+        description = "Returns all pricing history records sorted by changedAt ascending",
         responses = {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
                 responseCode = "200",
@@ -98,23 +96,18 @@ public class PricingHistoryController {
                             {
                               "code": "999999",
                               "message": null,
-                              "data": {
-                                "page": 1,
-                                "size": 10,
-                                "totalElements": 15,
-                                "totalPages": 2,
-                                "data": [
-                                  {
-                                    "priceHistoryId": 1,
-                                    "listingId": 123,
-                                    "oldPrice": 1000.00,
-                                    "newPrice": 1200.00,
-                                    "changeType": "INCREASE",
-                                    "changePercentage": 20.00,
-                                    "changedAt": "2024-01-01T00:00:00"
-                                  }
-                                ]
-                              }
+                              "data": [
+                                {
+                                  "id": 1,
+                                  "listingId": 123,
+                                  "oldPrice": null,
+                                  "newPrice": 8500000,
+                                  "changeType": "INITIAL",
+                                  "changePercentage": 0,
+                                  "changedAt": "2024-01-01T00:00:00",
+                                  "current": false
+                                }
+                              ]
                             }
                             """
                     )
@@ -122,14 +115,9 @@ public class PricingHistoryController {
             )
         }
     )
-    ApiResponse<PageResponse<PricingHistoryResponse>> getPricingHistory(
-            @PathVariable Long listingId,
-            @Parameter(description = "Page number (1-indexed)", example = "1")
-            @RequestParam(defaultValue = "1") int page,
-            @Parameter(description = "Number of items per page", example = "10")
-            @RequestParam(defaultValue = "10") int size) {
-        PageResponse<PricingHistoryResponse> response = pricingHistoryService.getPricingHistoryByListingId(listingId, page, size);
-        return ApiResponse.<PageResponse<PricingHistoryResponse>>builder()
+    ApiResponse<List<PricingHistoryResponse>> getPricingHistory(@PathVariable Long listingId) {
+        List<PricingHistoryResponse> response = pricingHistoryService.getPricingHistoryByListingId(listingId);
+        return ApiResponse.<List<PricingHistoryResponse>>builder()
                 .data(response)
                 .build();
     }
@@ -158,54 +146,24 @@ public class PricingHistoryController {
     @GetMapping("/{listingId}/pricing-history/date-range")
     @Operation(
         summary = "Get pricing history within a date range",
-        description = "Returns pricing history for a listing within a date range with pagination",
+        description = "Returns pricing history sorted by changedAt ascending. Dates must be ISO 8601 (e.g. 2024-01-01T00:00:00)",
         responses = {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
                 responseCode = "200",
                 description = "Pricing history for date range returned",
                 content = @Content(
                     mediaType = "application/json",
-                    schema = @Schema(implementation = ApiResponse.class),
-                    examples = @ExampleObject(
-                        name = "Success Response",
-                        value = """
-                            {
-                              "code": "999999",
-                              "message": null,
-                              "data": {
-                                "page": 1,
-                                "size": 10,
-                                "totalElements": 8,
-                                "totalPages": 1,
-                                "data": [
-                                  {
-                                    "priceHistoryId": 1,
-                                    "listingId": 123,
-                                    "oldPrice": 1000.00,
-                                    "newPrice": 1200.00,
-                                    "changeType": "INCREASE",
-                                    "changePercentage": 20.00,
-                                    "changedAt": "2024-01-01T00:00:00"
-                                  }
-                                ]
-                              }
-                            }
-                            """
-                    )
+                    schema = @Schema(implementation = ApiResponse.class)
                 )
             )
         }
     )
-    ApiResponse<PageResponse<PricingHistoryResponse>> getPricingHistoryByDateRange(
+    ApiResponse<List<PricingHistoryResponse>> getPricingHistoryByDateRange(
             @PathVariable Long listingId,
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime startDate,
-            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime endDate,
-            @Parameter(description = "Page number (1-indexed)", example = "1")
-            @RequestParam(defaultValue = "1") int page,
-            @Parameter(description = "Number of items per page", example = "10")
-            @RequestParam(defaultValue = "10") int size) {
-        PageResponse<PricingHistoryResponse> response = pricingHistoryService.getPricingHistoryByDateRange(listingId, startDate, endDate, page, size);
-        return ApiResponse.<PageResponse<PricingHistoryResponse>>builder()
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime endDate) {
+        List<PricingHistoryResponse> response = pricingHistoryService.getPricingHistoryByDateRange(listingId, startDate, endDate);
+        return ApiResponse.<List<PricingHistoryResponse>>builder()
                 .data(response)
                 .build();
     }

--- a/smart-rent/src/main/java/com/smartrent/dto/request/PriceUpdateRequest.java
+++ b/smart-rent/src/main/java/com/smartrent/dto/request/PriceUpdateRequest.java
@@ -23,8 +23,11 @@ public class PriceUpdateRequest {
     @Positive(message = "Price must be positive")
     BigDecimal newPrice;
 
-    @NotNull(message = "Price unit is required")
+    // Optional — if omitted, inherits the listing's current price unit
     String priceUnit; // MONTH, DAY, YEAR
 
     String changeReason;
+
+    // Optional ISO 8601 timestamp — if provided, overrides the auto-generated changedAt
+    String effectiveAt;
 }

--- a/smart-rent/src/main/java/com/smartrent/dto/response/PricingHistoryResponse.java
+++ b/smart-rent/src/main/java/com/smartrent/dto/response/PricingHistoryResponse.java
@@ -1,5 +1,6 @@
 package com.smartrent.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -27,6 +28,7 @@ public class PricingHistoryResponse {
     String changeType;
     BigDecimal changePercentage;
     BigDecimal changeAmount;
+    @JsonProperty("current")
     boolean isCurrent;
     String changedBy;
     String changeReason;

--- a/smart-rent/src/main/java/com/smartrent/infra/repository/PricingHistoryRepository.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/PricingHistoryRepository.java
@@ -15,14 +15,21 @@ import java.util.Optional;
 @Repository
 public interface PricingHistoryRepository extends JpaRepository<PricingHistory, Long> {
 
-    // Get all pricing history for a listing, ordered by date
+    // Get all pricing history for a listing, ordered by date (newest first)
     List<PricingHistory> findByListingListingIdOrderByChangedAtDesc(Long listingId);
+
+    // Get all pricing history for a listing, ordered by date (oldest first — for charts)
+    List<PricingHistory> findByListingListingIdOrderByChangedAtAsc(Long listingId);
 
     // Get current price for a listing
     Optional<PricingHistory> findByListingListingIdAndIsCurrentTrue(Long listingId);
 
-    // Get pricing history within date range
+    // Get pricing history within date range (newest first)
     List<PricingHistory> findByListingListingIdAndChangedAtBetweenOrderByChangedAtDesc(
+            Long listingId, LocalDateTime startDate, LocalDateTime endDate);
+
+    // Get pricing history within date range (oldest first — for charts)
+    List<PricingHistory> findByListingListingIdAndChangedAtBetweenOrderByChangedAtAsc(
             Long listingId, LocalDateTime startDate, LocalDateTime endDate);
 
     // Get price changes by change type

--- a/smart-rent/src/main/java/com/smartrent/infra/repository/entity/PricingHistory.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/entity/PricingHistory.java
@@ -8,8 +8,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.experimental.FieldDefaults;
-import org.hibernate.annotations.CreationTimestamp;
-
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
@@ -71,8 +69,7 @@ public class PricingHistory {
     @Column(name = "change_reason", length = 500)
     String changeReason;
 
-    @CreationTimestamp
-    @Column(name = "changed_at", updatable = false)
+    @Column(name = "changed_at", nullable = false)
     LocalDateTime changedAt;
 
     // Enums

--- a/smart-rent/src/main/java/com/smartrent/service/pricing/impl/PricingHistoryServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/pricing/impl/PricingHistoryServiceImpl.java
@@ -13,15 +13,13 @@ import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -56,6 +54,7 @@ public class PricingHistoryServiceImpl implements PricingHistoryService {
                 .isCurrent(true)
                 .changedBy(changedBy)
                 .changeReason("Initial pricing")
+                .changedAt(LocalDateTime.now())
                 .build();
 
         PricingHistory savedPricing = pricingHistoryRepository.save(initialPricing);
@@ -65,7 +64,7 @@ public class PricingHistoryServiceImpl implements PricingHistoryService {
     @Override
     public List<PricingHistoryResponse> getPricingHistoryByListingId(Long listingId) {
         log.info("Getting pricing history for listing: {}", listingId);
-        return pricingHistoryRepository.findByListingListingIdOrderByChangedAtDesc(listingId)
+        return pricingHistoryRepository.findByListingListingIdOrderByChangedAtAsc(listingId)
                 .stream()
                 .map(pricingHistoryMapper::toResponse)
                 .collect(Collectors.toList());
@@ -75,23 +74,18 @@ public class PricingHistoryServiceImpl implements PricingHistoryService {
     public PageResponse<PricingHistoryResponse> getPricingHistoryByListingId(Long listingId, int page, int size) {
         log.info("Getting pricing history for listing: {} with pagination - page: {}, size: {}", listingId, page, size);
 
-        Pageable pageable = PageRequest.of(page - 1, size);
-        Page<PricingHistory> pricingHistoryPage = pricingHistoryRepository.findAll(pageable);
-
-        // Filter by listingId
-        List<PricingHistoryResponse> pricingHistoryResponses = pricingHistoryPage.getContent().stream()
-                .filter(ph -> ph.getListing().getListingId().equals(listingId))
-                .map(pricingHistoryMapper::toResponse)
-                .collect(Collectors.toList());
-
-        log.info("Successfully retrieved {} pricing history records", pricingHistoryResponses.size());
+        List<PricingHistoryResponse> all = getPricingHistoryByListingId(listingId);
+        int start = (page - 1) * size;
+        int end = Math.min(start + size, all.size());
+        List<PricingHistoryResponse> paged = (start < all.size()) ? all.subList(start, end) : List.of();
+        int totalPages = (int) Math.ceil((double) all.size() / size);
 
         return PageResponse.<PricingHistoryResponse>builder()
                 .page(page)
-                .size(pricingHistoryPage.getSize())
-                .totalPages(pricingHistoryPage.getTotalPages())
-                .totalElements(pricingHistoryPage.getTotalElements())
-                .data(pricingHistoryResponses)
+                .size(size)
+                .totalPages(totalPages)
+                .totalElements((long) all.size())
+                .data(paged)
                 .build();
     }
 
@@ -106,7 +100,7 @@ public class PricingHistoryServiceImpl implements PricingHistoryService {
     @Override
     public List<PricingHistoryResponse> getPricingHistoryByDateRange(Long listingId, LocalDateTime startDate, LocalDateTime endDate) {
         log.info("Getting pricing history for listing: {} between {} and {}", listingId, startDate, endDate);
-        return pricingHistoryRepository.findByListingListingIdAndChangedAtBetweenOrderByChangedAtDesc(listingId, startDate, endDate)
+        return pricingHistoryRepository.findByListingListingIdAndChangedAtBetweenOrderByChangedAtAsc(listingId, startDate, endDate)
                 .stream()
                 .map(pricingHistoryMapper::toResponse)
                 .collect(Collectors.toList());
@@ -117,24 +111,18 @@ public class PricingHistoryServiceImpl implements PricingHistoryService {
         log.info("Getting pricing history for listing: {} between {} and {} with pagination - page: {}, size: {}",
                 listingId, startDate, endDate, page, size);
 
-        Pageable pageable = PageRequest.of(page - 1, size);
-        Page<PricingHistory> pricingHistoryPage = pricingHistoryRepository.findAll(pageable);
-
-        // Filter by listingId and date range
-        List<PricingHistoryResponse> pricingHistoryResponses = pricingHistoryPage.getContent().stream()
-                .filter(ph -> ph.getListing().getListingId().equals(listingId))
-                .filter(ph -> !ph.getChangedAt().isBefore(startDate) && !ph.getChangedAt().isAfter(endDate))
-                .map(pricingHistoryMapper::toResponse)
-                .collect(Collectors.toList());
-
-        log.info("Successfully retrieved {} pricing history records for date range", pricingHistoryResponses.size());
+        List<PricingHistoryResponse> all = getPricingHistoryByDateRange(listingId, startDate, endDate);
+        int start = (page - 1) * size;
+        int end = Math.min(start + size, all.size());
+        List<PricingHistoryResponse> paged = (start < all.size()) ? all.subList(start, end) : List.of();
+        int totalPages = (int) Math.ceil((double) all.size() / size);
 
         return PageResponse.<PricingHistoryResponse>builder()
                 .page(page)
-                .size(pricingHistoryPage.getSize())
-                .totalPages(pricingHistoryPage.getTotalPages())
-                .totalElements(pricingHistoryPage.getTotalElements())
-                .data(pricingHistoryResponses)
+                .size(size)
+                .totalPages(totalPages)
+                .totalElements((long) all.size())
+                .data(paged)
                 .build();
     }
 
@@ -153,15 +141,23 @@ public class PricingHistoryServiceImpl implements PricingHistoryService {
         // Mark current pricing as not current
         pricingHistoryRepository.updateIsCurrentFalseByListingListingId(listingId);
 
-        // Calculate change
+        // Calculate change — fall back to listing's current unit if frontend omits priceUnit
         BigDecimal oldPrice = currentPricing.getNewPrice();
         BigDecimal newPrice = request.getNewPrice();
         Listing.PriceUnit oldPriceUnit = currentPricing.getNewPriceUnit();
-        Listing.PriceUnit newPriceUnit = Listing.PriceUnit.valueOf(request.getPriceUnit());
+        Listing.PriceUnit newPriceUnit = (request.getPriceUnit() != null)
+                ? Listing.PriceUnit.valueOf(request.getPriceUnit())
+                : oldPriceUnit;
 
         PricingHistory.PriceChangeType changeType = determineChangeType(oldPrice, newPrice, oldPriceUnit, newPriceUnit);
         BigDecimal changeAmount = newPrice.subtract(oldPrice);
         BigDecimal changePercentage = calculateChangePercentage(oldPrice, newPrice);
+
+        // If effectiveAt is provided, use it; otherwise default to now
+        LocalDateTime effectiveAt = LocalDateTime.now();
+        if (request.getEffectiveAt() != null && !request.getEffectiveAt().isBlank()) {
+            effectiveAt = OffsetDateTime.parse(request.getEffectiveAt()).toLocalDateTime();
+        }
 
         // Create new pricing history
         PricingHistory newPricing = PricingHistory.builder()
@@ -176,6 +172,7 @@ public class PricingHistoryServiceImpl implements PricingHistoryService {
                 .isCurrent(true)
                 .changedBy(changedBy)
                 .changeReason(request.getChangeReason())
+                .changedAt(effectiveAt)
                 .build();
 
         PricingHistory savedPricing = pricingHistoryRepository.save(newPricing);

--- a/smart-rent/src/main/resources/application.yml
+++ b/smart-rent/src/main/resources/application.yml
@@ -62,6 +62,9 @@ logging:
 spring:
   application:
     name: smart-rent
+  jackson:
+    serialization:
+      write-dates-as-timestamps: false
   cloud:
     compatibility-verifier:
       enabled: false

--- a/smart-rent/src/main/resources/db/migration/V68__Backfill_initial_pricing_history.sql
+++ b/smart-rent/src/main/resources/db/migration/V68__Backfill_initial_pricing_history.sql
@@ -1,0 +1,35 @@
+-- Backfill initial pricing_history rows for listings that have no pricing history yet.
+-- Uses the listing's current price/price_unit and created_at as the effective date.
+-- Sets is_current = true and change_type = 'INITIAL'.
+
+INSERT INTO pricing_histories (
+    listing_id,
+    old_price,
+    new_price,
+    old_price_unit,
+    new_price_unit,
+    change_type,
+    change_percentage,
+    change_amount,
+    is_current,
+    changed_by,
+    change_reason,
+    changed_at
+)
+SELECT
+    l.listing_id,
+    NULL,
+    l.price,
+    NULL,
+    l.price_unit,
+    'INITIAL',
+    0,
+    0,
+    TRUE,
+    l.user_id,
+    'Initial listing price',
+    l.created_at
+FROM listings l
+WHERE NOT EXISTS (
+    SELECT 1 FROM pricing_histories ph WHERE ph.listing_id = l.listing_id
+);


### PR DESCRIPTION
- Fix GET /pricing-history and /date-range to return flat List<> sorted ASC
- Make priceUnit optional in PriceUpdateRequest; add effectiveAt field
- Remove @CreationTimestamp from PricingHistory.changedAt so effectiveAt can override the persisted timestamp
- Add OrderByChangedAtAsc repo methods for chart-correct sort order
- Fix paginated service methods (was doing full table scan in memory)
- Add @JsonProperty("current") to align isCurrent field with frontend contract
- Enable Jackson write-dates-as-timestamps=false for ISO string serialization
- Add V68 Flyway migration to backfill INITIAL pricing row for existing listings
- Add populate_pricing_history_local.sql: CRC32-seeded stored procedure that inserts 3–4 realistic history records per listing across 3 price scenarios (upward / volatile / downward) with magnitudes scaled by category