### PR TITLE
feat: expand listing title and description length limits

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/dto/request/AiListingVerificationRequest.java
+++ b/smart-rent/src/main/java/com/smartrent/dto/request/AiListingVerificationRequest.java
@@ -30,13 +30,13 @@ public class AiListingVerificationRequest {
 
     @JsonProperty("title")
     @NotBlank(message = "Title is required")
-    @Size(min = 1, max = 200, message = "Title must be between 1 and 200 characters")
+    @Size(min = 1, max = 500, message = "Title must be between 1 and 500 characters")
     @Schema(description = "Listing title", example = "Cho thuê căn hộ 2PN Vinhomes Central Park", required = true)
     private String title;
 
     @JsonProperty("description")
     @NotBlank(message = "Description is required")
-    @Size(min = 10, max = 5000, message = "Description must be between 10 and 5000 characters")
+    @Size(min = 10, max = 50000, message = "Description must be between 10 and 50000 characters")
     @Schema(description = "Listing description", example = "Căn hộ 2 phòng ngủ, đầy đủ nội thất, view sông đẹp", required = true)
     private String description;
 

--- a/smart-rent/src/main/java/com/smartrent/dto/request/DraftListingRequest.java
+++ b/smart-rent/src/main/java/com/smartrent/dto/request/DraftListingRequest.java
@@ -37,7 +37,7 @@ public class DraftListingRequest {
     @Schema(hidden = true)
     String userId;
 
-    @Size(max = 200)
+    @Size(max = 500)
     @Schema(description = "Listing title", example = "Căn hộ 2 phòng ngủ")
     String title;
 

--- a/smart-rent/src/main/java/com/smartrent/dto/request/ListingCreationRequest.java
+++ b/smart-rent/src/main/java/com/smartrent/dto/request/ListingCreationRequest.java
@@ -32,7 +32,7 @@ public class ListingCreationRequest {
     String userId;
 
     // Fields that can be optional for draft listings
-    @Size(max = 200)
+    @Size(max = 500)
     String title;
 
     String description;

--- a/smart-rent/src/main/java/com/smartrent/dto/request/ListingRequest.java
+++ b/smart-rent/src/main/java/com/smartrent/dto/request/ListingRequest.java
@@ -24,11 +24,11 @@ import java.util.Set;
 @JsonIgnoreProperties(ignoreUnknown = true)
 @Schema(description = "Request to update or filter listings")
 public class ListingRequest {
-    @Size(max = 200)
+    @Size(max = 500)
     @Schema(description = "Listing title", example = "Cho thuê căn hộ 2PN Q7")
     String title;
 
-    @Size(max = 10000)
+    @Size(max = 50000)
     @Schema(description = "Detailed description", example = "Căn hộ đẹp, view sông")
     String description;
 

--- a/smart-rent/src/main/java/com/smartrent/infra/repository/entity/Listing.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/entity/Listing.java
@@ -43,7 +43,7 @@ public class Listing {
     Long listingId;
 
     // Core Information
-    @Column(name = "title", nullable = false, length = 200)
+    @Column(name = "title", nullable = false, length = 500)
     String title;
 
     @Column(name = "description", columnDefinition = "LONGTEXT")

--- a/smart-rent/src/main/java/com/smartrent/infra/repository/entity/ListingDraft.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/entity/ListingDraft.java
@@ -43,7 +43,7 @@ public class ListingDraft {
     String userId;
 
     // Core Information - all optional
-    @Column(name = "title", length = 200)
+    @Column(name = "title", length = 500)
     String title;
 
     @Column(name = "description", columnDefinition = "LONGTEXT")

--- a/smart-rent/src/main/resources/db/migration/V70__Expand_listing_title_length.sql
+++ b/smart-rent/src/main/resources/db/migration/V70__Expand_listing_title_length.sql
@@ -1,0 +1,6 @@
+-- Expand title column from VARCHAR(200) to VARCHAR(500) to allow longer listing titles
+ALTER TABLE listings
+    MODIFY COLUMN title VARCHAR(500) NOT NULL;
+
+ALTER TABLE listing_drafts
+    MODIFY COLUMN title VARCHAR(500);


### PR DESCRIPTION
- V70 migration: ALTER listings.title and listing_drafts.title from VARCHAR(200) to VARCHAR(500)
- Update @Column length=500 on Listing and ListingDraft entities
- Update @Size validation: title max 200→500, description max 5000/10000→50000