### PR TITLE
perf(map): make map-bounds deterministic and cacheable

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/config/Constants.java
+++ b/smart-rent/src/main/java/com/smartrent/config/Constants.java
@@ -32,6 +32,13 @@ public class Constants {
      * {@code HomepageStatsCacheScheduler}.
      */
     public static final String LISTING_STATS_PROVINCES = LISTING + "stats.provinces";
+    /**
+     * Short-TTL cache for POST /v1/listings/map-bounds (interactive map pins).
+     * Keyed by quantized bounding box + zoom + filters. Map browsing is bursty
+     * (pan/zoom around the same city, many concurrent users on the same area),
+     * so even a 60s TTL absorbs most repeat hits while keeping pins fresh.
+     */
+    public static final String LISTING_MAP = LISTING + "map";
     public static final String LISTING_RECOMMENDATION_SIMILAR = LISTING + "recommendation.similar";
     public static final String LISTING_RECOMMENDATION_PERSONALIZED = LISTING + "recommendation.personalized";
   }

--- a/smart-rent/src/main/java/com/smartrent/service/listing/ListingQueryService.java
+++ b/smart-rent/src/main/java/com/smartrent/service/listing/ListingQueryService.java
@@ -169,9 +169,20 @@ public class ListingQueryService {
         Specification<Listing> spec = ListingSpecification.withinMapBounds(
                 neLat, neLng, swLat, swLng, verifiedOnly, categoryId, vipType);
 
-        // Create pageable with limit (no default sorting)
+        // Deterministic ordering is REQUIRED for the map: the query is capped by
+        // `limit`, so without a stable ORDER BY the database is free to return a
+        // different subset (and different order) for the same bounding box on each
+        // call — which is exactly the "points flicker / disappear in the same area"
+        // bug. Sort by VIP tier (DIAMOND first) so the most relevant pins always
+        // win the cap, then newest first, then listingId as a final tie-breaker so
+        // the result set is fully reproducible.
+        Sort sort = Sort.by(Sort.Direction.ASC, "vipTypeSortOrder")
+                .and(Sort.by(Sort.Direction.DESC, "updatedAt"))
+                .and(Sort.by(Sort.Direction.ASC, "listingId"));
+
+        // Create pageable with limit and the deterministic sort
         int safeLimit = Math.min(Math.max(limit, 1), 500); // Max 500 for map queries
-        Pageable pageable = PageRequest.of(0, safeLimit);
+        Pageable pageable = PageRequest.of(0, safeLimit, sort);
 
         // Execute query
         Page<Listing> results = listingRepository.findAll(spec, pageable);

--- a/smart-rent/src/main/java/com/smartrent/service/listing/impl/ListingServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/listing/impl/ListingServiceImpl.java
@@ -2970,6 +2970,9 @@ public class ListingServiceImpl implements ListingService {
 
     @Override
     @Transactional(readOnly = true)
+    @Cacheable(cacheNames = com.smartrent.config.Constants.CacheNames.LISTING_MAP,
+            key = "T(com.smartrent.util.CacheKeyBuilder).mapBoundsKey(#request)",
+            unless = "#result == null")
     public com.smartrent.dto.response.MapListingsResponse getListingsByMapBounds(
             MapBoundsRequest request) {
         log.info("Getting listings by map bounds - NE: ({}, {}), SW: ({}, {}), zoom: {}, limit: {}",

--- a/smart-rent/src/main/java/com/smartrent/util/CacheKeyBuilder.java
+++ b/smart-rent/src/main/java/com/smartrent/util/CacheKeyBuilder.java
@@ -184,6 +184,31 @@ public final class CacheKeyBuilder {
             .collect(Collectors.joining(","));
     }
 
+    /**
+     * Cache key for {@code POST /v1/listings/map-bounds}.
+     * Encodes the bounding box, zoom, limit and filters. The frontend already
+     * rounds the bounds to 4 decimals (~11m) before sending, so identical
+     * viewports — the same user returning to a spot, or many users browsing the
+     * same area — collapse to a single entry instead of each re-running the geo
+     * query.
+     *
+     * @param request Map bounds request (must not be {@code null} at call time —
+     *                guarded for safety)
+     * @return Cache key string prefixed with {@code "map|"}
+     */
+    public static String mapBoundsKey(com.smartrent.dto.request.MapBoundsRequest request) {
+        if (request == null) {
+            return "null";
+        }
+        return "map|ne=" + Objects.toString(request.getNeLat(), "") + ',' + Objects.toString(request.getNeLng(), "")
+             + "|sw=" + Objects.toString(request.getSwLat(), "") + ',' + Objects.toString(request.getSwLng(), "")
+             + "|z=" + Objects.toString(request.getZoom(), "")
+             + "|lim=" + Objects.toString(request.getLimit(), "")
+             + "|cat=" + Objects.toString(request.getCategoryId(), "")
+             + "|vip=" + Objects.toString(request.getVipType(), "")
+             + "|ver=" + Objects.toString(request.getVerifiedOnly(), "false");
+    }
+
     public static String suggestionKey(String query, String provinceId, Long categoryId, int limit) {
         String norm = SearchTextCanonicalizer.cacheCanonical(query);
         return "sugg|q="  + Objects.toString(norm, "")

--- a/smart-rent/src/main/resources/application.yml
+++ b/smart-rent/src/main/resources/application.yml
@@ -147,6 +147,7 @@ spring:
       - "listing.browse"
       - "listing.detail"
       - "listing.suggestions"
+      - "listing.map"
       - "listing.stats.categories"
       - "listing.stats.provinces"
       - "listing.recommendation.similar"
@@ -163,6 +164,7 @@ spring:
         "[listing.browse]": 3m
         "[listing.detail]": 3m
         "[listing.suggestions]": 2m
+        "[listing.map]": 1m
         # Homepage stats: permanent (0s = no TTL). Refreshed daily at 00:00
         # Asia/Ho_Chi_Minh by HomepageStatsCacheScheduler.
         "[listing.stats.categories]": 0s


### PR DESCRIPTION
The /v1/listings/map-bounds query applied a hard LIMIT with no ORDER BY, so the database was free to return a different subset (and different order) for the same bounding box on each call. This is the root cause of pins flickering / disappearing in the same map area.

- Add a deterministic sort to queryByMapBounds (vipTypeSortOrder ASC, updatedAt DESC, listingId ASC). The most relevant pins now always win the cap and the result set is fully reproducible for a given viewport.
- Cache the endpoint with @Cacheable on a new short-TTL (1m) "listing.map" cache, keyed by quantized bounds + zoom + filters via CacheKeyBuilder.mapBoundsKey. Map browsing is bursty, so repeat hits on the same area are served from Redis.