### PR TITLE
fix(payment): remove duplicate providerData on MembershipUpgradeResponse

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/dto/response/MembershipUpgradeResponse.java
+++ b/smart-rent/src/main/java/com/smartrent/dto/response/MembershipUpgradeResponse.java
@@ -23,10 +23,6 @@ public class MembershipUpgradeResponse {
     String transactionRef;
     String paymentUrl;
     String paymentProvider;
-    // Provider-specific checkout data. SePay returns signed form fields the FE
-    // must POST to the hosted checkout; without providerData the FE cannot
-    // start the SePay checkout.
-    Map<String, Object> providerData;
 
     /**
      * Provider-specific data needed to start the checkout, mirroring

--- a/smart-rent/src/main/java/com/smartrent/service/membership/impl/MembershipServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/membership/impl/MembershipServiceImpl.java
@@ -859,7 +859,6 @@ public class MembershipServiceImpl implements MembershipService {
                 // Without this the frontend only has paymentUrl and GETs the checkout URL -> 404.
                 .providerData(paymentResponse.getProviderData())
                 .paymentProvider(request.getPaymentProvider() != null ? request.getPaymentProvider() : "SEPAY")
-                .providerData(paymentResponse.getProviderData())
                 .previousMembershipId(currentMembership.getUserMembershipId())
                 .newMembershipPackageId(targetPackage.getMembershipId())
                 .newPackageName(targetPackage.getPackageName())


### PR DESCRIPTION
PR #302 and an independent change on main both added a `providerData` field to MembershipUpgradeResponse (and the matching builder call in MembershipServiceImpl). The merge combined both, producing a duplicate field declaration that fails to compile ("variable providerData is already defined"). javac's error makes Lombok bail on the whole round, so every @Slf4j `log`, @Builder `builder()`, and @Getter accessor across the module also fails — the hundreds of cascading "cannot find symbol" errors in CI all trace back to this single duplicate.

Keep the better-documented declaration, drop the duplicate field and the duplicate `.providerData(...)` builder call.