### PR TITLE
fix(phone-click): lazy-init on customer search + add join index

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/infra/repository/entity/PhoneClickDetail.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/entity/PhoneClickDetail.java
@@ -22,6 +22,7 @@ import java.time.LocalDateTime;
                 @Index(name = "idx_listing_id", columnList = "listing_id"),
                 @Index(name = "idx_user_id", columnList = "user_id"),
                 @Index(name = "idx_listing_user", columnList = "listing_id, user_id"),
+                @Index(name = "idx_phone_clicks_user_listing", columnList = "user_id, listing_id"),
                 @Index(name = "idx_clicked_at", columnList = "clicked_at")
         })
 @Getter

--- a/smart-rent/src/main/java/com/smartrent/service/phoneclickdetail/impl/PhoneClickDetailServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/phoneclickdetail/impl/PhoneClickDetailServiceImpl.java
@@ -370,6 +370,7 @@ public class PhoneClickDetailServiceImpl implements PhoneClickDetailService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public PageResponse<UserPhoneClickDetailResponse> searchUsersWhoClickedOnMyListings(String ownerId, String keyword, int page, int size) {
         log.info("Searching users who clicked on listings owned by user {} with keyword '{}' - page: {}, size: {}",
                 ownerId, keyword, page, size);

--- a/smart-rent/src/main/resources/db/migration/V85__Add_phone_clicks_user_listing_index.sql
+++ b/smart-rent/src/main/resources/db/migration/V85__Add_phone_clicks_user_listing_index.sql
@@ -1,0 +1,39 @@
+-- Migration V85: Composite index for the seller "customer management" page
+-- ============================================================================
+-- Backs PhoneClickDetailServiceImpl.buildUsersWhoClickedResponse, which — for
+-- every clicking user on the page — runs:
+--
+--   SELECT pc.* FROM phone_clicks pc
+--   JOIN listings l ON pc.listing_id = l.listing_id
+--   WHERE l.user_id = :ownerId AND pc.user_id = :clickingUserId
+--   ORDER BY pc.clicked_at DESC
+--
+-- (repository method findByListingOwnerIdAndClickingUserId). The existing
+-- phone_clicks indexes are idx_user_id (user_id) and idx_listing_user
+-- (listing_id, user_id) — neither lets MySQL both filter by user_id AND pull
+-- listing_id from the index for the join, so it falls back to row lookups.
+-- A (user_id, listing_id) composite covers the filter + join in one index
+-- read, which matters now that the page issues one such query per row plus
+-- the new keyword search path.
+--
+-- NOTE: the keyword search itself filters users with LOWER(col) LIKE '%kw%'
+-- (leading wildcard) on first_name/last_name/email/contact_phone_number, which
+-- is not B-tree indexable; the owner scope is already served by
+-- listings.idx_user_created and phone_clicks.idx_listing_id, so this migration
+-- only closes the per-user join gap. A FULLTEXT index would be the next step
+-- if substring user search becomes a hot path.
+--
+-- Idempotent via information_schema check, matching V78/V80/V81 style.
+-- ============================================================================
+
+SET @idx_exists = (SELECT COUNT(*)
+                   FROM information_schema.statistics
+                   WHERE table_schema = DATABASE()
+                     AND table_name = 'phone_clicks'
+                     AND index_name = 'idx_phone_clicks_user_listing');
+SET @sql = IF(@idx_exists = 0,
+    'CREATE INDEX idx_phone_clicks_user_listing ON phone_clicks (user_id, listing_id)',
+    'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;


### PR DESCRIPTION
searchUsersWhoClickedOnMyListings was missing @Transactional(readOnly), so with open-in-view disabled the Hibernate session closed before buildUsersWhoClickedResponse lazily loaded Listing — surfacing as "Could not initialize proxy [Listing#...] - no session". Mark it read-only transactional like the sibling get* methods.

Also add a (user_id, listing_id) composite index on phone_clicks (entity + Flyway V85) to back findByListingOwnerIdAndClickingUserId, which the customer page runs once per listed user.