### PR TITLE
fix(payment): restore VNPAY enum as legacy provider

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/enums/PaymentProvider.java
+++ b/smart-rent/src/main/java/com/smartrent/enums/PaymentProvider.java
@@ -12,7 +12,14 @@ public enum PaymentProvider {
     SEPAY("sepay", "SePay Payment Gateway"),
     PAYPAL("paypal", "PayPal Payment Gateway"),
     MOMO("momo", "MoMo Payment Gateway"),
-    ZALOPAY("zalopay", "ZaloPay Payment Gateway");
+    ZALOPAY("zalopay", "ZaloPay Payment Gateway"),
+
+    /**
+     * Legacy provider, kept only so historical transactions created before the
+     * SePay migration can still be read. No provider bean is registered for it,
+     * so it must not be used to initiate new payments.
+     */
+    VNPAY("vnpay", "VNPay Payment Gateway (legacy)");
 
     String code;
     String displayName;

--- a/smart-rent/src/main/java/com/smartrent/service/payment/impl/PaymentServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/payment/impl/PaymentServiceImpl.java
@@ -228,6 +228,8 @@ public class PaymentServiceImpl implements PaymentService {
             case PAYPAL -> params.get("token");
             case MOMO -> params.get("orderId");
             case ZALOPAY -> params.get("apptransid");
+            // Legacy provider; no new callbacks expected, but kept for exhaustiveness.
+            case VNPAY -> params.get("vnp_TxnRef");
         };
     }
 


### PR DESCRIPTION
Hibernate failed to hydrate legacy transactions with payment_provider='VNPAY' ('No enum constant ...PaymentProvider.VNPAY') after the constant was dropped, breaking GET /v1/me/transactions for any page containing pre-SePay records.

Re-add VNPAY as a legacy-only constant (no provider bean registered, so it can't be used to initiate new payments) and add the matching case to the callback transaction-ref switch to keep it exhaustive.