### PR TITLE
feat(phone-click): keyword search on my-listings/users

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/controller/PhoneClickDetailController.java
+++ b/smart-rent/src/main/java/com/smartrent/controller/PhoneClickDetailController.java
@@ -669,9 +669,13 @@ public class PhoneClickDetailController {
                     Get all users who clicked on phone numbers in any of the authenticated user's listings (paginated).
                     Each user detail contains a list of the owner's listings they have clicked on.
 
+                    Optionally filter by a `keyword` matched (case-insensitive, partial) against the
+                    clicking user's first name, last name, full name, email or contact phone number.
+
                     **Use Case:**
                     - Renter views listing management dashboard
                     - See all users who showed interest in any of their listings
+                    - Search interested users by name, email or phone
                     - Click on a user to see which specific listings they were interested in
                     - Contact interested users
                     """,
@@ -746,6 +750,8 @@ public class PhoneClickDetailController {
             )
     })
     public ApiResponse<PageResponse<UserPhoneClickDetailResponse>> getUsersWhoClickedOnMyListings(
+            @Parameter(description = "Optional keyword to filter users by name, email or contact phone", example = "john")
+            @RequestParam(required = false) String keyword,
             @Parameter(description = "Page number (1-indexed)", example = "1")
             @RequestParam(defaultValue = "1") int page,
             @Parameter(description = "Number of items per page", example = "10")
@@ -755,9 +761,13 @@ public class PhoneClickDetailController {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         String userId = authentication.getName();
 
-        log.info("Getting users who clicked on listings owned by user {} - page: {}, size: {}", userId, page, size);
+        boolean hasKeyword = keyword != null && !keyword.isBlank();
+        log.info("Getting users who clicked on listings owned by user {} - keyword: '{}', page: {}, size: {}",
+                userId, keyword, page, size);
 
-        PageResponse<UserPhoneClickDetailResponse> responses = phoneClickDetailService.getUsersWhoClickedOnMyListings(userId, page, size);
+        PageResponse<UserPhoneClickDetailResponse> responses = hasKeyword
+                ? phoneClickDetailService.searchUsersWhoClickedOnMyListings(userId, keyword, page, size)
+                : phoneClickDetailService.getUsersWhoClickedOnMyListings(userId, page, size);
 
         return ApiResponse.<PageResponse<UserPhoneClickDetailResponse>>builder()
                 .code("999999")

--- a/smart-rent/src/main/java/com/smartrent/infra/repository/PhoneClickDetailRepository.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/PhoneClickDetailRepository.java
@@ -142,6 +142,22 @@ public interface PhoneClickDetailRepository extends JpaRepository<PhoneClickDeta
     Page<String> findDistinctUserIdsByListingOwnerId(@Param("ownerId") String ownerId, Pageable pageable);
 
     /**
+     * Search distinct user IDs who clicked on any listing owned by a specific user,
+     * filtered by a keyword matched against the clicking user's name, email or contact phone (paginated)
+     */
+    @Query("SELECT DISTINCT pc.user.userId FROM phone_clicks pc " +
+           "WHERE pc.listing.userId = :ownerId " +
+           "AND (LOWER(pc.user.firstName) LIKE LOWER(CONCAT('%', :keyword, '%')) " +
+           "OR LOWER(pc.user.lastName) LIKE LOWER(CONCAT('%', :keyword, '%')) " +
+           "OR LOWER(CONCAT(pc.user.firstName, ' ', pc.user.lastName)) LIKE LOWER(CONCAT('%', :keyword, '%')) " +
+           "OR LOWER(pc.user.email) LIKE LOWER(CONCAT('%', :keyword, '%')) " +
+           "OR LOWER(pc.user.contactPhoneNumber) LIKE LOWER(CONCAT('%', :keyword, '%')))")
+    Page<String> searchDistinctUserIdsByListingOwnerId(
+            @Param("ownerId") String ownerId,
+            @Param("keyword") String keyword,
+            Pageable pageable);
+
+    /**
      * Get all phone clicks for listings owned by a specific user, filtered by clicking user
      */
     @Query("SELECT pc FROM phone_clicks pc " +

--- a/smart-rent/src/main/java/com/smartrent/service/phoneclickdetail/PhoneClickDetailService.java
+++ b/smart-rent/src/main/java/com/smartrent/service/phoneclickdetail/PhoneClickDetailService.java
@@ -95,5 +95,17 @@ public interface PhoneClickDetailService {
      * @return Paginated user phone click detail responses
      */
     PageResponse<UserPhoneClickDetailResponse> getUsersWhoClickedOnMyListings(String ownerId, int page, int size);
+
+    /**
+     * Search users who clicked on any of the owner's listings, filtered by a keyword
+     * matched against the clicking user's name, email or contact phone (paginated)
+     *
+     * @param ownerId Owner/renter user ID
+     * @param keyword Keyword to match against user name, email or contact phone
+     * @param page Page number (1-indexed)
+     * @param size Page size
+     * @return Paginated user phone click detail responses
+     */
+    PageResponse<UserPhoneClickDetailResponse> searchUsersWhoClickedOnMyListings(String ownerId, String keyword, int page, int size);
 }
 

--- a/smart-rent/src/main/java/com/smartrent/service/phoneclickdetail/impl/PhoneClickDetailServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/phoneclickdetail/impl/PhoneClickDetailServiceImpl.java
@@ -366,6 +366,46 @@ public class PhoneClickDetailServiceImpl implements PhoneClickDetailService {
         // Get distinct user IDs who clicked on any of the owner's listings (paginated)
         Page<String> userIdsPage = phoneClickDetailRepository.findDistinctUserIdsByListingOwnerId(ownerId, pageable);
 
+        return buildUsersWhoClickedResponse(ownerId, userIdsPage, page);
+    }
+
+    @Override
+    public PageResponse<UserPhoneClickDetailResponse> searchUsersWhoClickedOnMyListings(String ownerId, String keyword, int page, int size) {
+        log.info("Searching users who clicked on listings owned by user {} with keyword '{}' - page: {}, size: {}",
+                ownerId, keyword, page, size);
+
+        // Verify user exists
+        userRepository.findById(ownerId)
+                .orElseThrow(() -> new RuntimeException("User not found with ID: " + ownerId));
+
+        // Validate pagination parameters
+        if (page < 1) {
+            throw new RuntimeException("Page number must be greater than 0");
+        }
+        if (size <= 0) {
+            throw new RuntimeException("Page size must be greater than 0");
+        }
+
+        // Blank keyword falls back to the unfiltered listing
+        if (keyword == null || keyword.isBlank()) {
+            return getUsersWhoClickedOnMyListings(ownerId, page, size);
+        }
+
+        Pageable pageable = PageRequest.of(page - 1, size);
+
+        // Get distinct user IDs matching the keyword (paginated)
+        Page<String> userIdsPage = phoneClickDetailRepository.searchDistinctUserIdsByListingOwnerId(
+                ownerId, keyword.trim(), pageable);
+
+        return buildUsersWhoClickedResponse(ownerId, userIdsPage, page);
+    }
+
+    /**
+     * Build the paginated user detail response for a page of clicking user IDs.
+     * For each user, loads their details and the owner's listings they clicked on.
+     */
+    private PageResponse<UserPhoneClickDetailResponse> buildUsersWhoClickedResponse(
+            String ownerId, Page<String> userIdsPage, int page) {
         // For each user, get their details and all owner's listings they clicked on
         List<UserPhoneClickDetailResponse> responses = new ArrayList<>();
         for (String clickingUserId : userIdsPage.getContent()) {


### PR DESCRIPTION
Add an optional `keyword` query param to GET /v1/phone-click-details/ my-listings/users so the seller customer management page can search interested users server-side (case-insensitive partial match on the clicking user's first name, last name, full name, email or contact phone).

- repository: searchDistinctUserIdsByListingOwnerId
- service: searchUsersWhoClickedOnMyListings; shared response builder extracted from getUsersWhoClickedOnMyListings
- controller: route to search when keyword is present, blank falls back