### PR TITLE
fix(listing-stats): resolve merged-away province names instead of "Un…

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/service/listing/impl/ListingServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/listing/impl/ListingServiceImpl.java
@@ -1684,6 +1684,19 @@ public class ListingServiceImpl implements ListingService {
         Map<String, String> provinceNames = provinceRepository.findByCodeIn(provinceCodes)
                 .stream().collect(Collectors.toMap(Province::getCode, Province::getName));
 
+        // Fallback for codes that no longer exist in the new 34-province structure
+        // (e.g. provinces merged away on 2025-07-01 such as Bình Dương "74" → HCM "79").
+        // FE may still feature such a legacy code as a "top province" card; resolve its
+        // display name from legacy_provinces so the card shows the real name instead of
+        // the generic "Unknown Province" placeholder.
+        List<String> unresolvedCodes = provinceCodes.stream()
+                .filter(code -> !provinceNames.containsKey(code))
+                .collect(Collectors.toList());
+        if (!unresolvedCodes.isEmpty()) {
+            legacyProvinceRepository.findByCodeIn(unresolvedCodes)
+                    .forEach(lp -> provinceNames.putIfAbsent(lp.getCode(), lp.getName()));
+        }
+
         // Reverse mapping (new code → representative legacy id) for the response
         Map<String, Integer> codeToLegacyId = new HashMap<>();
         for (Map.Entry<Integer, String> entry : legacyIdToCode.entrySet()) {


### PR DESCRIPTION
…known Province"

Province cards on the homepage "Bất động sản theo địa điểm" section showed "Unknown Province" for legacy codes that no longer exist in the new 34-province structure (e.g. Bình Dương "74", merged into HCM "79" on 2025-07-01). The FE still features such codes as top-province cards, but computeProvinceStats only looked up names in the new provinces table and fell back to a generic placeholder.

Add a fallback that resolves unresolved codes from legacy_provinces so the card shows the real name.