### PR TITLE
chore(ai): make AI moderation scheduler toggleable via property

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/cronjob/AiListingAutoModerationScheduler.java
+++ b/smart-rent/src/main/java/com/smartrent/cronjob/AiListingAutoModerationScheduler.java
@@ -11,6 +11,7 @@ import com.smartrent.infra.repository.entity.enums.VerificationStatus;
 import com.smartrent.service.ai.AiListingVerificationService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -21,6 +22,11 @@ import java.util.List;
 @Component
 @RequiredArgsConstructor
 @Slf4j
+@ConditionalOnProperty(
+    name = "smartrent.ai.verification.scheduler.enabled",
+    havingValue = "true",
+    matchIfMissing = true
+)
 public class AiListingAutoModerationScheduler {
 
     private final ListingRepository listingRepository;


### PR DESCRIPTION
Wraps AiListingAutoModerationScheduler with @ConditionalOnProperty on smartrent.ai.verification.scheduler.enabled (default true). Lets ops disable the 5-minute auto-moderation poll without a code change — useful while seeding bulk demo data that would otherwise be repeatedly re-classified by Gemini as duplicate/templated, wasting Vertex AI quota.

To disable on a running deployment, set:
  SMARTRENT_AI_VERIFICATION_SCHEDULER_ENABLED=false
and restart the backend. Behavior unchanged when the property is absent or set to true.