### PR TITLE
fix: exclude expired listings from PENDING_REVIEW filter in admin

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/infra/repository/specification/ListingSpecification.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/specification/ListingSpecification.java
@@ -133,6 +133,22 @@ public class ListingSpecification {
                             criteriaBuilder.equal(root.get("moderationStatus"), moderationStatus),
                             criteriaBuilder.isNull(root.get("moderationStatus"))
                         ));
+                        // "Chờ duyệt" (IN_REVIEW) means the listing is active AND pending review.
+                        // An expired listing with PENDING_REVIEW belongs to "Hết hạn" (EXPIRED),
+                        // not "Chờ duyệt". Exclude it even though getAllListingsForAdmin sets
+                        // excludeExpired=false (admin general view), because this specific filter
+                        // implies the user wants only genuinely reviewable listings.
+                        LocalDateTime pendingReviewNow = LocalDateTime.now();
+                        predicates.add(criteriaBuilder.and(
+                            criteriaBuilder.or(
+                                criteriaBuilder.isFalse(root.get("expired")),
+                                criteriaBuilder.isNull(root.get("expired"))
+                            ),
+                            criteriaBuilder.or(
+                                criteriaBuilder.isNull(root.get("expiryDate")),
+                                criteriaBuilder.greaterThan(root.get("expiryDate"), pendingReviewNow)
+                            )
+                        ));
                     } else {
                         predicates.add(criteriaBuilder.equal(root.get("moderationStatus"), moderationStatus));
                     }

--- a/smart-rent/src/main/java/com/smartrent/infra/repository/specification/ListingSpecification.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/specification/ListingSpecification.java
@@ -133,12 +133,11 @@ public class ListingSpecification {
                             criteriaBuilder.equal(root.get("moderationStatus"), moderationStatus),
                             criteriaBuilder.isNull(root.get("moderationStatus"))
                         ));
-                        // "Chờ duyệt" (IN_REVIEW) means the listing is active AND pending review.
-                        // An expired listing with PENDING_REVIEW belongs to "Hết hạn" (EXPIRED),
-                        // not "Chờ duyệt". Exclude it even though getAllListingsForAdmin sets
-                        // excludeExpired=false (admin general view), because this specific filter
-                        // implies the user wants only genuinely reviewable listings.
-                        LocalDateTime pendingReviewNow = LocalDateTime.now();
+                        // Both PENDING_REVIEW and RESUBMITTED map to IN_REVIEW in the seller view —
+                        // they represent listings actively awaiting admin action. Expired listings
+                        // with these statuses belong to "Hết hạn" (EXPIRED), not the review queue.
+                        // Exclude them even though getAllListingsForAdmin sets excludeExpired=false.
+                        LocalDateTime reviewNow = LocalDateTime.now();
                         predicates.add(criteriaBuilder.and(
                             criteriaBuilder.or(
                                 criteriaBuilder.isFalse(root.get("expired")),
@@ -146,10 +145,28 @@ public class ListingSpecification {
                             ),
                             criteriaBuilder.or(
                                 criteriaBuilder.isNull(root.get("expiryDate")),
-                                criteriaBuilder.greaterThan(root.get("expiryDate"), pendingReviewNow)
+                                criteriaBuilder.greaterThan(root.get("expiryDate"), reviewNow)
+                            )
+                        ));
+                    } else if (moderationStatus == com.smartrent.enums.ModerationStatus.RESUBMITTED) {
+                        predicates.add(criteriaBuilder.equal(root.get("moderationStatus"), moderationStatus));
+                        // RESUBMITTED is the other sub-state of IN_REVIEW (owner resubmitted after
+                        // revision request). Same rule as PENDING_REVIEW: expired listings here
+                        // belong in "Hết hạn", not the active review queue.
+                        LocalDateTime resubmittedNow = LocalDateTime.now();
+                        predicates.add(criteriaBuilder.and(
+                            criteriaBuilder.or(
+                                criteriaBuilder.isFalse(root.get("expired")),
+                                criteriaBuilder.isNull(root.get("expired"))
+                            ),
+                            criteriaBuilder.or(
+                                criteriaBuilder.isNull(root.get("expiryDate")),
+                                criteriaBuilder.greaterThan(root.get("expiryDate"), resubmittedNow)
                             )
                         ));
                     } else {
+                        // APPROVED, REJECTED, REVISION_REQUIRED, SUSPENDED — admin views these
+                        // for history/tracking; expired listings remain visible intentionally.
                         predicates.add(criteriaBuilder.equal(root.get("moderationStatus"), moderationStatus));
                     }
                 } catch (IllegalArgumentException e) {


### PR DESCRIPTION
When admin filters by moderationStatus=PENDING_REVIEW ("Chờ duyệt"), listings with listingStatus=EXPIRED were incorrectly shown because getAllListingsForAdmin sets excludeExpired=false globally. Now the PENDING_REVIEW branch explicitly excludes expired listings (expired=true OR expiryDate < now) since "Chờ duyệt" = IN_REVIEW (active + pending review). Expired + PENDING_REVIEW belongs in "Hết hạn", not "Chờ duyệt".