### PR TITLE
feat(listings): batch VIP-tier carousels behind POST /search/sections

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/config/OpenAPIConfig.java
+++ b/smart-rent/src/main/java/com/smartrent/config/OpenAPIConfig.java
@@ -579,6 +579,7 @@ public class OpenAPIConfig {
                             .packagesToScan(packageToScan)
                             .pathsToMatch(
                                             "/v1/listings/search",
+                                            "/v1/listings/search/sections",
                                             "/v1/listings/autocomplete",
                                             "/v1/listings/map-bounds",
                                             "/v1/listings/search-suggestions",

--- a/smart-rent/src/main/java/com/smartrent/controller/ListingSearchController.java
+++ b/smart-rent/src/main/java/com/smartrent/controller/ListingSearchController.java
@@ -1,9 +1,11 @@
 package com.smartrent.controller;
 
 import com.smartrent.dto.request.ListingFilterRequest;
+import com.smartrent.dto.request.ListingSectionsRequest;
 import com.smartrent.dto.request.MapBoundsRequest;
 import com.smartrent.dto.response.ListingCardListResponse;
 import com.smartrent.dto.response.*;
+import com.smartrent.service.listing.ListingSectionsService;
 import com.smartrent.service.listing.ListingService;
 import com.smartrent.service.discovery.SearchSuggestionService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -40,6 +42,7 @@ import java.util.List;
 public class ListingSearchController {
 
     private final ListingService listingService;
+    private final ListingSectionsService listingSectionsService;
     private final SearchSuggestionService searchSuggestionService;
 
     @PostMapping("/search")
@@ -170,6 +173,29 @@ public class ListingSearchController {
 
         ListingCardListResponse response = listingService.searchListings(filter);
         return ApiResponse.<ListingCardListResponse>builder().data(response).build();
+    }
+
+    @PostMapping("/search/sections")
+    @Operation(
+        summary = "[PUBLIC API] Lấy nhiều carousel VIP tier trong một lần gọi (homepage)",
+        description = """
+            **PUBLIC API - Không cần authentication**
+
+            Gộp nhiều section theo VIP tier (DIAMOND / GOLD / SILVER / NORMAL) vào MỘT request,
+            thay cho việc gọi `POST /search` riêng cho từng tier ở màn hình chính.
+
+            - `verified`, `page`, `size`: dùng chung cho mọi section (section có thể override `size`).
+            - Mỗi `sections[]` gồm `vipType` và `sortBy` (tùy chọn, ví dụ `NEWEST`).
+            - Mỗi section chạy qua đúng pipeline `searchListings` (cùng cache, cùng thứ tự ưu tiên
+              tin đẩy), nên kết quả giống hệt khi gọi `/search` cho từng tier — chỉ khác là 1 round-trip.
+
+            Không nhận tọa độ GPS: carousel theo tier không xếp hạng theo khoảng cách.
+            """
+    )
+    public ApiResponse<ListingSectionsResponse> searchListingSections(
+            @RequestBody(required = false) ListingSectionsRequest request) {
+        ListingSectionsResponse response = listingSectionsService.searchSections(request);
+        return ApiResponse.<ListingSectionsResponse>builder().data(response).build();
     }
 
     @GetMapping("/sellers/{userId}/diamond")

--- a/smart-rent/src/main/java/com/smartrent/dto/request/ListingSectionsRequest.java
+++ b/smart-rent/src/main/java/com/smartrent/dto/request/ListingSectionsRequest.java
@@ -1,0 +1,64 @@
+package com.smartrent.dto.request;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.FieldDefaults;
+
+import java.util.List;
+
+/**
+ * Request for {@code POST /v1/listings/search/sections} — fetch several VIP-tier
+ * carousels (DIAMOND / GOLD / SILVER / NORMAL) in a single round-trip instead of
+ * one {@code POST /search} per tier.
+ *
+ * <p>{@code verified}, {@code page} and {@code size} are shared defaults applied
+ * to every section; a section may override {@code size} and add a {@code sortBy}.
+ * Each section maps 1:1 onto an ordinary {@link ListingFilterRequest} and runs
+ * through the very same {@code searchListings} path (and cache), so the promoted
+ * ("đẩy tin") ordering is byte-identical to the per-tier calls it replaces.
+ *
+ * <p>Geo coordinates are intentionally absent: tier carousels are not ranked by
+ * distance, so sending user coordinates only fragmented the cache for no effect.
+ */
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class ListingSectionsRequest {
+
+    /** Applied to every section (homepage sends {@code true} to show verified tins only). */
+    Boolean verified;
+
+    /** 1-based page shared by every section (defaults to 1 when null/invalid). */
+    Integer page;
+
+    /** Default page size shared by every section (defaults to 10 when null/invalid). */
+    Integer size;
+
+    /** Ordered tier sections to fetch. */
+    List<Section> sections;
+
+    @Getter
+    @Setter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @FieldDefaults(level = AccessLevel.PRIVATE)
+    public static class Section {
+
+        /** NORMAL / SILVER / GOLD / DIAMOND. */
+        String vipType;
+
+        /** Optional sort override (e.g. {@code NEWEST}); null keeps the default VIP-tier sort. */
+        String sortBy;
+
+        /** Optional per-section size override; falls back to the shared size when null. */
+        Integer size;
+    }
+}

--- a/smart-rent/src/main/java/com/smartrent/dto/response/ListingSectionsResponse.java
+++ b/smart-rent/src/main/java/com/smartrent/dto/response/ListingSectionsResponse.java
@@ -1,0 +1,41 @@
+package com.smartrent.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.FieldDefaults;
+
+import java.util.List;
+
+/**
+ * Response for {@code POST /v1/listings/search/sections}.
+ * One {@link SectionResult} per requested tier, in request order. Each result is
+ * a plain {@link ListingCardListResponse}, identical to what {@code POST /search}
+ * returns for that tier — so the frontend mapping is unchanged.
+ */
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class ListingSectionsResponse {
+
+    List<SectionResult> sections;
+
+    @Getter
+    @Setter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @FieldDefaults(level = AccessLevel.PRIVATE)
+    public static class SectionResult {
+
+        String vipType;
+        String sortBy;
+        ListingCardListResponse result;
+    }
+}

--- a/smart-rent/src/main/java/com/smartrent/infra/repository/entity/Listing.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/entity/Listing.java
@@ -36,7 +36,9 @@ import java.util.List;
                 @Index(name = "idx_listings_public_price_sort",
                         columnList = "moderation_status, is_shadow, is_draft, expired, price"),
                 @Index(name = "idx_listings_product_type", columnList = "product_type, listing_type"),
-                @Index(name = "idx_listings_user_vip_updated", columnList = "user_id, vip_type, updated_at")
+                @Index(name = "idx_listings_user_vip_updated", columnList = "user_id, vip_type, updated_at"),
+                // Public homepage VIP-tier carousels (POST /v1/listings/search/sections) — see V91.
+                @Index(name = "idx_listings_public_vip_tier", columnList = "vip_type, verified, is_draft, is_shadow, updated_at")
         })
 @Getter
 @Setter

--- a/smart-rent/src/main/java/com/smartrent/service/listing/ListingSectionsService.java
+++ b/smart-rent/src/main/java/com/smartrent/service/listing/ListingSectionsService.java
@@ -1,0 +1,107 @@
+package com.smartrent.service.listing;
+
+import com.smartrent.dto.request.ListingFilterRequest;
+import com.smartrent.dto.request.ListingSectionsRequest;
+import com.smartrent.dto.response.ListingCardListResponse;
+import com.smartrent.dto.response.ListingSectionsResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Fans a single {@code POST /v1/listings/search/sections} request out into one
+ * {@code searchListings} call per VIP tier, collapsing what used to be four
+ * separate homepage round-trips into one.
+ *
+ * <p><b>Why delegate to {@link ListingService} (the bean) rather than inline the
+ * query:</b> {@code searchListings} is {@code @Cacheable}, and Spring's cache
+ * advice lives on the proxy. Calling it through the injected interface reference
+ * goes through that proxy, so every tier still hits the listing-search cache and
+ * runs the <i>exact</i> same specification + sort — the promoted ("đẩy tin")
+ * ordering is preserved bit-for-bit. (Inlining, or a self-invocation inside
+ * {@code ListingServiceImpl}, would silently bypass the cache.)
+ *
+ * <p>Each tier is isolated in its own try/catch so one failing tier degrades to
+ * an empty carousel instead of blanking the whole homepage — mirroring the old
+ * setup where each tier was an independent request.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ListingSectionsService {
+
+    private static final int DEFAULT_SIZE = 10;
+    private static final int MAX_SIZE = 100;
+
+    private final ListingService listingService;
+
+    public ListingSectionsResponse searchSections(ListingSectionsRequest request) {
+        List<ListingSectionsRequest.Section> sections =
+                request != null && request.getSections() != null
+                        ? request.getSections()
+                        : Collections.emptyList();
+
+        Boolean verified = request != null ? request.getVerified() : null;
+        int page = request != null && request.getPage() != null && request.getPage() > 0
+                ? request.getPage()
+                : 1;
+        int defaultSize = clampSize(request != null ? request.getSize() : null);
+
+        List<ListingSectionsResponse.SectionResult> results = new ArrayList<>(sections.size());
+        for (ListingSectionsRequest.Section section : sections) {
+            if (section == null || section.getVipType() == null || section.getVipType().isBlank()) {
+                continue;
+            }
+            int size = section.getSize() != null && section.getSize() > 0
+                    ? clampSize(section.getSize())
+                    : defaultSize;
+
+            // Built to be identical to the per-tier POST /search call it replaces.
+            ListingFilterRequest filter = ListingFilterRequest.builder()
+                    .vipType(section.getVipType())
+                    .verified(verified)
+                    .page(page)
+                    .size(size)
+                    .sortBy(section.getSortBy())
+                    .build();
+
+            ListingCardListResponse result;
+            try {
+                result = listingService.searchListings(filter);
+            } catch (Exception e) {
+                log.warn("Section search failed (vipType={}, sortBy={}): {}",
+                        section.getVipType(), section.getSortBy(), e.getMessage());
+                result = emptyResult(page, size);
+            }
+
+            results.add(ListingSectionsResponse.SectionResult.builder()
+                    .vipType(section.getVipType())
+                    .sortBy(section.getSortBy())
+                    .result(result)
+                    .build());
+        }
+
+        return ListingSectionsResponse.builder().sections(results).build();
+    }
+
+    private static int clampSize(Integer size) {
+        if (size == null || size <= 0) {
+            return DEFAULT_SIZE;
+        }
+        return Math.min(size, MAX_SIZE);
+    }
+
+    private static ListingCardListResponse emptyResult(int page, int size) {
+        return ListingCardListResponse.builder()
+                .listings(Collections.emptyList())
+                .totalCount(0L)
+                .currentPage(page)
+                .pageSize(size)
+                .totalPages(0)
+                .build();
+    }
+}

--- a/smart-rent/src/main/java/com/smartrent/util/CacheKeyBuilder.java
+++ b/smart-rent/src/main/java/com/smartrent/util/CacheKeyBuilder.java
@@ -39,9 +39,14 @@ public final class CacheKeyBuilder {
         append(sb, "isLegacy", filter.getIsLegacy());
         append(sb, "latitude", filter.getLatitude());
         append(sb, "longitude", filter.getLongitude());
-        append(sb, "userLatitude", filter.getUserLatitude());
-        append(sb, "userLongitude", filter.getUserLongitude());
-        append(sb, "radiusKm", filter.getRadiusKm());
+        // NOTE: userLatitude/userLongitude/radiusKm are intentionally NOT part of
+        // the key. The search query (ListingSpecification + sort) ignores them
+        // entirely — two requests differing only in user coordinates produce an
+        // identical result — so including them only multiplied the key space by
+        // every distinct GPS fix and drove the cache hit-rate to ~0 (each user,
+        // and each GPS jitter, minted a brand-new key for the same result).
+        // If geo-proximity ranking is ever implemented, re-add these AND bucket
+        // the coordinates (e.g. round to ~2 decimals) so the cache still groups.
 
         append(sb, "categoryId", filter.getCategoryId());
         append(sb, "listingType", filter.getListingType());

--- a/smart-rent/src/main/resources/application-local.yaml
+++ b/smart-rent/src/main/resources/application-local.yaml
@@ -70,6 +70,7 @@ application:
         - "/v1/listings/*/reports"
         - "/v1/ai/listings/**"
         - "/v1/listings/search"
+        - "/v1/listings/search/sections"
         - "/v1/listings/map-bounds"
 # Enable debug logging for authentication
 logging:

--- a/smart-rent/src/main/resources/application.yml
+++ b/smart-rent/src/main/resources/application.yml
@@ -220,6 +220,7 @@ application:
         - "/otp/**"
         - "/v1/listings/*/reports"
         - "/v1/listings/search"
+        - "/v1/listings/search/sections"
         - "/api/v1/advanced-search"
         - "/v1/listings/stats/provinces"
         - "/v1/listings/stats/categories"

--- a/smart-rent/src/main/resources/db/migration/V91__Public_vip_tier_carousel_index.sql
+++ b/smart-rent/src/main/resources/db/migration/V91__Public_vip_tier_carousel_index.sql
@@ -1,0 +1,50 @@
+-- Migration V91: Public VIP-tier carousel index — the homepage analog of V84
+-- ============================================================================
+-- The homepage fires one query per VIP tier (DIAMOND / GOLD / SILVER / NORMAL),
+-- now batched behind POST /v1/listings/search/sections. Each section runs the
+-- ordinary ListingSpecification.fromFilterRequest path with verified=true and a
+-- pinned vip_type, producing this shape:
+--
+--     WHERE vip_type = ? AND verified = true
+--           AND is_draft = false AND is_shadow = false
+--     ORDER BY vip_type_sort_order ASC, updated_at DESC
+--     LIMIT 10
+--
+-- (No moderation_status predicate: the FE sends verified=true, so the spec gates
+-- on `verified` and the moderation_status=APPROVED branch is NOT taken. No
+-- expired predicate either — the homepage doesn't send expired/excludeExpired.)
+--
+-- vip_type is pinned by the section, so vip_type_sort_order is constant
+-- post-filter → effective sort is `updated_at DESC` (same reasoning as V84).
+--
+-- Why current indexes don't seek this cleanly:
+--   • V84 idx_listings_user_vip_updated (user_id, vip_type, updated_at)
+--     — that's the SELLER analog; it leads with user_id, which is null here.
+--   • V82 idx_listings_public_default_sort
+--     (moderation_status, is_shadow, is_draft, expired, vip_type_sort_order,
+--      updated_at) — leads with moderation_status, which is NOT a predicate on
+--     the verified=true path → planner can't use it for this query.
+--   • idx_status (verified, expired, vip_type) — `expired` sits between the two
+--     usable equalities (and isn't constrained here), and it carries no sort
+--     column → equality seek on `verified` only, then filesort on the tier sort.
+--
+-- This index leads with the selective vip_type, matches the three boolean
+-- equalities, then exposes updated_at for an ordered LIMIT 10 with no filesort.
+--
+-- NOTE: modelled on V84's proven shape but NOT yet EXPLAIN-validated on prod
+-- data — validate with EXPLAIN on the 100k-row DB before relying on the numbers,
+-- as V81-V84 did.
+--
+-- Idempotent via information_schema check, matching V78-V84 style.
+-- ============================================================================
+
+SET @idx_exists = (SELECT COUNT(*) FROM information_schema.statistics
+                   WHERE table_schema = DATABASE()
+                     AND table_name = 'listings'
+                     AND index_name = 'idx_listings_public_vip_tier');
+SET @sql = IF(@idx_exists = 0,
+    'CREATE INDEX idx_listings_public_vip_tier ON listings (vip_type, verified, is_draft, is_shadow, updated_at)',
+    'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;


### PR DESCRIPTION
The homepage fetched DIAMOND/GOLD/SILVER/NORMAL tiers via four separate POST /v1/listings/search calls. Add one endpoint that fans out to the same searchListings pipeline (one call per tier, through the cache + specification), so the promoted-listing ordering is byte-identical while collapsing four round-trips into one. Each tier is isolated so one failing tier can't blank the homepage.

Also drop user coordinates from the listing-search cache key: the query never used them for filtering or sorting, so they only fragmented the cache to a near-0% hit rate (every distinct GPS fix minted a new key for the same result).

- ListingSectionsService orchestration + POST /v1/listings/search/sections
- permit the new public endpoint in security config (yml + local) and swagger group
- V91 + entity index idx_listings_public_vip_tier: dedicated index for the verified=true per-tier query, which previously had no covering index (filesort)