### PR TITLE
fix(listings): exclude expired listings from homepage tier carousel

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/infra/repository/ListingRepository.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/ListingRepository.java
@@ -119,6 +119,8 @@ public interface ListingRepository extends JpaRepository<Listing, Long>, JpaSpec
     @Query("SELECT l FROM listings l LEFT JOIN FETCH l.address " +
            "WHERE l.vipType = :vipType AND l.verified = true " +
            "AND l.isDraft = false AND l.isShadow = false " +
+           "AND l.expired = false " +
+           "AND (l.expiryDate IS NULL OR l.expiryDate > CURRENT_TIMESTAMP) " +
            "ORDER BY l.updatedAt DESC")
     List<Listing> findHomepageTier(@Param("vipType") Listing.VipType vipType, Pageable pageable);
 


### PR DESCRIPTION
findHomepageTier query was missing expiry checks — listings with expired=true or expiryDate in the past could appear on the homepage. Added AND l.expired = false AND (l.expiryDate IS NULL OR l.expiryDate > CURRENT_TIMESTAMP).