### PR TITLE
ci: split CI/CD + deploy via Dokploy webhook (drop SSH/tags.env)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,8 +1,11 @@
-name: Java CI with Gradle
+name: CI
+
+# Continuous Integration — the merge gate.
+# Builds + runs unit tests (with coverage) on every PR into main. Image build
+# + deploy live in cd.yml and run only AFTER merge. Enable branch protection
+# so this check must pass before a PR can merge → main only contains tested code.
 
 on:
-  push:
-    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
 
@@ -13,9 +16,6 @@ concurrency:
 jobs:
   unit-test:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-
     defaults:
       run:
         working-directory: ./smart-rent
@@ -43,7 +43,7 @@ jobs:
           gradle-${{ runner.os }}-
           gradle-
 
-    - name: Build and Run unit tests with coverage
+    - name: Build and run unit tests with coverage
       run: |
         chmod +x gradlew
         ./gradlew build jacocoTestReport \
@@ -51,132 +51,3 @@ jobs:
           --parallel \
           --build-cache \
           --continue
-
-  #      - name: SonarCloud Scan
-  #        uses: SonarSource/sonarcloud-github-action@v2
-  #        with:
-  #          projectBaseDir: ./smart-rent
-  #          args: >
-  #            -Dsonar.projectKey=${{ secrets.SONAR_PROJECT_KEY }}
-  #            -Dsonar.organization=${{ secrets.SONAR_ORG }}
-  #            -Dsonar.host.url=https://sonarcloud.io
-  #            -Dsonar.java.binaries=build/classes
-  #            -Dsonar.coverage.jacoco.xmlReportPaths=build/reports/jacoco/test/jacocoTestReport.xml
-  #        env:
-  #          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-
-  build-and-push:
-    runs-on: ubuntu-latest
-    needs: unit-test
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    defaults:
-      run:
-        working-directory: ./smart-rent
-    steps:
-    - name: Checkout Repository
-      uses: actions/checkout@v4
-
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
-
-    - name: Log in to Docker Hub
-      uses: docker/login-action@v3
-      with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-    - name: Build and push Docker image
-      uses: docker/build-push-action@v5
-      with:
-        context: ./smart-rent
-        file: ./smart-rent/Dockerfile
-        push: true
-        tags: |
-          vuhuydiet/smartrent-backend:${{ github.sha }}
-          vuhuydiet/smartrent-backend:dev
-        cache-from: type=gha
-        cache-to: type=gha,mode=max
-
-  update-dev-deployment:
-    runs-on: ubuntu-latest
-    needs: build-and-push
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    steps:
-      - name: Checkout Deployment Repository
-        uses: actions/checkout@v4
-        with:
-          repository: 'Vuhuydiet/smartrent-deploy'
-          token: ${{ secrets.DEPLOY_REPO_TOKEN }}
-          path: 'smartrent-deploy'
-
-      - name: Update backend image tag
-        run: |
-          sed -i 's/^BACKEND_TAG=.*/BACKEND_TAG=${{ github.sha }}/' smartrent-deploy/docker/tags.env
-
-      - name: Commit and push changes
-        working-directory: smartrent-deploy
-        env:
-            COMMIT_MSG: ${{ github.event.head_commit.message }}
-        run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
-          git add docker/tags.env
-          
-          if git diff --staged --quiet; then
-            echo "No changes to commit"
-            exit 0
-          fi
-      
-          COMMIT_LINK="https://github.com/${{ github.repository }}/commit/${{ github.sha }}"
-          printf "Deploy: %s\n\n(%s)" "$COMMIT_MSG" "$COMMIT_LINK" > .commit_msg
-          
-          git commit -F .commit_msg
-          git push
-
-  deploy:
-    runs-on: ubuntu-latest
-    needs: update-dev-deployment
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    steps:
-      - name: Deploy to Droplet
-        uses: appleboy/ssh-action@v1
-        with:
-          host: ${{ secrets.DROPLET_HOST }}
-          username: ${{ secrets.DROPLET_USER }}
-          key: ${{ secrets.DROPLET_SSH_KEY }}
-          script: |
-            cd ~/smartrent-deploy
-            git fetch origin main
-            git reset --hard origin/main
-            docker compose \
-              --env-file docker/.env \
-              --env-file docker/tags.env \
-              -f docker/docker-compose.yml \
-              pull backend
-            docker compose \
-              --env-file docker/.env \
-              --env-file docker/tags.env \
-              -f docker/docker-compose.yml \
-              up -d --no-deps backend
-
-            # ---- Image retention (best-effort, never fails the deploy) ----
-            # Without this the Droplet accumulates one ~686MB image per push
-            # because each build is tagged with the commit SHA and never
-            # overwritten. `docker rmi` on the currently-running image fails
-            # with "image is being used" — that's the safety net.
-            set +e
-            REPO="vuhuydiet/smartrent-backend"
-            KEEP=5
-            docker container prune -f
-            docker images "$REPO" --format '{{.Tag}} {{.CreatedAt}}' \
-              | grep -Ev '^(dev|prd|prod|main|latest) ' \
-              | grep -v '^<none>' \
-              | sort -k2,2 -r \
-              | tail -n +$((KEEP + 1)) \
-              | awk '{print $1}' \
-              | while read -r tag; do
-                  docker rmi "${REPO}:${tag}" 2>/dev/null || true
-                done
-            docker image prune -f
-            docker builder prune -f --keep-storage 2GB
-            docker system df

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,53 @@
+name: CD
+
+# Continuous Deployment — runs only after code is merged to main.
+# Builds + pushes the image to DockerHub, then triggers a Dokploy redeploy via
+# its per-app deploy webhook (Dokploy pulls the new image and recreates the
+# container). No SSH, no tags.env bump — Dokploy owns the deploy.
+#
+# Gating: merges to main go through PRs and CI (CI.yml) is a required check,
+# so code here has already built + passed tests.
+#
+# Required secrets:
+#   DOCKERHUB_USERNAME, DOCKERHUB_TOKEN  — push image
+#   DOKPLOY_BACKEND_WEBHOOK              — Dokploy deploy webhook for the `backend` app
+#                                          (https://deploy.thuenhatro.net/api/deploy/<token>)
+
+on:
+  push:
+    branches: [ "main" ]
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v4
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Log in to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v5
+      with:
+        context: ./smart-rent
+        file: ./smart-rent/Dockerfile
+        push: true
+        # The Dokploy `backend` app pulls `:dev`; keep that tag moving + a
+        # unique SHA tag for traceability/rollback.
+        tags: |
+          vuhuydiet/smartrent-backend:${{ github.sha }}
+          vuhuydiet/smartrent-backend:dev
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+
+    - name: Trigger Dokploy redeploy
+      run: |
+        curl -fsSL -X POST "${{ secrets.DOKPLOY_BACKEND_WEBHOOK }}"
+        echo "Dokploy redeploy triggered for backend."


### PR DESCRIPTION
- CI.yml (CI): Gradle build + unit tests on PR only — the merge gate.
- cd.yml (CD): on push to main → build + push image to DockerHub → trigger Dokploy redeploy webhook. Dokploy pulls the new :dev image and recreates the container.
- Removes the old SSH-to-droplet deploy + tags.env bump (pointed at the retired droplet). CI and CD are now separate workflows.

New secret required: DOKPLOY_BACKEND_WEBHOOK. No longer needs DROPLET_HOST/ USER/SSH_KEY or DEPLOY_REPO_TOKEN.