### PR TITLE
fix(address): store legacy province/district PKs instead of GSO codes

### DIFF
--- a/smart-rent/scripts/populate_addresses_for_listings.sql
+++ b/smart-rent/scripts/populate_addresses_for_listings.sql
@@ -45,6 +45,11 @@ BEGIN
 
     -- Legacy ward fields
     DECLARE v_legacy_ward_id INT;
+    -- Surrogate PKs of the parent province/district (NOT the GSO codes). These
+    -- are what addresses.legacy_province_id / legacy_district_id must store so
+    -- they match ListingSpecification + the FE province dropdown (province.id).
+    DECLARE v_legacy_province_id INT;
+    DECLARE v_legacy_district_id INT;
     DECLARE v_legacy_province_code VARCHAR(10);
     DECLARE v_legacy_district_code VARCHAR(10);
     DECLARE v_legacy_ward_code VARCHAR(10);
@@ -88,6 +93,8 @@ BEGIN
     DECLARE ward_cursor CURSOR FOR
         SELECT
             lw.legacy_ward_id,
+            lp.legacy_province_id,
+            ld.legacy_district_id,
             lw.province_code,
             lw.district_code,
             lw.ward_code,
@@ -106,6 +113,8 @@ BEGIN
             am.new_ward_lat,
             am.new_ward_lon
         FROM legacy_wards lw
+        JOIN legacy_provinces lp ON lp.province_code = lw.province_code
+        JOIN legacy_districts ld ON ld.district_code = lw.district_code
         LEFT JOIN address_mapping am
             ON lw.province_code = am.legacy_province_code
             AND lw.district_code = am.legacy_district_code
@@ -133,6 +142,7 @@ BEGIN
     ward_loop: LOOP
         FETCH ward_cursor INTO
             v_legacy_ward_id,
+            v_legacy_province_id, v_legacy_district_id,
             v_legacy_province_code, v_legacy_district_code, v_legacy_ward_code,
             v_legacy_province_name, v_legacy_province_short,
             v_legacy_district_name, v_legacy_district_short,
@@ -212,8 +222,10 @@ BEGIN
                 latitude, longitude
             ) VALUES (
                 v_full_address,
-                CAST(v_legacy_province_code AS UNSIGNED),
-                CAST(v_legacy_district_code AS UNSIGNED),
+                -- Store the surrogate PKs (NOT the GSO codes) so the values
+                -- match legacy_provinces/legacy_districts and the FE filter.
+                v_legacy_province_id,
+                v_legacy_district_id,
                 v_legacy_ward_id,
                 CONCAT('Số ', v_street_num, ' Đường ', v_street_name),
                 v_full_newaddress,

--- a/smart-rent/src/main/resources/db/migration/V86__Fix_legacy_address_province_district_ids.sql
+++ b/smart-rent/src/main/resources/db/migration/V86__Fix_legacy_address_province_district_ids.sql
@@ -1,0 +1,37 @@
+-- Migration V86: Repair corrupted legacy_province_id / legacy_district_id on addresses
+-- ============================================================================
+-- BUG: the bulk address seeder (scripts/populate_addresses_for_listings.sql)
+-- wrote the official GSO *codes* into the addresses.legacy_province_id and
+-- addresses.legacy_district_id columns instead of the legacy_provinces /
+-- legacy_districts surrogate primary keys those columns are supposed to hold:
+--
+--     legacy_province_id  <- CAST(province_code AS UNSIGNED)   -- wrong
+--     legacy_district_id  <- CAST(district_code AS UNSIGNED)   -- wrong
+--
+-- Because legacy_provinces.legacy_province_id is AUTO_INCREMENT (assigned in
+-- code order, 1..63) it diverges from province_code for every province past
+-- the second. e.g. Đồng Tháp: code '87' but PK 56; Khánh Hòa: code '56' but
+-- PK 37. The frontend province dropdown emits the PK (province.id) and
+-- ListingSpecification matches addresses.legacy_province_id against that PK,
+-- so filtering "Đồng Tháp" (provinceId=56) returned Khánh Hòa listings
+-- (whose seeded legacy_province_id happened to be the code 56).
+--
+-- FIX: the seeder stored legacy_ward_id CORRECTLY (the real legacy_wards PK),
+-- so we re-derive the right province/district PKs from the ward. The update
+-- is idempotent — the WHERE clause only touches rows whose stored value
+-- disagrees with the derived-correct value, so genuine user-created listings
+-- (which already hold the right PK) and re-runs are no-ops.
+--
+-- legacy_districts.district_code is globally UNIQUE, so joining on it alone
+-- resolves the district unambiguously.
+-- ============================================================================
+
+UPDATE addresses a
+JOIN legacy_wards     w ON w.legacy_ward_id = a.legacy_ward_id
+JOIN legacy_provinces p ON p.province_code  = w.province_code
+JOIN legacy_districts d ON d.district_code  = w.district_code
+SET a.legacy_province_id = p.legacy_province_id,
+    a.legacy_district_id = d.legacy_district_id
+WHERE a.legacy_ward_id IS NOT NULL
+  AND (a.legacy_province_id <> p.legacy_province_id
+       OR a.legacy_district_id <> d.legacy_district_id);


### PR DESCRIPTION
## Problem

Selecting **Đồng Tháp** in the property filter (`?provinceId=56`) returned **Khánh Hòa** listings.

Root cause is in the **data**, not the filter logic. The bulk address seeder
(`scripts/populate_addresses_for_listings.sql`) wrote the official GSO
province/district **codes** into `addresses.legacy_province_id` /
`addresses.legacy_district_id`:

```sql
legacy_province_id <- CAST(province_code AS UNSIGNED)   -- wrong
legacy_district_id <- CAST(district_code AS UNSIGNED)   -- wrong
```

But those columns are FKs to the `legacy_provinces` / `legacy_districts`
**surrogate PKs** (`AUTO_INCREMENT`, assigned in code order → they diverge from
the codes for every province past the second):

| Province | PK (`legacy_province_id`) | GSO code |
|---|---|---|
| Khánh Hòa | 37 | **56** |
| Đồng Tháp | **56** | 87 |

The FE province dropdown emits the PK (`province.id`) and
`ListingSpecification` matches `legacy_province_id` against that PK. So
`provinceId=56` (Đồng Tháp's PK) collided with the seeded **code** 56
(Khánh Hòa). Confirmed on the live DB: `WHERE legacy_province_id = 56` → 710
Khánh Hòa listings.

## Fix

- **`V86__Fix_legacy_address_province_district_ids.sql`** — idempotent repair of
  the already-seeded `addresses`. The seeder stored `legacy_ward_id` *correctly*
  (the real `legacy_wards` PK), so we re-derive the right province/district PKs
  from the ward. The `WHERE` clause only touches rows whose stored value
  disagrees with the derived value, so genuine user-created listings (already
  correct) and re-runs are no-ops. `legacy_districts.district_code` is globally
  UNIQUE, so the district join is unambiguous.
- **`populate_addresses_for_listings.sql`** — resolve the PKs via JOIN in the
  cursor instead of `CAST(code)`, preventing recurrence on future runs.

## How to verify

```sql
-- after V86, expected: Tỉnh Đồng Tháp
SELECT SUBSTRING_INDEX(full_address, ',', -1) AS tinh, COUNT(*)
FROM addresses WHERE legacy_province_id = 56 GROUP BY tinh ORDER BY 2 DESC LIMIT 3;
```

Then reload `?provinceId=56` — Đồng Tháp listings should appear.

## Notes

- No application/FE code changes — filter logic was already correct.
- Affects province **and** district ids (same seeding bug); V86 repairs both.
- Recommend a backup of `addresses` and running the dry-run COUNT before applying.
