### PR TITLE
fix(entity): map favorites/views user_id as String, not Long

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/infra/repository/entity/FavoriteId.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/entity/FavoriteId.java
@@ -21,8 +21,12 @@ import java.io.Serializable;
 @FieldDefaults(level = AccessLevel.PRIVATE)
 public class FavoriteId implements Serializable {
 
+    // user_id is users.user_id VARCHAR(36) (UUID) — must be String, not Long.
+    // Mapping it as Long made Hibernate read the column via getLong(), which
+    // threw NumberFormatException when initializing the Listing.favorites
+    // collection for any UUID user_id (e.g. AI auto-moderation of seeded data).
     @Column(name = "user_id")
-    Long userId;
+    String userId;
 
     @Column(name = "listing_id")
     Long listingId;

--- a/smart-rent/src/main/java/com/smartrent/infra/repository/entity/View.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/entity/View.java
@@ -36,8 +36,8 @@ public class View {
     @JoinColumn(name = "listing_id", nullable = false)
     Listing listing;
 
-    @Column(name = "user_id") // Can be null for anonymous views
-    Long userId; // Reference to User.id
+    @Column(name = "user_id", length = 36) // Can be null for anonymous views
+    String userId; // Reference to User.userId (UUID), matches users.user_id VARCHAR(36)
 
     @Column(name = "ip_address", length = 45)
     String ipAddress;


### PR DESCRIPTION
## Problem

The AI auto-moderation scheduler errored every 5 minutes:

```
InvalidDataAccessApiUsageException: For input string: "00000000-test-0008-0000-000000000008"
  ... com.mysql.cj.jdbc.result.ResultSetImpl.getLong
  ... org.hibernate.type.descriptor.jdbc.BigIntJdbcType ...
  ... CollectionLoaderSingleKey.load → AbstractCollectionPersister.initialize
```

Root cause is a **mapping bug**, not bad data. `FavoriteId.userId` and
`View.userId` were typed `Long`, but their columns are `users.user_id`
**`VARCHAR(36)`** (UUID). Hibernate read the column via `getLong()`, so
initializing the `Listing.favorites` / `Listing.views` lazy collections threw
`NumberFormatException` for any UUID `user_id`.

It happened to surface on seeded test data (`user_id LIKE '00000000-test-%'`),
but it breaks **real users identically** — their `user_id`s are UUIDs too
(hex + hyphens, also non-numeric). Changing the data does **not** fix it.

## Fix

Map both fields as `String` to match the `VARCHAR(36)` columns and the
`@MapsId` `User` association (whose `@Id` is `String`):

- `FavoriteId.userId`: `Long` → `String`
- `View.userId`: `Long` → `String`

`listingId` stays `Long` (`listing_id` is `BIGINT`).

## Why this is safe

- `Favorite`/`FavoriteId` are referenced only by the entity files and the
  `Listing.favorites` collection — there is **no `FavoriteRepository` or
  service** constructing/querying the id. Zero call-site blast radius.
- `View.userId` already had a sibling pattern; no numeric usage of it.
- `./gradlew compileJava` passes.
- No data migration required.

## Verify

After deploy, the AI moderation scheduler batch should complete cleanly
(no more `NumberFormatException`), and loading a listing's favorites/views
works for both seeded and real users.
