### PR TITLE
perf(listings): dedicated GET /homepage-tier — no paging, no COUNT

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/controller/ListingSearchController.java
+++ b/smart-rent/src/main/java/com/smartrent/controller/ListingSearchController.java
@@ -172,6 +172,28 @@ public class ListingSearchController {
         return ApiResponse.<ListingCardListResponse>builder().data(response).build();
     }
 
+    @GetMapping("/homepage-tier")
+    @Operation(
+        summary = "[PUBLIC API] Top listings of one VIP tier for homepage carousels",
+        description = """
+            **PUBLIC API - Không cần authentication**
+
+            Lấy nhanh `limit` tin mới nhất của MỘT tier VIP (DIAMOND/GOLD/SILVER/NORMAL)
+            cho carousel ở màn hình chính. Khác với `POST /search`: endpoint này KHÔNG
+            phân trang và KHÔNG đếm tổng (no COUNT) — chỉ trả top N — nên nhanh kể cả với
+            tier NORMAL (tin "Tin mới") vốn rất lớn. Frontend gọi 1 lần cho mỗi tier.
+
+            Sắp xếp: trong cùng tier là mới nhất trước (updatedAt DESC). Chỉ tin đã verify,
+            không nháp, không shadow. Không nhận tọa độ (không xếp theo khoảng cách).
+            """
+    )
+    public ApiResponse<List<ListingCardResponse>> getHomepageTier(
+            @RequestParam("vipType") String vipType,
+            @RequestParam(value = "limit", defaultValue = "10") int limit) {
+        List<ListingCardResponse> listings = listingService.getHomepageTierListings(vipType, limit);
+        return ApiResponse.<List<ListingCardResponse>>builder().data(listings).build();
+    }
+
     @GetMapping("/sellers/{userId}/diamond")
     @Operation(
         summary = "[PUBLIC API] Seller DIAMOND listings",

--- a/smart-rent/src/main/java/com/smartrent/infra/repository/ListingRepository.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/ListingRepository.java
@@ -93,6 +93,30 @@ public interface ListingRepository extends JpaRepository<Listing, Long>, JpaSpec
     List<Listing> findByIdsWithMedia(@Param("ids") Collection<Long> ids);
 
     /**
+     * Homepage VIP-tier carousel: the latest {@code N} verified, non-draft,
+     * non-shadow listings of one tier. Returns a plain {@code List} (not a
+     * {@code Page}) so Spring Data does NOT run a COUNT(*) — the carousel only
+     * needs the top N, and counting the whole tier (huge for NORMAL) was the
+     * main cost of reusing the paginated search. {@code Pageable} supplies only
+     * the LIMIT. Backed by idx_listings_public_vip_tier (no filesort).
+     *
+     * <p>address is to-one, so JOIN FETCH + LIMIT is safe (no in-memory paging).
+     *
+     * <p>PUSH ("đẩy tin") is preserved: this is the SAME filter + ORDER BY as the
+     * public search's homepage path (ListingSpecification.fromFilterRequest with
+     * verified=true, ordered by vipTypeSortOrder ASC then updatedAt DESC).
+     * Pushing a listing bumps updated_at (PushServiceImpl saves the row, and
+     * updatedAt is @UpdateTimestamp; it also stamps pushed_at/post_date), so a
+     * pushed listing rises to the top of `updatedAt DESC` exactly as before.
+     * Do NOT change this ORDER BY without also re-checking the push behaviour.
+     */
+    @Query("SELECT l FROM listings l LEFT JOIN FETCH l.address " +
+           "WHERE l.vipType = :vipType AND l.verified = true " +
+           "AND l.isDraft = false AND l.isShadow = false " +
+           "ORDER BY l.vipTypeSortOrder ASC, l.updatedAt DESC")
+    List<Listing> findHomepageTier(@Param("vipType") Listing.VipType vipType, Pageable pageable);
+
+    /**
      * Find listings by ward ID for location-based pricing
      */
     @Query("""

--- a/smart-rent/src/main/java/com/smartrent/service/listing/ListingService.java
+++ b/smart-rent/src/main/java/com/smartrent/service/listing/ListingService.java
@@ -85,6 +85,19 @@ public interface ListingService {
     ListingCardListResponse searchListings(ListingFilterRequest filter);
 
     /**
+     * Homepage carousel data source: the latest {@code limit} verified,
+     * non-draft, non-shadow listings of a single VIP tier. No pagination and no
+     * total count — the carousel only needs the top N, so this avoids the
+     * COUNT(*) that {@link #searchListings} runs over the (potentially huge)
+     * tier. Cached and coordinate-free, so it is shared across all users.
+     *
+     * @param vipType NORMAL / SILVER / GOLD / DIAMOND (invalid → empty list)
+     * @param limit   max items to return (clamped)
+     * @return up to {@code limit} card DTOs, newest first within the tier
+     */
+    List<com.smartrent.dto.response.ListingCardResponse> getHomepageTierListings(String vipType, int limit);
+
+    /**
      * Public endpoint data source: get top saved listings for a specific seller.
      * Sorted by number of saves descending.
      *

--- a/smart-rent/src/main/java/com/smartrent/service/listing/impl/ListingServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/listing/impl/ListingServiceImpl.java
@@ -1336,6 +1336,28 @@ public class ListingServiceImpl implements ListingService {
                 .build();
     }
 
+    @Override
+    @Transactional(readOnly = true)
+    @Cacheable(cacheNames = com.smartrent.config.Constants.CacheNames.LISTING_SEARCH,
+            key = "'homepage-tier:' + #vipType + ':' + #limit")
+    public List<ListingCardResponse> getHomepageTierListings(String vipType, int limit) {
+        Listing.VipType tier;
+        try {
+            tier = Listing.VipType.valueOf(vipType);
+        } catch (IllegalArgumentException | NullPointerException e) {
+            log.warn("getHomepageTierListings: invalid vipType '{}'", vipType);
+            return Collections.emptyList();
+        }
+        int safeLimit = Math.min(Math.max(limit, 1), 50);
+
+        // List (not Page) → no COUNT(*). idx_listings_public_vip_tier serves the
+        // WHERE + ORDER BY, so this is a 10-row index read regardless of tier size.
+        List<Listing> listings = listingRepository.findHomepageTier(
+                tier, org.springframework.data.domain.PageRequest.of(0, safeLimit));
+
+        return batchMapCardListings(listings);
+    }
+
             @Override
             @Transactional(readOnly = true)
             public ListingCardListResponse getTopSavedListingsByUser(String userId, int limit) {


### PR DESCRIPTION
The homepage carousels reused POST /search, which returns a Page and therefore runs COUNT(*) over the whole tier. For NORMAL ('Tin mới') — the bulk of all listings — that count dominated and made the section very slow.

Add GET /v1/listings/homepage-tier returning just the top N of one tier as a plain List (no pagination, no count). Public via the existing GET /v1/listings/** rule. Uses idx_listings_public_vip_tier (V92) so it's an index read, no filesort.

Push is preserved: same filter + ORDER BY vipTypeSortOrder ASC, updatedAt DESC as the old search path. Pushing bumps updated_at (PushServiceImpl save + @UpdateTimestamp; also stamps pushed_at/post_date), so pushed listings still rise to the top.