### PR TITLE
fix(admin): exclude expired listings from Chờ duyệt filter

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/infra/repository/specification/ListingSpecification.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/specification/ListingSpecification.java
@@ -84,9 +84,14 @@ public class ListingSpecification {
             }
 
             // Expired filter
+            // Note: @Builder.Default on excludeExpired is not applied by Jackson's no-args constructor
+            // deserialization, so we treat null as "true" (exclude expired) via !Boolean.FALSE.equals().
+            // Skip the default exclusion only when the caller explicitly requests EXPIRED listings
+            // via listingStatus=EXPIRED (that predicate gates on expired=true itself).
             if (filter.getExpired() != null) {
                 predicates.add(criteriaBuilder.equal(root.get("expired"), filter.getExpired()));
-            } else if (Boolean.TRUE.equals(filter.getExcludeExpired())) {
+            } else if (!Boolean.FALSE.equals(filter.getExcludeExpired())
+                    && !"EXPIRED".equals(filter.getListingStatus())) {
                 LocalDateTime now = LocalDateTime.now();
                 predicates.add(criteriaBuilder.and(
                     criteriaBuilder.equal(root.get("expired"), false),


### PR DESCRIPTION
@Builder.Default on excludeExpired is not applied by Jackson's no-args constructor deserialization, so null was treated as false, letting expired listings slip through the PENDING_REVIEW / IN_REVIEW filter.

Fix: use !Boolean.FALSE.equals() so null defaults to "exclude expired". Exception: skip the default exclusion for listingStatus=EXPIRED, which explicitly queries for expired listings via its own predicate.