### PR TITLE
fix filter mapping address

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/dto/request/ListingFilterRequest.java
+++ b/smart-rent/src/main/java/com/smartrent/dto/request/ListingFilterRequest.java
@@ -83,8 +83,16 @@ public class ListingFilterRequest {
     @Schema(hidden = true)
     List<Integer> resolvedLegacyProvinceIds; // Populated by service layer — NOT from API
 
+    @JsonIgnore
+    @Schema(hidden = true)
+    List<String> resolvedNewProvinceCodes; // Populated by service layer when legacy provinceId is sent — NOT from API
+
     @Schema(description = "District ID (OLD structure)", example = "5")
     Integer districtId;
+
+    @JsonIgnore
+    @Schema(hidden = true)
+    List<String> resolvedNewWardCodesForDistrict; // Populated by service layer when legacy districtId is sent — NOT from API
 
     @Schema(description = """
             Ward ID (OLD structure - 63 provinces).
@@ -102,6 +110,10 @@ public class ListingFilterRequest {
     @JsonIgnore
     @Schema(hidden = true)
     List<Integer> resolvedLegacyWardIds; // Populated by service layer — NOT from API
+
+    @JsonIgnore
+    @Schema(hidden = true)
+    List<String> resolvedNewWardCodes; // Populated by service layer when legacy wardId is sent — NOT from API
 
     @Schema(description = "Street ID", example = "10")
     Integer streetId;

--- a/smart-rent/src/main/java/com/smartrent/infra/repository/AddressMappingRepository.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/AddressMappingRepository.java
@@ -128,6 +128,43 @@ public interface AddressMappingRepository extends JpaRepository<AddressMapping, 
     List<String> findNewProvinceCodesByLegacyProvinceCodes(@Param("legacyProvinceCodes") List<String> legacyProvinceCodes);
 
     /**
+     * Returns distinct new province codes that map to the given legacy province IDs.
+     * Joins AddressMapping → LegacyProvince on province_code, so we can pass the
+     * legacy_provinces.id (auto-increment) directly from the search filter.
+     * Used when FE sends old provinceId (legacy auto-id) in LEGACY mode and we
+     * need new_province_code matches to also pick up listings stored under the
+     * new structure.
+     */
+    @Query("SELECT DISTINCT am.newProvinceCode FROM AddressMapping am " +
+            "JOIN am.legacyProvince lp " +
+            "WHERE lp.id IN :legacyProvinceIds")
+    List<String> findNewProvinceCodesByLegacyProvinceIds(@Param("legacyProvinceIds") List<Integer> legacyProvinceIds);
+
+    /**
+     * Returns distinct new ward codes that map to the given legacy ward IDs.
+     * Joins AddressMapping → LegacyWard on ward_code, so we can pass the
+     * legacy_wards.id (auto-increment) directly from the search filter.
+     * Used when FE sends old wardId in LEGACY mode and we need new_ward_code
+     * matches to also pick up listings stored under the new structure.
+     */
+    @Query("SELECT DISTINCT am.newWardCode FROM AddressMapping am " +
+            "JOIN am.legacyWard lw " +
+            "WHERE lw.id IN :legacyWardIds")
+    List<String> findNewWardCodesByLegacyWardIds(@Param("legacyWardIds") List<Integer> legacyWardIds);
+
+    /**
+     * Returns distinct new ward codes that map to ANY legacy ward inside the
+     * given legacy district. NEW administrative structure (2-tier) has no
+     * district, so to honor a districtId filter against new-structure listings
+     * we expand the district into its constituent ward codes.
+     * Used when FE sends old districtId in LEGACY mode.
+     */
+    @Query("SELECT DISTINCT am.newWardCode FROM AddressMapping am " +
+            "JOIN am.legacyDistrict ld " +
+            "WHERE ld.id = :legacyDistrictId AND am.newWardCode IS NOT NULL")
+    List<String> findNewWardCodesByLegacyDistrictId(@Param("legacyDistrictId") Integer legacyDistrictId);
+
+    /**
      * Find all merged provinces
      */
     @Query("SELECT DISTINCT am FROM AddressMapping am WHERE am.isMergedProvince = TRUE")

--- a/smart-rent/src/main/java/com/smartrent/infra/repository/specification/ListingSpecification.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/specification/ListingSpecification.java
@@ -143,6 +143,14 @@ public class ListingSpecification {
                             provinceOrParts.add(criteriaBuilder.equal(
                                 addressJoin.get("legacyProvinceId"), provinceIdInt));
                         } catch (NumberFormatException ignored) {}
+
+                        // Also match new-structure listings via resolved new province codes
+                        // (populated by service when FE sends old provinceId in LEGACY mode)
+                        if (filter.getResolvedNewProvinceCodes() != null
+                                && !filter.getResolvedNewProvinceCodes().isEmpty()) {
+                            provinceOrParts.add(addressJoin.get("newProvinceCode")
+                                    .in(filter.getResolvedNewProvinceCodes()));
+                        }
                     }
 
                     // New structure: provinceCodes list + resolved legacy IDs
@@ -171,12 +179,24 @@ public class ListingSpecification {
                     }
                 }
 
-                // District filter (old structure)
+                // District filter — OR'd with resolved new ward codes so that
+                // listings created under the 2-tier NEW structure (with NULL
+                // legacy_district_id) are still matched when FE picks a district
+                // in LEGACY mode. The new ward codes were resolved by the
+                // service layer from this districtId.
                 if (filter.getDistrictId() != null) {
-                    predicates.add(criteriaBuilder.equal(
+                    List<Predicate> districtOrParts = new ArrayList<>();
+                    districtOrParts.add(criteriaBuilder.equal(
                         addressJoin.get("legacyDistrictId"),
                         filter.getDistrictId()
                     ));
+                    if (filter.getResolvedNewWardCodesForDistrict() != null
+                            && !filter.getResolvedNewWardCodesForDistrict().isEmpty()) {
+                        districtOrParts.add(addressJoin.get("newWardCode")
+                                .in(filter.getResolvedNewWardCodesForDistrict()));
+                    }
+                    predicates.add(criteriaBuilder.or(
+                            districtOrParts.toArray(new Predicate[0])));
                 }
 
                 // Ward filters — combine new-structure newWardCode with old-structure
@@ -191,6 +211,14 @@ public class ListingSpecification {
                             wardOrParts.add(criteriaBuilder.equal(
                                 addressJoin.get("legacyWardId"), wardIdInt));
                         } catch (NumberFormatException ignored) {}
+
+                        // Also match new-structure listings via resolved new ward codes
+                        // (populated by service when FE sends old wardId in LEGACY mode)
+                        if (filter.getResolvedNewWardCodes() != null
+                                && !filter.getResolvedNewWardCodes().isEmpty()) {
+                            wardOrParts.add(addressJoin.get("newWardCode")
+                                    .in(filter.getResolvedNewWardCodes()));
+                        }
                     }
 
                     if (filter.getNewWardCode() != null) {

--- a/smart-rent/src/main/java/com/smartrent/service/listing/impl/ListingServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/listing/impl/ListingServiceImpl.java
@@ -1297,6 +1297,43 @@ public class ListingServiceImpl implements ListingService {
             log.info("Search province filter: provinceCodes={}, resolvedLegacyIds={}", filter.getProvinceCodes(), filter.getResolvedLegacyProvinceIds());
         }
 
+        // Reverse direction: resolve legacy provinceId → new province codes so the
+        // spec can also match listings stored under the new structure (their
+        // addresses.legacy_province_id may be a different merged-province ID, e.g.
+        // a Bình Dương listing whose new_province_code is HCM after the 2025 merger).
+        // Without this, filtering by old provinceId returns 0 for listings that
+        // only carry new_province_code.
+        if (filter.getProvinceId() != null && !filter.getProvinceId().isBlank()) {
+            try {
+                Integer legacyId = Integer.parseInt(filter.getProvinceId());
+                List<String> newCodes = addressMappingRepository
+                        .findNewProvinceCodesByLegacyProvinceIds(List.of(legacyId));
+                if (newCodes.isEmpty()) {
+                    // Fallback: address_mapping has no row for this legacy province.
+                    // Handles non-merged provinces whose code is unchanged (e.g. HCM '79' before/after).
+                    LegacyProvince lp = legacyProvinceRepository.findById(legacyId).orElse(null);
+                    if (lp != null) {
+                        List<String> direct = provinceRepository
+                                .findByCodeIn(java.util.Collections.singletonList(lp.getCode()))
+                                .stream().map(Province::getCode).distinct().toList();
+                        if (!direct.isEmpty()) {
+                            newCodes = direct;
+                            log.info("Resolved legacy provinceId {} (code {}) → new codes {} (via direct Province.findByCode fallback)",
+                                    legacyId, lp.getCode(), newCodes);
+                        }
+                    }
+                }
+                if (!newCodes.isEmpty()) {
+                    filter.setResolvedNewProvinceCodes(newCodes);
+                    log.info("Resolved legacy provinceId {} → new province codes {}", legacyId, newCodes);
+                } else {
+                    log.warn("No new province codes resolved for legacy provinceId {} — new-structure listings won't be matched", legacyId);
+                }
+            } catch (NumberFormatException ignored) {
+                log.warn("provinceId {} is not a valid integer — skipping legacy→new resolution", filter.getProvinceId());
+            }
+        }
+
         // Resolve newWardCode to legacy ward IDs so the spec can match old-structure
         // listings (whose addresses.new_ward_code is NULL because they predate the
         // 2-tier reform or weren't backfilled). Without this, filtering by newWardCode
@@ -1324,6 +1361,43 @@ public class ListingServiceImpl implements ListingService {
             } else {
                 log.warn("No legacy ward IDs resolved for newWardCode {} — old-structure listings won't be matched",
                         filter.getNewWardCode());
+            }
+        }
+
+        // Reverse direction: resolve legacy districtId → new ward codes so the
+        // spec can match new-structure listings (which have NULL legacy_district_id
+        // because the 2-tier reform removed the district level). Without this,
+        // any listing created in NEW mode is filtered out the moment user picks
+        // a district in LEGACY mode.
+        if (filter.getDistrictId() != null) {
+            List<String> newWardCodes = addressMappingRepository
+                    .findNewWardCodesByLegacyDistrictId(filter.getDistrictId());
+            if (!newWardCodes.isEmpty()) {
+                filter.setResolvedNewWardCodesForDistrict(newWardCodes);
+                log.info("Resolved legacy districtId {} → {} new ward codes (used for OR with new-structure listings)",
+                        filter.getDistrictId(), newWardCodes.size());
+            } else {
+                log.warn("No new ward codes resolved for legacy districtId {} — new-structure listings won't be matched",
+                        filter.getDistrictId());
+            }
+        }
+
+        // Reverse direction: resolve legacy wardId → new ward codes so the spec
+        // can also match listings stored under the new structure when FE filters
+        // by old-structure ward.
+        if (filter.getWardId() != null && !filter.getWardId().isBlank()) {
+            try {
+                Integer legacyWardIdInt = Integer.parseInt(filter.getWardId());
+                List<String> newWardCodes = addressMappingRepository
+                        .findNewWardCodesByLegacyWardIds(List.of(legacyWardIdInt));
+                if (!newWardCodes.isEmpty()) {
+                    filter.setResolvedNewWardCodes(newWardCodes);
+                    log.info("Resolved legacy wardId {} → new ward codes {}", legacyWardIdInt, newWardCodes);
+                } else {
+                    log.warn("No new ward codes resolved for legacy wardId {} — new-structure listings won't be matched", legacyWardIdInt);
+                }
+            } catch (NumberFormatException ignored) {
+                log.warn("wardId {} is not a valid integer — skipping legacy→new resolution", filter.getWardId());
             }
         }
 


### PR DESCRIPTION
This pull request enhances the listing search to support both legacy (pre-2025) and new (post-2025, 34-province) address structures, ensuring that filters using old province, district, or ward IDs will also match listings created under the new structure. The main improvements are the addition of reverse mapping logic and repository methods to resolve new codes from legacy IDs, and updating the search/filter logic to OR-match both legacy and new fields.

**Reverse mapping and filter enhancements for new/legacy address compatibility:**

_Repository and mapping logic:_
* Added repository methods in `AddressMappingRepository` to resolve new province and ward codes from legacy province, district, and ward IDs, enabling cross-structure search.
* In `ListingServiceImpl`, implemented logic to populate new filter fields (`resolvedNewProvinceCodes`, `resolvedNewWardCodesForDistrict`, `resolvedNewWardCodes`) by resolving them from legacy IDs before executing the search. [[1]](diffhunk://#diff-ace3438ab9c2eccde599e57c4156051f6df51d80af154c2abff132733b4360e9R1300-R1336) [[2]](diffhunk://#diff-ace3438ab9c2eccde599e57c4156051f6df51d80af154c2abff132733b4360e9R1367-R1403)

_DTO and filter request changes:_
* Added new fields (`resolvedNewProvinceCodes`, `resolvedNewWardCodesForDistrict`, `resolvedNewWardCodes`) to `ListingFilterRequest`, populated by the service layer (not exposed in API), to carry resolved codes for use in the query. [[1]](diffhunk://#diff-3b2f5456818de7e662c88c06c2d547c83b70343819d65487d2b98c6bd9f8126bR86-R96) [[2]](diffhunk://#diff-3b2f5456818de7e662c88c06c2d547c83b70343819d65487d2b98c6bd9f8126bR114-R117)

_Query and specification logic:_
* Updated `ListingSpecification` to OR-match legacy and new structure fields for province, district, and ward filters—ensuring that a filter using a legacy ID will also match listings stored under the new structure. [[1]](diffhunk://#diff-fe03afb689e96a8b4558a1c9a14410f5e86bc80fe162bde69d2b220b6e819ea9R146-R153) [[2]](diffhunk://#diff-fe03afb689e96a8b4558a1c9a14410f5e86bc80fe162bde69d2b220b6e819ea9L174-R199) [[3]](diffhunk://#diff-fe03afb689e96a8b4558a1c9a14410f5e86bc80fe162bde69d2b220b6e819ea9R214-R221)

These changes ensure that users filtering by legacy address fields will not miss listings created under the new administrative structure, improving search accuracy and backward compatibility.