### PR TITLE
fix(search): stop NL location search from 500-ing (audit #2)

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/infra/repository/specification/ListingSpecification.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/specification/ListingSpecification.java
@@ -1075,22 +1075,26 @@ public class ListingSpecification {
                 predicates.add(criteriaBuilder.greaterThanOrEqualTo(root.get("bedrooms"), criteria.getBedrooms()));
             }
 
-            // Location filters using text pattern matching for simplicity,
-            // since AI returns raw string (e.g. "quận 1")
+            // Location filters using text pattern matching, since AI returns a
+            // raw string (e.g. "quận 1", "Bình Thạnh", "TP.HCM"). Address has NO
+            // per-component name columns — only the full address strings — so we
+            // match each term against fullAddress (legacy structure) OR
+            // fullNewAddress (post-2025 structure). Matching the non-existent
+            // districtName/provinceName/wardName attributes previously made
+            // Hibernate throw while building the query, 500-ing every
+            // location-filtered search.
             if (criteria.getDistrict() != null || criteria.getProvince() != null || criteria.getWard() != null) {
                 Join<Listing, Address> addressJoin = root.join("address", JoinType.INNER);
 
-                if (criteria.getDistrict() != null) {
-                    predicates.add(criteriaBuilder.like(criteriaBuilder.lower(addressJoin.get("districtName")),
-                        "%" + criteria.getDistrict().toLowerCase() + "%"));
-                }
-                if (criteria.getProvince() != null) {
-                    predicates.add(criteriaBuilder.like(criteriaBuilder.lower(addressJoin.get("provinceName")),
-                        "%" + criteria.getProvince().toLowerCase() + "%"));
-                }
-                if (criteria.getWard() != null) {
-                    predicates.add(criteriaBuilder.like(criteriaBuilder.lower(addressJoin.get("wardName")),
-                        "%" + criteria.getWard().toLowerCase() + "%"));
+                for (String locationTerm : new String[]{
+                        criteria.getDistrict(), criteria.getProvince(), criteria.getWard()}) {
+                    if (locationTerm != null && !locationTerm.isBlank()) {
+                        String pattern = "%" + locationTerm.toLowerCase() + "%";
+                        predicates.add(criteriaBuilder.or(
+                                criteriaBuilder.like(criteriaBuilder.lower(addressJoin.get("fullAddress")), pattern),
+                                criteriaBuilder.like(criteriaBuilder.lower(addressJoin.get("fullNewAddress")), pattern)
+                        ));
+                    }
                 }
             }
 


### PR DESCRIPTION
ListingSpecification matched the AI's free-text location against addressJoin.get("districtName"/"provinceName"/"wardName") — attributes that do NOT exist on the Address entity (it only has fullAddress/fullNewAddress + legacy*Id/new*Code). Hibernate threw IllegalArgumentException while building the criteria query, so EVERY location-filtered NL search (the most common dimension) returned HTTP 500 — including the offline local-parse fallback.

Fix: match each location term (district/province/ward) against the real fullAddress OR fullNewAddress columns via LIKE, preserving the intended text-matching behaviour while referencing attributes that actually exist.

Compiles clean (gradlew compileJava).