### PR TITLE
fix(saved-listings): show listing owner instead of saver on saved cards

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/mapper/impl/SavedListingMapperImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/mapper/impl/SavedListingMapperImpl.java
@@ -82,10 +82,13 @@ public class SavedListingMapperImpl implements SavedListingMapper {
         if (entity.getListing() != null) {
             Listing listing = entity.getListing();
 
-            // Map user
+            // Map the listing's owner (poster), not the user who saved it
             UserCreationResponse user = null;
-            if (entity.getUser() != null) {
-                user = userMapper.mapFromUserEntityToUserCreationResponse(entity.getUser());
+            if (listing.getUserId() != null) {
+                User owner = userRepository.findById(listing.getUserId()).orElse(null);
+                if (owner != null) {
+                    user = userMapper.mapFromUserEntityToUserCreationResponse(owner);
+                }
             }
 
             // Map address


### PR DESCRIPTION
toResponseWithListing mapped the listing's user from the SavedListing's user (the person who saved it), so every saved card showed the current user as the poster. Resolve the owner from listing.getUserId() instead, matching the normal listing-detail flow.