### PR TITLE
chore(ci): auto-prune old images after deploy

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -158,3 +158,25 @@ jobs:
               --env-file docker/tags.env \
               -f docker/docker-compose.yml \
               up -d --no-deps backend
+
+            # ---- Image retention (best-effort, never fails the deploy) ----
+            # Without this the Droplet accumulates one ~686MB image per push
+            # because each build is tagged with the commit SHA and never
+            # overwritten. `docker rmi` on the currently-running image fails
+            # with "image is being used" — that's the safety net.
+            set +e
+            REPO="vuhuydiet/smartrent-backend"
+            KEEP=5
+            docker container prune -f
+            docker images "$REPO" --format '{{.Tag}} {{.CreatedAt}}' \
+              | grep -Ev '^(dev|prd|prod|main|latest) ' \
+              | grep -v '^<none>' \
+              | sort -k2,2 -r \
+              | tail -n +$((KEEP + 1)) \
+              | awk '{print $1}' \
+              | while read -r tag; do
+                  docker rmi "${REPO}:${tag}" 2>/dev/null || true
+                done
+            docker image prune -f
+            docker builder prune -f --keep-storage 2GB
+            docker system df


### PR DESCRIPTION
The Droplet was running out of disk because each deploy left a new SHA-tagged ~686MB image behind with nothing cleaning them up.

After `up -d`, keep the 5 newest SHA tags for vuhuydiet/smartrent-backend plus the protected moving tags (:dev/:prd/:latest), then prune dangling images and builder cache (keeping 2GB hot). Wrapped in `set +e` so cleanup failures never fail the deploy itself.