### PR TITLE
fix(admin): show expired listings when filtering by owner in admin view

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/service/listing/impl/ListingServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/listing/impl/ListingServiceImpl.java
@@ -1937,6 +1937,11 @@ public class ListingServiceImpl implements ListingService {
         adminRepository.findById(adminId)
                 .orElseThrow(() -> new AppException(DomainCode.UNAUTHORIZED, "Admin not found"));
 
+        // Admin must see ALL listings regardless of expiry — the DTO defaults
+        // excludeExpired=true (intended for public search), so we clear it here.
+        // Admins can still filter by `expired` or `expiryDate` explicitly.
+        filter.setExcludeExpired(false);
+
         // Execute query using shared query service
         Page<Listing> page = listingQueryService.executeQuery(filter);
 


### PR DESCRIPTION
The DTO defaults excludeExpired=true for public search, but admin must see all listings regardless of expiry. Without this override, filtering by owner name silently excluded expired listings, causing admin counts to be lower than the seller dashboard for the same user.