### PR TITLE
fix(security): close 4 critical authz/IDOR holes from cross-repo audit

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/controller/AdminController.java
+++ b/smart-rent/src/main/java/com/smartrent/controller/AdminController.java
@@ -23,6 +23,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
@@ -31,11 +32,16 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 @FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
 @Tag(name = "Admin Management", description = "APIs for managing administrator accounts and profiles")
+// Admin account management is staff-only. Listing/reading admins needs any
+// admin role; creating/updating/deleting admins is restricted to Super Admin
+// per-method below.
+@PreAuthorize("hasAnyAuthority('ROLE_SA', 'ROLE_UA', 'ROLE_SPA')")
 public class AdminController {
 
   AdminService adminService;
 
   @PostMapping
+  @PreAuthorize("hasAuthority('ROLE_SA')")
   @Operation(summary = "Create a new admin account", description = "Creates a new administrator account with the provided information and assigned roles. Only existing admins with appropriate permissions can create new admin accounts.", security = @SecurityRequirement(name = "Bearer Authentication"), requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "Admin creation details including roles", required = true, content = @Content(mediaType = "application/json", schema = @Schema(implementation = AdminCreationRequest.class), examples = @ExampleObject(name = "Admin Creation Example", value = """
       {
         "phoneCode": "+1",
@@ -179,6 +185,7 @@ public class AdminController {
   }
 
   @PutMapping("/{adminId}")
+  @PreAuthorize("hasAuthority('ROLE_SA')")
   @Operation(summary = "Update admin", description = "Updates an existing administrator's information", security = @SecurityRequirement(name = "Bearer Authentication"))
   @ApiResponses(value = {
       @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Admin updated successfully", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiResponse.class), examples = @ExampleObject(name = "Success Response", value = """
@@ -214,6 +221,7 @@ public class AdminController {
   }
 
   @DeleteMapping("/{adminId}")
+  @PreAuthorize("hasAuthority('ROLE_SA')")
   @ResponseStatus(HttpStatus.NO_CONTENT)
   @Operation(summary = "Delete admin", description = "Deletes an administrator from the system", security = @SecurityRequirement(name = "Bearer Authentication"))
   @ApiResponses(value = {

--- a/smart-rent/src/main/java/com/smartrent/controller/UserController.java
+++ b/smart-rent/src/main/java/com/smartrent/controller/UserController.java
@@ -23,6 +23,7 @@ import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
@@ -339,6 +340,7 @@ public class UserController {
         }
 
         @PutMapping("/{userId}")
+        @PreAuthorize("hasAnyAuthority('ROLE_SA', 'ROLE_UA', 'ROLE_SPA')")
         @Operation(summary = "Update user (Admin operation)", description = "Updates an existing user's information. This is an admin operation.", security = @SecurityRequirement(name = "Bearer Authentication"))
         @ApiResponses(value = {
                         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "User updated successfully", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiResponse.class), examples = @ExampleObject(name = "Success Response", value = """
@@ -385,6 +387,7 @@ public class UserController {
         }
 
         @DeleteMapping("/{userId}")
+        @PreAuthorize("hasAnyAuthority('ROLE_SA', 'ROLE_UA', 'ROLE_SPA')")
         @ResponseStatus(HttpStatus.NO_CONTENT)
         @Operation(summary = "Delete user (Admin operation)", description = "Deletes a user from the system. This is an admin operation.", security = @SecurityRequirement(name = "Bearer Authentication"))
         @ApiResponses(value = {

--- a/smart-rent/src/main/java/com/smartrent/service/pricing/impl/PricingHistoryServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/pricing/impl/PricingHistoryServiceImpl.java
@@ -3,6 +3,8 @@ package com.smartrent.service.pricing.impl;
 import com.smartrent.dto.request.PriceUpdateRequest;
 import com.smartrent.dto.response.PageResponse;
 import com.smartrent.dto.response.PricingHistoryResponse;
+import com.smartrent.infra.exception.AppException;
+import com.smartrent.infra.exception.model.DomainCode;
 import com.smartrent.infra.repository.ListingRepository;
 import com.smartrent.infra.repository.PricingHistoryRepository;
 import com.smartrent.infra.repository.entity.Listing;
@@ -133,6 +135,13 @@ public class PricingHistoryServiceImpl implements PricingHistoryService {
 
         Listing listing = listingRepository.findById(listingId)
                 .orElseThrow(() -> new RuntimeException("Listing not found with id: " + listingId));
+
+        // Ownership guard: only the listing owner may change its price. The AI
+        // update_listing_price tool relies on the backend enforcing this (it
+        // maps a 403 to "Bạn không có quyền sửa tin này").
+        if (!listing.getUserId().equals(changedBy)) {
+            throw new AppException(DomainCode.UNAUTHORIZED);
+        }
 
         // Get current price
         PricingHistory currentPricing = pricingHistoryRepository.findByListingListingIdAndIsCurrentTrue(listingId)

--- a/smart-rent/src/main/resources/application.yml
+++ b/smart-rent/src/main/resources/application.yml
@@ -215,7 +215,6 @@ application:
         - "/v1/auth/**"
         - "/v1/payments/webhook/**"
         - "/v1/users"
-        - "/v1/admins"
         - "/v1/verification/**"
         - "/otp/**"
         - "/v1/listings/*/reports"


### PR DESCRIPTION
- #1 Price IDOR: PricingHistoryServiceImpl.updatePrice now verifies the caller owns the listing (listing.userId == changedBy) and throws UNAUTHORIZED otherwise. The AI update_listing_price tool already maps 403 → "không có quyền", so this makes its ownership story real.
- #7 Public admin creation: remove "/v1/admins" from the public POST allowlist + require @PreAuthorize hasAuthority('ROLE_SA') on createAdmin (previously anyone could create a Super Admin unauthenticated).
- #8 Admin management authz: class-level @PreAuthorize on AdminController (ROLE_SA/UA/SPA); create/update/delete admin restricted to ROLE_SA (previously any logged-in ROLE_USER could list/escalate/delete admins).
- #9 User CRUD IDOR: @PreAuthorize ROLE_SA/UA/SPA on PUT/DELETE /v1/users/{userId} (the "Admin operation" endpoints had no auth check — any user could edit/delete any account).

Compiles clean (gradlew compileJava). Self-service profile edits stay on the JWT-scoped /v1/users/profile + /contact-phone endpoints (unchanged).