### PR TITLE
feat(listing): decouple listing intent from category + add STORE prod…

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/dto/request/ListingRequest.java
+++ b/smart-rent/src/main/java/com/smartrent/dto/request/ListingRequest.java
@@ -66,7 +66,7 @@ public class ListingRequest {
     @NotNull
     Long categoryId;
 
-    @Pattern(regexp = "ROOM|APARTMENT|HOUSE|OFFICE|STUDIO", message = "productType must be ROOM, APARTMENT, HOUSE, OFFICE, or STUDIO")
+    @Pattern(regexp = "ROOM|APARTMENT|HOUSE|OFFICE|STUDIO|STORE", message = "productType must be ROOM, APARTMENT, HOUSE, OFFICE, STUDIO, or STORE")
     String productType;
 
     @DecimalMin(value = "0.0", inclusive = false, message = "price must be positive")

--- a/smart-rent/src/main/java/com/smartrent/infra/repository/entity/Listing.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/entity/Listing.java
@@ -260,7 +260,7 @@ public class Listing {
     }
 
     public enum ProductType {
-        ROOM, APARTMENT, HOUSE, OFFICE, STUDIO
+        ROOM, APARTMENT, HOUSE, OFFICE, STUDIO, STORE
     }
 
     public enum PriceUnit {

--- a/smart-rent/src/main/resources/db/migration/V85__Decouple_listing_intent_from_category.sql
+++ b/smart-rent/src/main/resources/db/migration/V85__Decouple_listing_intent_from_category.sql
@@ -1,0 +1,23 @@
+-- Decouple the "intent" axis (listing_type: RENT / SALE / SHARE) from the
+-- property-kind axis. Two changes:
+--
+-- 1. Category names baked the intent into the label ("Cho thuê phòng trọ").
+--    The intent now lives in listings.listing_type, so categories become pure
+--    property kinds. Slugs are kept unchanged to preserve existing links/SEO;
+--    only the display name changes.
+--
+-- 2. The product_type ENUM had no value for the existing "Mặt bằng" (store)
+--    category, while the column is NOT NULL. Add STORE so every category maps
+--    1:1 to a product_type and the value can always be derived from category.
+
+-- 1. Rename categories: strip the "Cho thuê " intent prefix.
+UPDATE categories SET name = 'Phòng trọ'      WHERE slug = 'cho-thue-phong-tro';
+UPDATE categories SET name = 'Căn hộ'         WHERE slug = 'cho-thue-can-ho';
+UPDATE categories SET name = 'Nhà nguyên căn' WHERE slug = 'cho-thue-nha-nguyen-can';
+UPDATE categories SET name = 'Văn phòng'      WHERE slug = 'cho-thue-van-phong';
+UPDATE categories SET name = 'Mặt bằng'       WHERE slug = 'cho-thue-mat-bang';
+
+-- 2. Add STORE to the product_type ENUM (keeps NOT NULL).
+ALTER TABLE listings
+    MODIFY COLUMN product_type
+    ENUM('ROOM', 'APARTMENT', 'HOUSE', 'OFFICE', 'STUDIO', 'STORE') NOT NULL;


### PR DESCRIPTION
…uct type

- Migration V85: rename category names to drop the "Cho thuê" intent prefix (slugs kept unchanged for SEO) so categories represent the property kind, while listing_type (RENT/SALE/SHARE) carries the intent
- Add STORE to the product_type ENUM (the column is NOT NULL) so the existing "Mặt bằng" category maps 1:1 to a product type
- Add STORE to Listing.ProductType enum and allow it in the ListingRequest productType @Pattern