### PR TITLE
feat(listings): add cursor (keyset) paginated search — POST /search/c…

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/controller/ListingSearchController.java
+++ b/smart-rent/src/main/java/com/smartrent/controller/ListingSearchController.java
@@ -172,6 +172,35 @@ public class ListingSearchController {
         return ApiResponse.<ListingCardListResponse>builder().data(response).build();
     }
 
+    @PostMapping("/search/cursor")
+    @Operation(
+        summary = "[PUBLIC API] Tìm kiếm bài đăng — phân trang bằng cursor (keyset)",
+        description = """
+            **PUBLIC API - Không cần authentication**
+
+            Giống hệt `POST /search` về bộ lọc, sắp xếp và index — chỉ khác cơ chế phân trang:
+            dùng **cursor (keyset)** thay cho `page`/OFFSET. Body là `ListingFilterRequest`
+            (mọi filter + `sortBy`/`sortDirection`); truyền `cursor` (rỗng cho trang đầu) và
+            `size` qua query param. Trả về `{ items, nextCursor, hasNext, size }` — KHÔNG có
+            tổng số (không COUNT), nên trang sâu vẫn nhanh O(size). Lấy `nextCursor` của lần
+            gọi trước để lấy trang kế.
+            """
+    )
+    public ApiResponse<ListingCursorResponse> searchListingsByCursor(
+            @RequestBody(required = false) ListingFilterRequest filter,
+            @RequestParam(value = "cursor", required = false) String cursor,
+            @RequestParam(value = "size", required = false) Integer size) {
+
+        if (filter == null) {
+            filter = ListingFilterRequest.builder().build();
+        }
+        int effectiveSize = size != null ? size
+                : (filter.getSize() != null ? filter.getSize() : 20);
+
+        ListingCursorResponse response = listingService.searchListingsByCursor(filter, cursor, effectiveSize);
+        return ApiResponse.<ListingCursorResponse>builder().data(response).build();
+    }
+
     @GetMapping("/homepage-tier")
     @Operation(
         summary = "[PUBLIC API] Top listings of one VIP tier for homepage carousels",

--- a/smart-rent/src/main/java/com/smartrent/dto/response/ListingCursorResponse.java
+++ b/smart-rent/src/main/java/com/smartrent/dto/response/ListingCursorResponse.java
@@ -1,0 +1,35 @@
+package com.smartrent.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.FieldDefaults;
+
+import java.util.List;
+
+/**
+ * Cursor-paginated listing feed (POST /v1/listings/search/cursor).
+ * Same card shape as the offset search, but paged by an opaque {@code nextCursor}
+ * instead of page numbers — and with NO total count.
+ */
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class ListingCursorResponse {
+
+    List<ListingCardResponse> items;
+
+    /** Opaque token for the next page; {@code null} when there are no more rows. */
+    String nextCursor;
+
+    boolean hasNext;
+
+    /** Echoes the effective page size used. */
+    Integer size;
+}

--- a/smart-rent/src/main/java/com/smartrent/infra/repository/ListingRepository.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/ListingRepository.java
@@ -17,7 +17,7 @@ import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
 @Repository
-public interface ListingRepository extends JpaRepository<Listing, Long>, JpaSpecificationExecutor<Listing> {
+public interface ListingRepository extends JpaRepository<Listing, Long>, JpaSpecificationExecutor<Listing>, ListingRepositoryCustom {
     List<Listing> findByListingIdIn(Collection<Long> listingIds);
 
     /**

--- a/smart-rent/src/main/java/com/smartrent/infra/repository/ListingRepositoryCustom.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/ListingRepositoryCustom.java
@@ -1,0 +1,23 @@
+package com.smartrent.infra.repository;
+
+import com.smartrent.infra.repository.entity.Listing;
+import com.smartrent.service.listing.cursor.ListingCursorSupport;
+import org.springframework.data.jpa.domain.Specification;
+
+import java.util.List;
+
+/**
+ * Custom listing queries that the derived/Specification repository can't express.
+ */
+public interface ListingRepositoryCustom {
+
+    /**
+     * Keyset (cursor) page: applies {@code spec} (filters + seek predicate),
+     * orders by {@code keys}, and returns at most {@code limit} rows as a plain
+     * List — NO {@code COUNT(*)} (unlike {@code findAll(spec, Pageable)}). That
+     * is the whole point of cursor pagination: deep pages stay O(limit).
+     */
+    List<Listing> findByCursor(Specification<Listing> spec,
+                               List<ListingCursorSupport.CursorKey> keys,
+                               int limit);
+}

--- a/smart-rent/src/main/java/com/smartrent/infra/repository/ListingRepositoryCustomImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/ListingRepositoryCustomImpl.java
@@ -1,0 +1,42 @@
+package com.smartrent.infra.repository;
+
+import com.smartrent.infra.repository.entity.Listing;
+import com.smartrent.service.listing.cursor.ListingCursorSupport;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import org.springframework.data.jpa.domain.Specification;
+
+import java.util.List;
+
+/**
+ * Spring Data picks this up by the {@code <RepositoryName>Impl} naming convention
+ * (same package as {@link ListingRepository}).
+ */
+public class ListingRepositoryCustomImpl implements ListingRepositoryCustom {
+
+    @PersistenceContext
+    private EntityManager em;
+
+    @Override
+    public List<Listing> findByCursor(Specification<Listing> spec,
+                                      List<ListingCursorSupport.CursorKey> keys,
+                                      int limit) {
+        CriteriaBuilder cb = em.getCriteriaBuilder();
+        CriteriaQuery<Listing> cq = cb.createQuery(Listing.class);
+        Root<Listing> root = cq.from(Listing.class);
+
+        // Reuse the exact same filter logic (and its address fetch / distinct) as
+        // the offset search path — only the paging mechanism differs.
+        Predicate p = spec.toPredicate(root, cq, cb);
+        if (p != null) {
+            cq.where(p);
+        }
+        cq.orderBy(ListingCursorSupport.orders(cb, root, keys));
+
+        return em.createQuery(cq).setMaxResults(limit).getResultList();
+    }
+}

--- a/smart-rent/src/main/java/com/smartrent/service/listing/ListingService.java
+++ b/smart-rent/src/main/java/com/smartrent/service/listing/ListingService.java
@@ -98,6 +98,16 @@ public interface ListingService {
     List<com.smartrent.dto.response.ListingCardResponse> getHomepageTierListings(String vipType, int limit);
 
     /**
+     * Cursor (keyset) paginated listing feed — a drop-in alternative to
+     * {@link #searchListings} for the public listings page. Same filters, same
+     * sort, same indexes; only the paging differs: it seeks past an opaque
+     * {@code cursor} instead of OFFSET-ing by page number, so deep pages stay
+     * O(size) and there is no COUNT(*). Pass {@code cursor = null} for page one.
+     */
+    com.smartrent.dto.response.ListingCursorResponse searchListingsByCursor(
+            ListingFilterRequest filter, String cursor, int size);
+
+    /**
      * Public endpoint data source: get top saved listings for a specific seller.
      * Sorted by number of saves descending.
      *

--- a/smart-rent/src/main/java/com/smartrent/service/listing/cursor/ListingCursorSupport.java
+++ b/smart-rent/src/main/java/com/smartrent/service/listing/cursor/ListingCursorSupport.java
@@ -1,0 +1,182 @@
+package com.smartrent.service.listing.cursor;
+
+import com.smartrent.infra.repository.entity.Listing;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.Expression;
+import jakarta.persistence.criteria.Order;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import org.springframework.data.jpa.domain.Specification;
+
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+
+/**
+ * Keyset (cursor) pagination support for the listing feed.
+ *
+ * <p>This is the cursor counterpart of {@code ListingQueryService.buildSort}: it
+ * produces the SAME ordering, but as a list of typed keys so we can (a) build a
+ * deterministic ORDER BY, (b) build a "seek" predicate {@code (row > cursor)},
+ * and (c) encode/decode an opaque cursor token. {@code listingId DESC} is always
+ * appended as the final, unique tiebreaker so the order is total and no row is
+ * ever skipped or repeated across pages.
+ *
+ * <p>Non-null sort columns (vip_type_sort_order, updated_at, price, created_at,
+ * listing_id) are used directly so the existing indexes still apply. The two
+ * genuinely-nullable sort columns (area, post_date) are COALESCE-d to a sentinel
+ * so they stay cursorable; those sorts have no dedicated index anyway, so the
+ * coalesce costs nothing extra.
+ */
+public final class ListingCursorSupport {
+
+    private ListingCursorSupport() {}
+
+    public enum KeyType { INT, LONG, DECIMAL, DATETIME }
+
+    /** One ORDER BY key. {@code attr} is the JPA attribute name on {@link Listing}. */
+    public record CursorKey(String attr, boolean asc, KeyType type, boolean nullable) {}
+
+    private static final CursorKey VIP = new CursorKey("vipTypeSortOrder", true, KeyType.INT, false);
+    private static final CursorKey UPDATED_DESC = new CursorKey("updatedAt", false, KeyType.DATETIME, false);
+    private static final CursorKey ID_TIEBREAK = new CursorKey("listingId", false, KeyType.LONG, false);
+
+    /**
+     * Build the ordered key list for a sortBy/sortDirection — mirrors
+     * {@code ListingQueryService.buildSort} — with listingId appended as the
+     * unique tiebreaker. The returned list IS the cursor: same list is used for
+     * ordering, the seek predicate, and encode/decode.
+     */
+    public static List<CursorKey> keysFor(String sortBy, String sortDirection) {
+        boolean asc = "ASC".equalsIgnoreCase(sortDirection);
+        List<CursorKey> keys = new ArrayList<>();
+        if (sortBy == null || sortBy.isEmpty()) {
+            keys.add(VIP);
+            keys.add(UPDATED_DESC);
+        } else {
+            switch (sortBy) {
+                case "NEWEST" -> { keys.add(VIP); keys.add(UPDATED_DESC); }
+                case "OLDEST" -> { keys.add(VIP); keys.add(new CursorKey("updatedAt", true, KeyType.DATETIME, false)); }
+                case "PRICE_ASC" -> { keys.add(new CursorKey("price", true, KeyType.DECIMAL, false)); keys.add(VIP); keys.add(UPDATED_DESC); }
+                case "PRICE_DESC" -> { keys.add(new CursorKey("price", false, KeyType.DECIMAL, false)); keys.add(VIP); keys.add(UPDATED_DESC); }
+                case "price" -> { keys.add(new CursorKey("price", asc, KeyType.DECIMAL, false)); keys.add(VIP); keys.add(UPDATED_DESC); }
+                case "area" -> { keys.add(new CursorKey("area", asc, KeyType.DECIMAL, true)); keys.add(VIP); keys.add(UPDATED_DESC); }
+                case "createdAt" -> { keys.add(new CursorKey("createdAt", asc, KeyType.DATETIME, false)); keys.add(VIP); keys.add(UPDATED_DESC); }
+                case "updatedAt" -> keys.add(new CursorKey("updatedAt", asc, KeyType.DATETIME, false));
+                case "postDate" -> { keys.add(new CursorKey("postDate", asc, KeyType.DATETIME, true)); keys.add(VIP); keys.add(UPDATED_DESC); }
+                default -> { keys.add(VIP); keys.add(UPDATED_DESC); } // includes "DEFAULT"
+            }
+        }
+        keys.add(ID_TIEBREAK);
+        return keys;
+    }
+
+    /** ORDER BY clause for the given keys. */
+    public static List<Order> orders(CriteriaBuilder cb, Root<Listing> root, List<CursorKey> keys) {
+        List<Order> orders = new ArrayList<>(keys.size());
+        for (CursorKey k : keys) {
+            Expression<?> e = expr(cb, root, k);
+            orders.add(k.asc() ? cb.asc(e) : cb.desc(e));
+        }
+        return orders;
+    }
+
+    /**
+     * Seek predicate: rows that come strictly AFTER the cursor row in the order.
+     * Standard lexicographic OR-expansion:
+     * (k0 ? v0) OR (k0=v0 AND k1 ? v1) OR ... where ? is &gt; for ASC, &lt; for DESC.
+     */
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public static Specification<Listing> seek(List<CursorKey> keys, Object[] values) {
+        return (root, query, cb) -> {
+            List<Predicate> ors = new ArrayList<>(keys.size());
+            for (int i = 0; i < keys.size(); i++) {
+                List<Predicate> ands = new ArrayList<>(i + 1);
+                for (int j = 0; j < i; j++) {
+                    ands.add(cb.equal(expr(cb, root, keys.get(j)), values[j]));
+                }
+                CursorKey k = keys.get(i);
+                Expression e = expr(cb, root, k);
+                Comparable v = (Comparable) values[i];
+                ands.add(k.asc() ? cb.greaterThan(e, v) : cb.lessThan(e, v));
+                ors.add(cb.and(ands.toArray(new Predicate[0])));
+            }
+            return cb.or(ors.toArray(new Predicate[0]));
+        };
+    }
+
+    /** Encode the cursor row's key values into an opaque token. */
+    public static String encode(List<CursorKey> keys, Listing last) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < keys.size(); i++) {
+            if (i > 0) sb.append('|');
+            sb.append(serialize(value(last, keys.get(i))));
+        }
+        return Base64.getUrlEncoder().withoutPadding()
+                .encodeToString(sb.toString().getBytes(StandardCharsets.UTF_8));
+    }
+
+    /** Decode a token back into typed values aligned with {@code keys}. */
+    public static Object[] decode(String cursor, List<CursorKey> keys) {
+        String raw = new String(Base64.getUrlDecoder().decode(cursor), StandardCharsets.UTF_8);
+        String[] parts = raw.split("\\|", -1);
+        if (parts.length != keys.size()) {
+            throw new IllegalArgumentException("Malformed cursor");
+        }
+        Object[] values = new Object[keys.size()];
+        for (int i = 0; i < keys.size(); i++) {
+            values[i] = parse(parts[i], keys.get(i).type());
+        }
+        return values;
+    }
+
+    // ── internals ──────────────────────────────────────────────────────────
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private static Expression<?> expr(CriteriaBuilder cb, Root<Listing> root, CursorKey k) {
+        Expression<?> path = root.get(k.attr());
+        if (k.nullable()) {
+            return cb.coalesce((Expression) path, (Comparable) sentinel(k.type()));
+        }
+        return path;
+    }
+
+    private static Object value(Listing l, CursorKey k) {
+        Object v = switch (k.attr()) {
+            case "vipTypeSortOrder" -> l.getVipTypeSortOrder();
+            case "updatedAt" -> l.getUpdatedAt();
+            case "createdAt" -> l.getCreatedAt();
+            case "postDate" -> l.getPostDate();
+            case "price" -> l.getPrice();
+            case "area" -> l.getArea();
+            case "listingId" -> l.getListingId();
+            default -> throw new IllegalStateException("Unknown cursor key: " + k.attr());
+        };
+        return (v == null && k.nullable()) ? sentinel(k.type()) : v;
+    }
+
+    private static String serialize(Object v) {
+        return v == null ? "" : v.toString();
+    }
+
+    private static Object parse(String s, KeyType type) {
+        return switch (type) {
+            case INT -> Integer.valueOf(s);
+            case LONG -> Long.valueOf(s);
+            case DECIMAL -> new BigDecimal(s);
+            case DATETIME -> LocalDateTime.parse(s);
+        };
+    }
+
+    private static Comparable<?> sentinel(KeyType type) {
+        return switch (type) {
+            case INT -> 0;
+            case LONG -> 0L;
+            case DECIMAL -> BigDecimal.ZERO;
+            case DATETIME -> LocalDateTime.of(1970, 1, 1, 0, 0);
+        };
+    }
+}

--- a/smart-rent/src/main/java/com/smartrent/service/listing/impl/ListingServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/listing/impl/ListingServiceImpl.java
@@ -1358,6 +1358,48 @@ public class ListingServiceImpl implements ListingService {
         return batchMapCardListings(listings);
     }
 
+    @Override
+    @Transactional(readOnly = true)
+    public com.smartrent.dto.response.ListingCursorResponse searchListingsByCursor(
+            ListingFilterRequest filter, String cursor, int size) {
+        int safeSize = Math.min(Math.max(size, 1), 100);
+
+        // Same filter resolution + specification as the offset search path.
+        resolveAddressMappings(filter);
+        Specification<Listing> spec = listingQueryService.buildSpecification(filter);
+
+        // Same ordering as buildSort, expressed as keyset keys (listingId tiebreaker appended).
+        java.util.List<com.smartrent.service.listing.cursor.ListingCursorSupport.CursorKey> keys =
+                com.smartrent.service.listing.cursor.ListingCursorSupport.keysFor(
+                        filter.getSortBy(), filter.getSortDirection());
+
+        if (cursor != null && !cursor.isBlank()) {
+            try {
+                Object[] values = com.smartrent.service.listing.cursor.ListingCursorSupport.decode(cursor, keys);
+                spec = spec.and(com.smartrent.service.listing.cursor.ListingCursorSupport.seek(keys, values));
+            } catch (RuntimeException e) {
+                log.warn("searchListingsByCursor: ignoring malformed cursor: {}", e.getMessage());
+            }
+        }
+
+        // Fetch size+1 to know whether another page exists — List, so NO COUNT(*).
+        List<Listing> rows = listingRepository.findByCursor(spec, keys, safeSize + 1);
+        boolean hasNext = rows.size() > safeSize;
+        List<Listing> pageRows = hasNext ? new ArrayList<>(rows.subList(0, safeSize)) : rows;
+
+        String nextCursor = (hasNext && !pageRows.isEmpty())
+                ? com.smartrent.service.listing.cursor.ListingCursorSupport.encode(
+                        keys, pageRows.get(pageRows.size() - 1))
+                : null;
+
+        return com.smartrent.dto.response.ListingCursorResponse.builder()
+                .items(batchMapCardListings(pageRows))
+                .nextCursor(nextCursor)
+                .hasNext(hasNext)
+                .size(safeSize)
+                .build();
+    }
+
             @Override
             @Transactional(readOnly = true)
             public ListingCardListResponse getTopSavedListingsByUser(String userId, int limit) {

--- a/smart-rent/src/main/resources/application-local.yaml
+++ b/smart-rent/src/main/resources/application-local.yaml
@@ -70,6 +70,7 @@ application:
         - "/v1/listings/*/reports"
         - "/v1/ai/listings/**"
         - "/v1/listings/search"
+        - "/v1/listings/search/cursor"
         - "/v1/listings/map-bounds"
 # Enable debug logging for authentication
 logging:

--- a/smart-rent/src/main/resources/application.yml
+++ b/smart-rent/src/main/resources/application.yml
@@ -220,6 +220,7 @@ application:
         - "/otp/**"
         - "/v1/listings/*/reports"
         - "/v1/listings/search"
+        - "/v1/listings/search/cursor"
         - "/api/v1/advanced-search"
         - "/v1/listings/stats/provinces"
         - "/v1/listings/stats/categories"


### PR DESCRIPTION
…ursor

Duplicate of the offset /search for the /properties feed, changing ONLY the paging: keyset/cursor instead of page+OFFSET. Same ListingSpecification filters, same buildSort ordering, same indexes — the existing /search endpoint is untouched.

- ListingCursorSupport: builds the ordering as typed keys (listingId appended as the unique tiebreaker), the lexicographic seek predicate, and the opaque base64 cursor codec. Non-null sort columns are used directly so indexes still apply; the two nullable ones (area/post_date) are COALESCE-d for determinism.

- ListingRepositoryCustom#findByCursor runs the criteria query via EntityManager with setMaxResults — a plain List, so NO COUNT(*); deep pages stay O(size).

- Returns { items, nextCursor, hasNext, size }; pass cursor=null for page one. Public POST permitted in security config.