### PR TITLE
fix(search): gate public listings on moderation status, not verified …

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/infra/repository/specification/ListingSpecification.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/specification/ListingSpecification.java
@@ -68,10 +68,14 @@ public class ListingSpecification {
             if (filter.getVerified() != null) {
                 predicates.add(criteriaBuilder.equal(root.get("verified"), filter.getVerified()));
             } else if (filter.getUserId() == null && !Boolean.TRUE.equals(filter.getIsAdminRequest())) {
-                // For public search (userId null AND not admin), only show verified listings
-                // This ensures unverified/pending/rejected listings are NOT visible to public users
-                // Admin requests (isAdminRequest=true) can see ALL listings regardless of verification status
-                predicates.add(criteriaBuilder.equal(root.get("verified"), true));
+                // Public search gates on moderation outcome, not the admin "verified" badge.
+                // verified=true still surfaces a "Tin đã xác minh" badge on the FE, but pending
+                // listings that passed moderation (APPROVED) are visible too — matching how
+                // batdongsan.com / chotot.vn treat the verified badge as a trust signal, not
+                // a visibility gate.
+                predicates.add(criteriaBuilder.equal(
+                    root.get("moderationStatus"),
+                    com.smartrent.enums.ModerationStatus.APPROVED));
             }
 
             // Verification pending filter


### PR DESCRIPTION
…flag

The default public-search predicate filtered on `verified=true`, which hid ~20% of moderation-APPROVED listings from buyers while their owners waited on a manual admin verify step. Switching to `moderation_status=APPROVED` matches the batdongsan.com / chotot.vn pattern where `verified=true` only drives the "Tin đã xác minh" badge, not visibility. Admin and owner views are unchanged.