### PR TITLE
chore(server): cap Tomcat thread pool and accept-count

### DIFF
--- a/smart-rent/src/main/resources/application.yml
+++ b/smart-rent/src/main/resources/application.yml
@@ -5,6 +5,17 @@ server:
     connection-timeout: 300000 # 5 minutes for video uploads
     max-http-form-post-size: 110MB
     max-swallow-size: 110MB
+    # Connector ceilings — sized for the HikariCP pool (30 connections) and the
+    # ~600 MB heap each backend replica runs with. The defaults
+    # (max-threads=200, accept-count=100, no max-connections cap) let a
+    # concurrency-200 burst on cache-missing stats endpoints saturate Tomcat
+    # *and* HikariCP at the same time, with no admission control to shed load.
+    # Cap below override via env so we can tune in prod without a rebuild.
+    threads:
+      max: ${TOMCAT_MAX_THREADS:150}
+      min-spare: ${TOMCAT_MIN_SPARE_THREADS:20}
+    accept-count: ${TOMCAT_ACCEPT_COUNT:100}
+    max-connections: ${TOMCAT_MAX_CONNECTIONS:500}
   error:
     # Disable Spring Boot's default error page to ensure @ControllerAdvice handles all exceptions
     whitelabel:


### PR DESCRIPTION
Spring Boot ships Tomcat with no max-connections cap and a 200-thread ceiling, so a burst of cache-missing requests on /listings/stats/* or /listings/search can spin up workers faster than HikariCP (max 30 connections) can serve them. Workers sit waiting on the DB pool, the heap creeps up, and once threads are saturated every subsequent connection blocks in the OS accept queue with no upper bound.

Setting:
  threads.max          = 150  — ~5x HikariCP pool, leaves headroom for
                                 non-DB requests without runaway thread
                                 growth
  threads.min-spare    = 20   — keeps a warm pool for traffic spikes
  accept-count         = 100  — bounded OS-level backlog
  max-connections      = 500  — hard ceiling; beyond this Tomcat closes
                                 new connections instead of queueing
                                 indefinitely

All four are overridable via TOMCAT_* env vars so we can re-tune on the droplet without a new build. Pairs with the Caddy per-IP rate_limit landing in the deploy repo — Caddy keeps any one IP under 30 rpm on the heavy endpoints, Tomcat caps the worst-case aggregate.