### PR TITLE
fix(cache): evict listing cache after AI moderation and admin decisions

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/service/ai/impl/AiModerationProcessorServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/ai/impl/AiModerationProcessorServiceImpl.java
@@ -2,6 +2,7 @@ package com.smartrent.service.ai.impl;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.smartrent.config.Constants;
 import com.smartrent.dto.request.AiListingVerificationRequest;
 import com.smartrent.dto.response.AiListingVerificationResponse;
 import com.smartrent.enums.ModerationStatus;
@@ -14,6 +15,8 @@ import com.smartrent.service.ai.AiListingVerificationService;
 import com.smartrent.service.ai.AiModerationProcessorService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Caching;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -44,6 +47,12 @@ public class AiModerationProcessorServiceImpl implements AiModerationProcessorSe
      */
     @Override
     @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @Caching(evict = {
+            @CacheEvict(cacheNames = Constants.CacheNames.LISTING_SEARCH, allEntries = true),
+            @CacheEvict(cacheNames = Constants.CacheNames.LISTING_BROWSE, allEntries = true),
+            @CacheEvict(cacheNames = Constants.CacheNames.LISTING_DETAIL, key = "#listing.listingId"),
+            @CacheEvict(cacheNames = Constants.CacheNames.LISTING_STATS_CATEGORIES, allEntries = true)
+    })
     public void processSingleListing(Listing listing, ListingAiModeration moderation) {
         try {
             log.info("Processing listing ID: {}", listing.getListingId());

--- a/smart-rent/src/main/java/com/smartrent/service/moderation/impl/ListingModerationServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/moderation/impl/ListingModerationServiceImpl.java
@@ -8,6 +8,7 @@ import com.smartrent.dto.response.ListingResponseWithAdmin;
 import com.smartrent.dto.response.ModerationEventResponse;
 import com.smartrent.dto.response.OwnerActionResponse;
 import com.smartrent.dto.response.UserCreationResponse;
+import com.smartrent.config.Constants;
 import com.smartrent.enums.*;
 import com.smartrent.infra.exception.DomainException;
 import com.smartrent.infra.exception.model.DomainCode;
@@ -39,6 +40,8 @@ import lombok.experimental.FieldDefaults;
 import lombok.experimental.NonFinal;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Caching;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -80,6 +83,12 @@ public class ListingModerationServiceImpl implements ListingModerationService {
     // ───────────────────────────────────────────────────────────────
     @Override
     @Transactional
+    @Caching(evict = {
+            @CacheEvict(cacheNames = Constants.CacheNames.LISTING_SEARCH, allEntries = true),
+            @CacheEvict(cacheNames = Constants.CacheNames.LISTING_BROWSE, allEntries = true),
+            @CacheEvict(cacheNames = Constants.CacheNames.LISTING_DETAIL, key = "#listingId"),
+            @CacheEvict(cacheNames = Constants.CacheNames.LISTING_STATS_CATEGORIES, allEntries = true)
+    })
     public ListingResponseWithAdmin moderateListing(Long listingId, ListingStatusChangeRequest request, String adminId) {
         Listing listing = listingRepository.findById(listingId)
                 .orElseThrow(() -> new DomainException(DomainCode.LISTING_NOT_FOUND));
@@ -167,6 +176,11 @@ public class ListingModerationServiceImpl implements ListingModerationService {
     // ───────────────────────────────────────────────────────────────
     @Override
     @Transactional
+    @Caching(evict = {
+            @CacheEvict(cacheNames = Constants.CacheNames.LISTING_SEARCH, allEntries = true),
+            @CacheEvict(cacheNames = Constants.CacheNames.LISTING_BROWSE, allEntries = true),
+            @CacheEvict(cacheNames = Constants.CacheNames.LISTING_DETAIL, key = "#listingId"),
+    })
     public void handleReportResolutionOwnerAction(Long reportId, Long listingId, ResolveReportRequest request, String adminId) {
         if (!Boolean.TRUE.equals(request.getOwnerActionRequired())) {
             return; // No owner action needed
@@ -234,6 +248,11 @@ public class ListingModerationServiceImpl implements ListingModerationService {
     // ───────────────────────────────────────────────────────────────
     @Override
     @Transactional
+    @Caching(evict = {
+            @CacheEvict(cacheNames = Constants.CacheNames.LISTING_SEARCH, allEntries = true),
+            @CacheEvict(cacheNames = Constants.CacheNames.LISTING_BROWSE, allEntries = true),
+            @CacheEvict(cacheNames = Constants.CacheNames.LISTING_DETAIL, key = "#listingId"),
+    })
     public void resubmitForReview(Long listingId, String userId, ResubmitListingRequest request) {
         Listing listing = listingRepository.findById(listingId)
                 .orElseThrow(() -> new DomainException(DomainCode.LISTING_NOT_FOUND));
@@ -321,6 +340,11 @@ public class ListingModerationServiceImpl implements ListingModerationService {
     // ───────────────────────────────────────────────────────────────
     @Override
     @Transactional
+    @Caching(evict = {
+            @CacheEvict(cacheNames = Constants.CacheNames.LISTING_SEARCH, allEntries = true),
+            @CacheEvict(cacheNames = Constants.CacheNames.LISTING_BROWSE, allEntries = true),
+            @CacheEvict(cacheNames = Constants.CacheNames.LISTING_DETAIL, key = "#listingId"),
+    })
     public void updateAndResubmitForReview(Long listingId, UpdateAndResubmitRequest request, String userId) {
         Listing listing = listingRepository.findById(listingId)
                 .orElseThrow(() -> new DomainException(DomainCode.LISTING_NOT_FOUND));


### PR DESCRIPTION
AI moderation updated moderationStatus in the DB but never cleared the LISTING_DETAIL cache, so a listing auto-approved (APPROVED) by AI still appeared as PENDING_REVIEW in the detail API while the admin list query (which hits DB directly) correctly excluded it — making the listing invisible in the admin review queue.

Same issue affected manual admin moderate/reject and owner resubmit.