### PR TITLE
fix(payment): pass SePay providerData through listing/repost/push/upg…

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/dto/response/ListingCreationResponse.java
+++ b/smart-rent/src/main/java/com/smartrent/dto/response/ListingCreationResponse.java
@@ -8,6 +8,8 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.experimental.FieldDefaults;
 
+import java.util.Map;
+
 @Getter
 @Setter
 @Builder
@@ -23,6 +25,11 @@ public class ListingCreationResponse {
     String transactionId;
     Long amount;
     String paymentUrl;
+    // Payment provider (e.g. "SEPAY") + provider-specific checkout data. SePay
+    // returns signed form fields that the FE must POST to the hosted checkout;
+    // without providerData the FE cannot start the SePay checkout.
+    String provider;
+    Map<String, Object> providerData;
     String message;
 }
 

--- a/smart-rent/src/main/java/com/smartrent/dto/response/MembershipUpgradeResponse.java
+++ b/smart-rent/src/main/java/com/smartrent/dto/response/MembershipUpgradeResponse.java
@@ -5,6 +5,7 @@ import lombok.experimental.FieldDefaults;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.Map;
 
 /**
  * Response DTO for membership upgrade initiation
@@ -22,6 +23,10 @@ public class MembershipUpgradeResponse {
     String transactionRef;
     String paymentUrl;
     String paymentProvider;
+    // Provider-specific checkout data. SePay returns signed form fields the FE
+    // must POST to the hosted checkout; without providerData the FE cannot
+    // start the SePay checkout.
+    Map<String, Object> providerData;
 
     // Upgrade details
     Long previousMembershipId;

--- a/smart-rent/src/main/java/com/smartrent/dto/response/PushResponse.java
+++ b/smart-rent/src/main/java/com/smartrent/dto/response/PushResponse.java
@@ -4,6 +4,7 @@ import lombok.*;
 import lombok.experimental.FieldDefaults;
 
 import java.time.LocalDateTime;
+import java.util.Map;
 
 @Getter
 @Setter
@@ -23,4 +24,9 @@ public class PushResponse {
     // Payment-related fields (only populated when payment is required)
     String paymentUrl;
     String transactionId;
+    // Payment provider (e.g. "SEPAY") + provider-specific checkout data. SePay
+    // returns signed form fields the FE must POST to the hosted checkout;
+    // without providerData the FE cannot start the SePay checkout.
+    String provider;
+    Map<String, Object> providerData;
 }

--- a/smart-rent/src/main/java/com/smartrent/dto/response/RepostResponse.java
+++ b/smart-rent/src/main/java/com/smartrent/dto/response/RepostResponse.java
@@ -4,6 +4,7 @@ import lombok.*;
 import lombok.experimental.FieldDefaults;
 
 import java.time.LocalDateTime;
+import java.util.Map;
 
 /**
  * Response from repost (re-publish) operations.
@@ -38,4 +39,9 @@ public class RepostResponse {
     // Only populated when payment is required
     String paymentUrl;
     String transactionId;
+    // Payment provider (e.g. "SEPAY") + provider-specific checkout data. SePay
+    // returns signed form fields the FE must POST to the hosted checkout;
+    // without providerData the FE cannot start the SePay checkout.
+    String provider;
+    Map<String, Object> providerData;
 }

--- a/smart-rent/src/main/java/com/smartrent/service/listing/impl/ListingServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/listing/impl/ListingServiceImpl.java
@@ -333,6 +333,8 @@ public class ListingServiceImpl implements ListingService {
                 .transactionId(transactionId)
                 .amount(amount.longValue())
                 .paymentUrl(paymentResponse.getPaymentUrl())
+                .provider(paymentResponse.getProvider() != null ? paymentResponse.getProvider().name() : null)
+                .providerData(paymentResponse.getProviderData())
                 .message("Payment required. Complete payment to create listing.")
                 .build();
     }
@@ -448,6 +450,8 @@ public class ListingServiceImpl implements ListingService {
                 .transactionId(transactionId)
                 .amount(amount.longValue())
                 .paymentUrl(paymentResponse.getPaymentUrl())
+                .provider(paymentResponse.getProvider() != null ? paymentResponse.getProvider().name() : null)
+                .providerData(paymentResponse.getProviderData())
                 .message("Payment required. Complete payment to activate VIP listing.")
                 .build();
     }

--- a/smart-rent/src/main/java/com/smartrent/service/membership/impl/MembershipServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/membership/impl/MembershipServiceImpl.java
@@ -856,6 +856,7 @@ public class MembershipServiceImpl implements MembershipService {
                 .transactionRef(transactionId)
                 .paymentUrl(paymentResponse.getPaymentUrl())
                 .paymentProvider(request.getPaymentProvider() != null ? request.getPaymentProvider() : "SEPAY")
+                .providerData(paymentResponse.getProviderData())
                 .previousMembershipId(currentMembership.getUserMembershipId())
                 .newMembershipPackageId(targetPackage.getMembershipId())
                 .newPackageName(targetPackage.getPackageName())

--- a/smart-rent/src/main/java/com/smartrent/service/push/impl/PushServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/push/impl/PushServiceImpl.java
@@ -174,6 +174,8 @@ public class PushServiceImpl implements PushService {
                 .message("Payment required")
                 .paymentUrl(paymentResponse.getPaymentUrl())
                 .transactionId(paymentResponse.getTransactionRef())
+                .provider(paymentResponse.getProvider() != null ? paymentResponse.getProvider().name() : null)
+                .providerData(paymentResponse.getProviderData())
                 .build();
     }
 

--- a/smart-rent/src/main/java/com/smartrent/service/repost/impl/RepostServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/repost/impl/RepostServiceImpl.java
@@ -134,6 +134,8 @@ public class RepostServiceImpl implements RepostService {
                 .message("Payment required")
                 .paymentUrl(paymentResponse.getPaymentUrl())
                 .transactionId(paymentResponse.getTransactionRef())
+                .provider(paymentResponse.getProvider() != null ? paymentResponse.getProvider().name() : null)
+                .providerData(paymentResponse.getProviderData())
                 .build();
     }
 


### PR DESCRIPTION
…rade responses

SePay's hosted checkout requires the FE to POST signed form fields (providerData.fields), unlike redirect providers. The membership purchase flow worked because it returns the raw PaymentResponse, which carries providerData. The listing-create, VIP-listing, repost, push, and membership-upgrade flows wrapped the payment in their own DTOs that dropped providerData (and provider), so the FE fell back to a GET redirect to the bare SePay init URL and the checkout failed.

Add provider + providerData to ListingCreationResponse, RepostResponse, PushResponse, and MembershipUpgradeResponse, and populate them from the PaymentResponse in each service. The FE response types already expect these fields.