### PR TITLE
fix(recently-viewed): only return currently displayed listings

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/infra/repository/ListingRepository.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/ListingRepository.java
@@ -20,6 +20,22 @@ import org.springframework.transaction.annotation.Transactional;
 public interface ListingRepository extends JpaRepository<Listing, Long>, JpaSpecificationExecutor<Listing> {
     List<Listing> findByListingIdIn(Collection<Long> listingIds);
 
+    /**
+     * Fetch listings by id restricted to those currently publicly displayed
+     * (same visibility filter as {@link #findPublicListings}). Used so that
+     * features like "recently viewed" never surface listings that have since
+     * been hidden, expired, unverified, drafted or shadowed.
+     */
+    @Query("""
+        SELECT l FROM listings l
+        WHERE l.listingId IN :listingIds
+        AND l.isDraft = false
+        AND l.isShadow = false
+        AND l.verified = true
+        AND l.expired = false
+    """)
+    List<Listing> findDisplayingByListingIdIn(@Param("listingIds") Collection<Long> listingIds);
+
     List<Listing> findByUserId(String userId);
 
     Optional<Listing> findByParentListingId(Long parentListingId);

--- a/smart-rent/src/main/java/com/smartrent/service/listing/ListingService.java
+++ b/smart-rent/src/main/java/com/smartrent/service/listing/ListingService.java
@@ -49,6 +49,12 @@ public interface ListingService {
 
     ListingResponse getListingById(Long id);
     List<ListingResponse> getListingsByIds(Set<Long> ids);
+
+    /**
+     * Same as {@link #getListingsByIds(Set)} but restricted to listings that are
+     * currently publicly displayed (not drafted, shadowed, unverified or expired).
+     */
+    List<ListingResponse> getDisplayingListingsByIds(Set<Long> ids);
     List<ListingResponse> getListings(int page, int size);
     ListingResponse updateListing(Long id, ListingRequest request, String userId);
     void deleteListing(Long id);

--- a/smart-rent/src/main/java/com/smartrent/service/listing/impl/ListingServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/listing/impl/ListingServiceImpl.java
@@ -588,6 +588,13 @@ public class ListingServiceImpl implements ListingService {
 
     @Override
     @Transactional(readOnly = true)
+    public List<ListingResponse> getDisplayingListingsByIds(Set<Long> ids) {
+        List<Listing> listings = listingRepository.findDisplayingByListingIdIn(ids);
+        return batchMapListings(listings);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
     @Cacheable(cacheNames = com.smartrent.config.Constants.CacheNames.LISTING_BROWSE,
             key = "'page:' + #page + ':size:' + #size",
             unless = "#result == null || #result.isEmpty()")

--- a/smart-rent/src/main/java/com/smartrent/service/recentlyviewed/impl/RecentlyViewedServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/recentlyviewed/impl/RecentlyViewedServiceImpl.java
@@ -134,9 +134,10 @@ public class RecentlyViewedServiceImpl implements RecentlyViewedService {
                         tuple -> tuple.getScore().longValue()
                 ));
 
-        // Fetch full listing details
+        // Fetch full listing details, restricted to listings that are currently
+        // publicly displayed so hidden/expired/unverified ones are not surfaced.
         Set<Long> listingIds = listingIdToTimestamp.keySet();
-        List<ListingResponse> listings = listingService.getListingsByIds(listingIds);
+        List<ListingResponse> listings = listingService.getDisplayingListingsByIds(listingIds);
 
         // Create a map for quick lookup
         Map<Long, ListingResponse> listingMap = listings.stream()


### PR DESCRIPTION
Recently viewed now filters to listings that are publicly displayed (not draft/shadow/unverified/expired), matching findPublicListings, so hidden or expired listings are no longer surfaced on the FE.