### PR TITLE
fix(listing): keep draft when payment fails on publish

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/dto/request/ListingCreationRequest.java
+++ b/smart-rent/src/main/java/com/smartrent/dto/request/ListingCreationRequest.java
@@ -144,4 +144,13 @@ public class ListingCreationRequest {
      * Required when useMembershipQuota is false
      */
     String paymentProvider;
+
+    /**
+     * Internal: the draft this publish request originated from.
+     * Set server-side by publishDraft (never sent by the client) so the draft can be
+     * deleted only after the listing is actually materialised — i.e. after a successful
+     * payment. If payment fails or never completes, the draft is preserved.
+     */
+    @Schema(hidden = true)
+    Long sourceDraftId;
 }

--- a/smart-rent/src/main/java/com/smartrent/service/listing/impl/ListingServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/listing/impl/ListingServiceImpl.java
@@ -1055,6 +1055,10 @@ public class ListingServiceImpl implements ListingService {
             // Remove from cache
             listingRequestCacheService.removeNormalListingRequest(transactionId);
 
+            // If this listing was published from a draft, the draft was kept until now
+            // (so a failed payment wouldn't lose it). Payment succeeded - delete it.
+            deleteSourceDraftIfPresent(request);
+
             return listingMapper.toCreationResponse(saved);
 
         } catch (Exception e) {
@@ -2319,6 +2323,9 @@ public class ListingServiceImpl implements ListingService {
         // Merge draft data with request (request takes precedence)
         ListingCreationRequest mergedRequest = mergeDraftWithRequest(draft, request);
         mergedRequest.setUserId(userId);
+        // Carry the draft id through the (Redis-cached) request so the post-payment
+        // callback can delete the draft only once the listing is actually created.
+        mergedRequest.setSourceDraftId(draftId);
 
         // Validate required fields
         validateDraftForPublish(mergedRequest);
@@ -2326,10 +2333,18 @@ public class ListingServiceImpl implements ListingService {
         // Create the listing using the normal flow
         ListingCreationResponse response = createListing(mergedRequest);
 
-        // Delete the draft after successful publish
-        listingDraftRepository.delete(draft);
-        log.info("Draft {} deleted after successful publish, listing created with id: {}",
-                draftId, response.getListingId());
+        if (Boolean.TRUE.equals(response.getPaymentRequired())) {
+            // Listing is not created yet - it will be materialised from the cache after
+            // payment succeeds, and the draft is deleted there. Keep the draft for now so a
+            // failed/abandoned payment doesn't lose the user's work.
+            log.info("Draft {} kept pending payment for transaction {}",
+                    draftId, response.getTransactionId());
+        } else {
+            // Listing created immediately (quota path) - safe to delete the draft now.
+            listingDraftRepository.delete(draft);
+            log.info("Draft {} deleted after successful publish, listing created with id: {}",
+                    draftId, response.getListingId());
+        }
 
         return response;
     }
@@ -2346,6 +2361,22 @@ public class ListingServiceImpl implements ListingService {
 
         listingDraftRepository.delete(draft);
         log.info("Draft listing {} deleted successfully", draftId);
+    }
+
+    /**
+     * Delete the originating draft after a payment-gated publish completes successfully.
+     * No-op when the request did not come from a draft, or the draft is already gone.
+     */
+    private void deleteSourceDraftIfPresent(ListingCreationRequest request) {
+        Long draftId = request.getSourceDraftId();
+        if (draftId == null) {
+            return;
+        }
+        listingDraftRepository.findByDraftIdAndUserId(draftId, request.getUserId())
+                .ifPresent(draft -> {
+                    listingDraftRepository.delete(draft);
+                    log.info("Draft {} deleted after payment-completed publish", draftId);
+                });
     }
 
     /**

--- a/smart-rent/src/test/java/com/smartrent/service/listing/impl/ListingServiceImplPublishDraftTest.java
+++ b/smart-rent/src/test/java/com/smartrent/service/listing/impl/ListingServiceImplPublishDraftTest.java
@@ -1,0 +1,105 @@
+package com.smartrent.service.listing.impl;
+
+import com.smartrent.dto.request.AddressCreationRequest;
+import com.smartrent.dto.request.ListingCreationRequest;
+import com.smartrent.dto.response.ListingCreationResponse;
+import com.smartrent.infra.repository.ListingDraftRepository;
+import com.smartrent.infra.repository.entity.ListingDraft;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ListingServiceImplPublishDraftTest {
+
+    @Mock
+    ListingDraftRepository listingDraftRepository;
+
+    @InjectMocks
+    ListingServiceImpl injected;
+
+    ListingServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        // Spy so we can stub createListing() and isolate publishDraft's draft-lifecycle logic.
+        service = spy(injected);
+    }
+
+    private ListingCreationRequest validPublishRequest() {
+        return ListingCreationRequest.builder()
+                .title("Nice room")
+                .description("A description")
+                .listingType("RENT")
+                .productType("APARTMENT")
+                .price(BigDecimal.valueOf(1_000_000))
+                .priceUnit("VND")
+                .categoryId(1L)
+                .vipType("NORMAL")
+                .address(AddressCreationRequest.builder().build())
+                .build();
+    }
+
+    @Test
+    void keepsDraftWhenPaymentRequired() {
+        Long draftId = 1L;
+        String userId = "user-1";
+        when(listingDraftRepository.findByDraftIdAndUserId(draftId, userId))
+                .thenReturn(Optional.of(ListingDraft.builder().build()));
+        doReturn(ListingCreationResponse.builder().paymentRequired(true).transactionId("tx-1").build())
+                .when(service).createListing(any());
+
+        service.publishDraft(draftId, validPublishRequest(), userId);
+
+        // Payment not yet completed -> draft must survive so a failed payment doesn't lose it.
+        verify(listingDraftRepository, never()).delete(any());
+    }
+
+    @Test
+    void propagatesDraftIdIntoCreateListingRequest() {
+        Long draftId = 7L;
+        String userId = "user-1";
+        when(listingDraftRepository.findByDraftIdAndUserId(draftId, userId))
+                .thenReturn(Optional.of(ListingDraft.builder().build()));
+        doReturn(ListingCreationResponse.builder().paymentRequired(true).build())
+                .when(service).createListing(any());
+
+        service.publishDraft(draftId, validPublishRequest(), userId);
+
+        ArgumentCaptor<ListingCreationRequest> captor = ArgumentCaptor.forClass(ListingCreationRequest.class);
+        verify(service).createListing(captor.capture());
+        // draftId must ride along so the post-payment callback can delete the draft.
+        assertEquals(draftId, captor.getValue().getSourceDraftId());
+    }
+
+    @Test
+    void deletesDraftWhenListingCreatedImmediately() {
+        Long draftId = 2L;
+        String userId = "user-1";
+        ListingDraft draft = ListingDraft.builder().build();
+        when(listingDraftRepository.findByDraftIdAndUserId(draftId, userId))
+                .thenReturn(Optional.of(draft));
+        doReturn(ListingCreationResponse.builder().paymentRequired(false).listingId(99L).build())
+                .when(service).createListing(any());
+
+        service.publishDraft(draftId, validPublishRequest(), userId);
+
+        // Quota path: listing already exists, no pending payment -> draft is safe to remove now.
+        verify(listingDraftRepository).delete(draft);
+    }
+}


### PR DESCRIPTION
publishDraft deleted the draft immediately after createListing returned, but in the payment flow createListing returns before payment completes (the listing is materialised from the Redis cache only after a successful payment callback). A failed or abandoned payment therefore lost the draft.

Now the draft id rides along in the cached request (sourceDraftId) and the draft is deleted only when the listing is actually created post-payment, or immediately for the quota path. Failed/abandoned payments preserve the draft.