### PR TITLE
feat(moderation): wire AI duplicate detection into the moderation pip…

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/dto/request/DuplicateCheckRequest.java
+++ b/smart-rent/src/main/java/com/smartrent/dto/request/DuplicateCheckRequest.java
@@ -1,0 +1,24 @@
+package com.smartrent.dto.request;
+
+import lombok.*;
+import lombok.experimental.FieldDefaults;
+
+import java.util.List;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class DuplicateCheckRequest {
+    String title;
+    String description;
+    Double price;
+    Double area;
+    String productType;
+    String provinceCode;
+    Integer districtId;
+    String address;
+    List<String> imageUrls;
+}

--- a/smart-rent/src/main/java/com/smartrent/dto/response/DuplicateCheckResponse.java
+++ b/smart-rent/src/main/java/com/smartrent/dto/response/DuplicateCheckResponse.java
@@ -1,0 +1,37 @@
+package com.smartrent.dto.response;
+
+import lombok.*;
+import lombok.experimental.FieldDefaults;
+
+import java.util.List;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class DuplicateCheckResponse {
+    boolean isDuplicate;
+    double highestScore;
+    String decision;  // PASS, SUSPICIOUS, DUPLICATE
+    List<SuspiciousMatch> suspiciousMatches;
+
+    @Getter
+    @Setter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @FieldDefaults(level = AccessLevel.PRIVATE)
+    public static class SuspiciousMatch {
+        Object listingId;
+        String title;
+        double score;
+        double titleSimilarity;
+        double descriptionSimilarity;
+        double addressSimilarity;
+        double priceSimilarity;
+        Double llmScore;
+        String llmReason;
+    }
+}

--- a/smart-rent/src/main/java/com/smartrent/infra/connector/SmartRentAiConnector.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/connector/SmartRentAiConnector.java
@@ -15,7 +15,9 @@ import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
+import com.smartrent.dto.request.DuplicateCheckRequest;
 import com.smartrent.dto.request.ListingVerificationRequest;
+import com.smartrent.dto.response.DuplicateCheckResponse;
 import com.smartrent.dto.response.ListingVerificationResponse;
 import java.util.List;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -62,6 +64,12 @@ public interface SmartRentAiConnector {
   @PostMapping(value = "/ai/verify-listing", consumes = MediaType.APPLICATION_JSON_VALUE)
   ListingVerificationResponse verifyListing(
       @RequestBody ListingVerificationRequest request);
+
+  /**
+   * Check whether a listing duplicates any existing one (TF-IDF + LLM pipeline).
+   */
+  @PostMapping(value = "/api/v1/listings/check-duplicate", consumes = MediaType.APPLICATION_JSON_VALUE)
+  DuplicateCheckResponse checkDuplicate(@RequestBody DuplicateCheckRequest request);
 }
 
 

--- a/smart-rent/src/main/java/com/smartrent/service/ai/impl/AiModerationProcessorServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/ai/impl/AiModerationProcessorServiceImpl.java
@@ -3,10 +3,14 @@ package com.smartrent.service.ai.impl;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.smartrent.dto.request.AiListingVerificationRequest;
+import com.smartrent.dto.request.DuplicateCheckRequest;
 import com.smartrent.dto.response.AiListingVerificationResponse;
+import com.smartrent.dto.response.DuplicateCheckResponse;
 import com.smartrent.enums.ModerationStatus;
+import com.smartrent.infra.connector.SmartRentAiConnector;
 import com.smartrent.infra.repository.ListingAiModerationRepository;
 import com.smartrent.infra.repository.ListingRepository;
+import com.smartrent.infra.repository.entity.Address;
 import com.smartrent.infra.repository.entity.Listing;
 import com.smartrent.infra.repository.entity.ListingAiModeration;
 import com.smartrent.infra.repository.entity.enums.VerificationStatus;
@@ -18,6 +22,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
+
 @Service
 @RequiredArgsConstructor
 @Slf4j
@@ -26,6 +33,7 @@ public class AiModerationProcessorServiceImpl implements AiModerationProcessorSe
     private final ListingRepository listingRepository;
     private final ListingAiModerationRepository listingAiModerationRepository;
     private final AiListingVerificationService aiVerificationService;
+    private final SmartRentAiConnector smartRentAiConnector;
     private final ObjectMapper objectMapper;
 
     /**
@@ -53,12 +61,6 @@ public class AiModerationProcessorServiceImpl implements AiModerationProcessorSe
             AiListingVerificationResponse response = aiVerificationService.verifyListing(request);
 
             moderation.setAiScore(response.getScore());
-            try {
-                // Persist the full AI response so admins can review image/video issues and violations.
-                moderation.setAiReason(objectMapper.writeValueAsString(response));
-            } catch (JsonProcessingException e) {
-                log.warn("Failed to serialize full AI response for listing ID: {}", listing.getListingId(), e);
-            }
 
             String suggestedStatus = response.getSuggestedStatus();
             log.info("AI suggested status for listing ID {}: {}", listing.getListingId(), suggestedStatus);
@@ -81,6 +83,34 @@ public class AiModerationProcessorServiceImpl implements AiModerationProcessorSe
                 listing.setModerationStatus(ModerationStatus.PENDING_REVIEW);
             }
 
+            // Duplicate detection — flag-for-admin, never hard-block. Best-effort:
+            // any failure or AI downtime leaves the verification decision untouched.
+            DuplicateCheckResponse duplicateResult = runDuplicateCheck(listing, request);
+            if (duplicateResult != null
+                    && ("DUPLICATE".equals(duplicateResult.getDecision())
+                        || "SUSPICIOUS".equals(duplicateResult.getDecision()))) {
+                log.info("Listing ID {} flagged as {} (score={}) — routing to admin review.",
+                        listing.getListingId(), duplicateResult.getDecision(), duplicateResult.getHighestScore());
+                // Do not auto-approve a suspected duplicate: downgrade an APPROVE to manual review.
+                if (moderation.getVerificationStatus() == VerificationStatus.VERIFIED) {
+                    moderation.setVerificationStatus(VerificationStatus.UNDER_REVIEW);
+                    listing.setVerified(false);
+                    listing.setIsVerify(true); // back to IN_REVIEW so admin can adjudicate
+                    listing.setModerationStatus(ModerationStatus.PENDING_REVIEW);
+                }
+            }
+
+            try {
+                // Persist verification + duplicate result together so admins can review
+                // image/video issues, violations, and any duplicate matches in one place.
+                Map<String, Object> aiReason = new LinkedHashMap<>();
+                aiReason.put("verification", response);
+                aiReason.put("duplicateCheck", duplicateResult);
+                moderation.setAiReason(objectMapper.writeValueAsString(aiReason));
+            } catch (JsonProcessingException e) {
+                log.warn("Failed to serialize AI moderation result for listing ID: {}", listing.getListingId(), e);
+            }
+
             listingAiModerationRepository.save(moderation);
             listingRepository.save(listing);
 
@@ -92,6 +122,42 @@ public class AiModerationProcessorServiceImpl implements AiModerationProcessorSe
             moderation.setRetryCount(moderation.getRetryCount() + 1);
             moderation.setVerificationStatus(VerificationStatus.PENDING); // revert for retry
             listingAiModerationRepository.save(moderation);
+        }
+    }
+
+    /**
+     * Calls the AI duplicate-detection endpoint for a listing. Reuses the fields
+     * already gathered for verification and enriches them with structured
+     * location (province/district) so the AI can retrieve candidates.
+     *
+     * <p>Best-effort by design: any failure (AI down, timeout, validation) is
+     * swallowed and returns {@code null} (treated as PASS) so duplicate detection
+     * can never block the moderation pipeline.
+     */
+    private DuplicateCheckResponse runDuplicateCheck(Listing listing, AiListingVerificationRequest request) {
+        try {
+            DuplicateCheckRequest.DuplicateCheckRequestBuilder builder = DuplicateCheckRequest.builder()
+                    .title(request.getTitle())
+                    .description(request.getDescription())
+                    .price(request.getPrice() != null ? request.getPrice().doubleValue() : null)
+                    .area(request.getArea())
+                    .address(request.getAddress())
+                    .productType(listing.getProductType() != null ? listing.getProductType().name() : null)
+                    .imageUrls(request.getImages());
+
+            Address addr = listing.getAddress();
+            if (addr != null) {
+                String provinceCode = addr.getNewProvinceCode() != null
+                        ? addr.getNewProvinceCode()
+                        : (addr.getLegacyProvinceId() != null ? String.valueOf(addr.getLegacyProvinceId()) : null);
+                builder.provinceCode(provinceCode).districtId(addr.getLegacyDistrictId());
+            }
+
+            return smartRentAiConnector.checkDuplicate(builder.build());
+        } catch (Exception e) {
+            log.warn("Duplicate check failed for listing ID {} (treating as PASS): {}",
+                    listing.getListingId(), e.getMessage());
+            return null;
         }
     }
 }


### PR DESCRIPTION
…eline

Listings already flow through AiModerationProcessorServiceImpl for AI verification. This hooks duplicate detection into that same per-listing step (flag-for-admin, never hard-block):

- SmartRentAiConnector: add checkDuplicate() -> POST /api/v1/listings/check-duplicate (the AI service's TF-IDF + LLM duplicate pipeline).
- DuplicateCheckRequest/Response DTOs.
- processSingleListing: after the verification decision, call the duplicate check (reusing the verification request's fields + structured province/ district from the listing's Address for candidate retrieval). If the decision is DUPLICATE/SUSPICIOUS, never auto-approve — downgrade an APPROVE to UNDER_REVIEW/PENDING_REVIEW so an admin adjudicates.
- Persist verification + duplicate result together in ListingAiModeration.aiReason (no schema change; the column was previously the raw verification JSON).

Best-effort: any AI failure/timeout is swallowed (treated as PASS) so duplicate detection can never block the moderation pipeline.

Compiles clean (gradlew compileJava). Live end-to-end smoke test pending (needs AI service running the duplicate-detection-v2 branch + backend + DB).