### PR TITLE
perf(listings): homepage-tier orders by updated_at only — kill the fi…

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/infra/repository/ListingRepository.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/ListingRepository.java
@@ -102,18 +102,24 @@ public interface ListingRepository extends JpaRepository<Listing, Long>, JpaSpec
      *
      * <p>address is to-one, so JOIN FETCH + LIMIT is safe (no in-memory paging).
      *
-     * <p>PUSH ("đẩy tin") is preserved: this is the SAME filter + ORDER BY as the
-     * public search's homepage path (ListingSpecification.fromFilterRequest with
-     * verified=true, ordered by vipTypeSortOrder ASC then updatedAt DESC).
-     * Pushing a listing bumps updated_at (PushServiceImpl saves the row, and
-     * updatedAt is @UpdateTimestamp; it also stamps pushed_at/post_date), so a
-     * pushed listing rises to the top of `updatedAt DESC` exactly as before.
-     * Do NOT change this ORDER BY without also re-checking the push behaviour.
+     * <p>ORDER BY is just {@code updatedAt DESC}: vipType is pinned to a single
+     * value, so vip_type_sort_order is constant across the whole result set and
+     * adding it to the sort is redundant. Dropping it lets idx_listings_public_vip_tier
+     * — which ends in a plain (ascending) updated_at — satisfy the order with a
+     * backward index scan on EVERY MySQL version (no dependency on a descending
+     * index, no filesort), which is the difference between a 10-row read and
+     * sorting the entire (huge) NORMAL tier.
+     *
+     * <p>PUSH ("đẩy tin") is preserved: pushing bumps updated_at (PushServiceImpl
+     * saves the row, updatedAt is @UpdateTimestamp; it also stamps pushed_at/
+     * post_date), so a pushed listing rises to the top of {@code updatedAt DESC}
+     * exactly as on the old search path. This is the same effective order the
+     * homepage search produced (its vipTypeSortOrder key is constant per tier).
      */
     @Query("SELECT l FROM listings l LEFT JOIN FETCH l.address " +
            "WHERE l.vipType = :vipType AND l.verified = true " +
            "AND l.isDraft = false AND l.isShadow = false " +
-           "ORDER BY l.vipTypeSortOrder ASC, l.updatedAt DESC")
+           "ORDER BY l.updatedAt DESC")
     List<Listing> findHomepageTier(@Param("vipType") Listing.VipType vipType, Pageable pageable);
 
     /**

--- a/smart-rent/src/main/java/com/smartrent/infra/repository/entity/Listing.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/entity/Listing.java
@@ -37,10 +37,10 @@ import java.util.List;
                         columnList = "moderation_status, is_shadow, is_draft, expired, price"),
                 @Index(name = "idx_listings_product_type", columnList = "product_type, listing_type"),
                 @Index(name = "idx_listings_user_vip_updated", columnList = "user_id, vip_type, updated_at"),
-                // Public homepage VIP-tier carousels (one POST /v1/listings/search per tier) — see V91/V92.
-                // Includes vip_type_sort_order before updated_at so ORDER BY (vip_type_sort_order, updated_at)
-                // is served by the index — no filesort. (Direction is set in V92; @Index can't express DESC.)
-                @Index(name = "idx_listings_public_vip_tier", columnList = "vip_type, verified, is_draft, is_shadow, vip_type_sort_order, updated_at")
+                // Public homepage VIP-tier carousels (GET /v1/listings/homepage-tier, one tier at a time) — see V91-V93.
+                // Single-tier query orders by updated_at DESC only (vip_type pinned ⇒ vip_type_sort_order constant),
+                // so a plain trailing updated_at serves it via backward index scan on any MySQL version — no filesort.
+                @Index(name = "idx_listings_public_vip_tier", columnList = "vip_type, verified, is_draft, is_shadow, updated_at")
         })
 @Getter
 @Setter

--- a/smart-rent/src/main/resources/db/migration/V93__Public_vip_tier_index_simplify.sql
+++ b/smart-rent/src/main/resources/db/migration/V93__Public_vip_tier_index_simplify.sql
@@ -1,0 +1,56 @@
+-- Migration V93: simplify the public VIP-tier carousel index
+-- ============================================================================
+-- The homepage tier carousels (GET /v1/listings/homepage-tier) and the per-tier
+-- search both query ONE vip_type at a time:
+--
+--     WHERE vip_type = ? AND verified = true
+--           AND is_draft = false AND is_shadow = false
+--     ORDER BY updated_at DESC          -- vip_type pinned ⇒ no vip_type_sort_order needed
+--     LIMIT N
+--
+-- V92 had built the index as
+--     (vip_type, verified, is_draft, is_shadow, vip_type_sort_order, updated_at DESC)
+-- to match an ORDER BY of (vip_type_sort_order ASC, updated_at DESC). That has two
+-- problems for this single-tier query:
+--   1. It depends on a DESCENDING index column, which only MySQL 8.0+ honours;
+--      on older engines DESC is ignored → filesort.
+--   2. With vip_type_sort_order sitting between the equality columns and
+--      updated_at, the planner can't use the index to order by updated_at alone
+--      (it doesn't know vip_type_sort_order is constant) → filesort over the
+--      whole tier (catastrophic for NORMAL — the bulk of all listings, the slow
+--      "Tin mới" carousel).
+--
+-- Fix: drop vip_type_sort_order from both the query (done in code) and the index.
+-- A plain trailing updated_at lets MySQL satisfy `ORDER BY updated_at DESC` with a
+-- BACKWARD index scan on any version — a 10-row read, no filesort.
+--
+-- Final shape: (vip_type, verified, is_draft, is_shadow, updated_at)
+-- (identical to V91's original; V92's variant is superseded.)
+--
+-- Idempotent via information_schema, matching V78-V92 style. Safe whether the
+-- index currently exists in V91, V92, or no form.
+-- ============================================================================
+
+-- 1. Drop whatever shape currently exists.
+SET @idx_exists = (SELECT COUNT(*) FROM information_schema.statistics
+                   WHERE table_schema = DATABASE()
+                     AND table_name = 'listings'
+                     AND index_name = 'idx_listings_public_vip_tier');
+SET @sql = IF(@idx_exists > 0,
+    'DROP INDEX idx_listings_public_vip_tier ON listings',
+    'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- 2. Recreate with the simple, version-portable shape.
+SET @idx_exists = (SELECT COUNT(*) FROM information_schema.statistics
+                   WHERE table_schema = DATABASE()
+                     AND table_name = 'listings'
+                     AND index_name = 'idx_listings_public_vip_tier');
+SET @sql = IF(@idx_exists = 0,
+    'CREATE INDEX idx_listings_public_vip_tier ON listings (vip_type, verified, is_draft, is_shadow, updated_at)',
+    'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;


### PR DESCRIPTION
…lesort

The single-tier carousel query ordered by (vip_type_sort_order ASC, updated_at DESC). vip_type is pinned, so vip_type_sort_order is constant — but the planner doesn't know that, so it filesorted the whole tier (catastrophic for NORMAL, the 'Tin mới' carousel: the query hung and the FE sat on its skeleton).

Drop the redundant sort key: ORDER BY updated_at DESC. Now idx_listings_public_vip_tier (ending in a plain updated_at) is satisfied by a backward index scan — a 10-row read, no filesort, on any MySQL version (no dependency on the V92 descending index).

V93 simplifies the index back to (vip_type, verified, is_draft, is_shadow, updated_at). Push still preserved: updated_at is bumped on push, so pushed listings stay on top.