### PR TITLE
feat(notifications): async email/OTP via Redis Streams

### DIFF
--- a/smart-rent/build.gradle
+++ b/smart-rent/build.gradle
@@ -79,8 +79,9 @@ dependencies {
     // WireMock for integration testing
     testImplementation 'org.wiremock:wiremock-standalone:3.9.2'
 
-    // Embedded Redis for testing
-    testImplementation 'it.ozimov:embedded-redis:0.7.3'
+    // Embedded Redis for testing — codemonstur fork bundles Redis >=6 with
+    // Streams support (ozimov's 0.7.3 ships Redis 2.8 which lacks XADD/XLEN).
+    testImplementation 'com.github.codemonstur:embedded-redis:1.4.3'
 
     // String matching and phonetic encoding for search
     implementation 'org.apache.commons:commons-text:1.10.0'

--- a/smart-rent/src/main/java/com/smartrent/config/notification/NotificationStreamConfig.java
+++ b/smart-rent/src/main/java/com/smartrent/config/notification/NotificationStreamConfig.java
@@ -1,0 +1,114 @@
+package com.smartrent.config.notification;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.smartrent.service.email.EmailService;
+import com.smartrent.service.notification.EmailNotificationHandler;
+import com.smartrent.service.notification.NotificationDispatcher;
+import com.smartrent.service.notification.NotificationHandler;
+import com.smartrent.service.notification.NotificationStreamConsumer;
+import com.smartrent.service.notification.OtpNotificationHandler;
+import com.smartrent.service.notification.RedisStreamNotificationQueue;
+import com.smartrent.service.otp.provider.OtpProvider;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.stream.Consumer;
+import org.springframework.data.redis.connection.stream.MapRecord;
+import org.springframework.data.redis.connection.stream.ReadOffset;
+import org.springframework.data.redis.connection.stream.StreamOffset;
+import org.springframework.data.redis.core.RedisCallback;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.stream.StreamMessageListenerContainer;
+import org.springframework.data.redis.stream.StreamMessageListenerContainer.StreamMessageListenerContainerOptions;
+
+/**
+ * Wires the async notification pipeline: handlers, dispatcher, and a Redis
+ * Streams consumer group that processes jobs off the request thread.
+ *
+ * <p>Gated by {@code notifications.async.enabled} (default on) so test/CI
+ * contexts that have no Redis can disable the listener container.
+ */
+@Slf4j
+@Configuration
+@ConditionalOnProperty(
+    name = "notifications.async.enabled",
+    havingValue = "true",
+    matchIfMissing = true)
+public class NotificationStreamConfig {
+
+  public static final String GROUP = "notification-workers";
+
+  @Value("${notifications.consumer-name:worker-1}")
+  private String consumerName;
+
+  @Bean
+  public EmailNotificationHandler emailNotificationHandler(
+      EmailService emailService, ObjectMapper objectMapper) {
+    return new EmailNotificationHandler(emailService, objectMapper);
+  }
+
+  @Bean
+  public OtpNotificationHandler otpNotificationHandler(
+      List<OtpProvider> providers, ObjectMapper objectMapper) {
+    return new OtpNotificationHandler(providers, objectMapper);
+  }
+
+  @Bean
+  public NotificationDispatcher notificationDispatcher(List<NotificationHandler> handlers) {
+    return new NotificationDispatcher(handlers);
+  }
+
+  @Bean
+  public NotificationStreamConsumer notificationStreamConsumer(
+      NotificationDispatcher dispatcher, StringRedisTemplate redisTemplate) {
+    return new NotificationStreamConsumer(dispatcher, redisTemplate, GROUP);
+  }
+
+  @Bean(destroyMethod = "stop")
+  public StreamMessageListenerContainer<String, MapRecord<String, String, String>>
+      notificationStreamListenerContainer(
+          RedisConnectionFactory connectionFactory,
+          StringRedisTemplate redisTemplate,
+          NotificationStreamConsumer consumer) {
+
+    ensureConsumerGroup(redisTemplate);
+
+    StreamMessageListenerContainerOptions<String, MapRecord<String, String, String>> options =
+        StreamMessageListenerContainerOptions.builder()
+            .pollTimeout(Duration.ofSeconds(1))
+            .build();
+
+    StreamMessageListenerContainer<String, MapRecord<String, String, String>> container =
+        StreamMessageListenerContainer.create(connectionFactory, options);
+    container.receive(
+        Consumer.from(GROUP, consumerName),
+        StreamOffset.create(RedisStreamNotificationQueue.STREAM_KEY, ReadOffset.lastConsumed()),
+        consumer);
+    container.start();
+    log.info(
+        "Notification stream consumer started: stream={}, group={}, consumer={}",
+        RedisStreamNotificationQueue.STREAM_KEY, GROUP, consumerName);
+    return container;
+  }
+
+  /** Idempotently create the consumer group (MKSTREAM), ignoring BUSYGROUP. */
+  private void ensureConsumerGroup(StringRedisTemplate redisTemplate) {
+    try {
+      redisTemplate.execute((RedisCallback<String>) connection ->
+          connection.streamCommands().xGroupCreate(
+              RedisStreamNotificationQueue.STREAM_KEY.getBytes(StandardCharsets.UTF_8),
+              GROUP,
+              ReadOffset.from("0"),
+              true));
+      log.info("Created notification consumer group {}", GROUP);
+    } catch (Exception e) {
+      log.debug("Notification consumer group {} already present: {}", GROUP, e.getMessage());
+    }
+  }
+}

--- a/smart-rent/src/main/java/com/smartrent/service/email/impl/VerificationEmailServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/email/impl/VerificationEmailServiceImpl.java
@@ -9,8 +9,8 @@ import com.smartrent.infra.exception.UserNotFoundException;
 import com.smartrent.infra.repository.UserRepository;
 import com.smartrent.infra.repository.entity.User;
 import com.smartrent.service.authentication.domain.OtpData;
-import com.smartrent.service.email.EmailService;
 import com.smartrent.service.email.VerificationEmailService;
+import com.smartrent.service.notification.NotificationPublisher;
 import com.smartrent.utility.EmailBuilder;
 import com.smartrent.utility.Utils;
 import java.time.LocalDateTime;
@@ -47,7 +47,7 @@ public class VerificationEmailServiceImpl implements VerificationEmailService {
   @Value("${application.otp.duration}")
   int otpDuration;
 
-  EmailService emailService;
+  NotificationPublisher notificationPublisher;
 
   UserRepository userRepository;
 
@@ -60,8 +60,9 @@ public class VerificationEmailServiceImpl implements VerificationEmailService {
     String htmlContent = EmailBuilder.buildVerifyHtmlContent(senderName, user.getFirstName(), user.getLastName(), otpData, otpDuration);
     EmailRequest emailRequest = buildEmailRequest(user, htmlContent);
 
-    // send email
-    emailService.sendEmail(emailRequest);
+    // enqueue email — actual provider send happens on a worker thread,
+    // off the request path (was a blocking emailService.sendEmail call).
+    notificationPublisher.publishEmail(emailRequest);
 
     return otpData;
   }

--- a/smart-rent/src/main/java/com/smartrent/service/notification/EmailMessage.java
+++ b/smart-rent/src/main/java/com/smartrent/service/notification/EmailMessage.java
@@ -1,0 +1,33 @@
+package com.smartrent.service.notification;
+
+import com.smartrent.infra.connector.model.EmailRequest;
+import java.util.List;
+
+/**
+ * Jackson round-trippable payload for an {@link NotificationType#EMAIL} job.
+ * Kept separate from {@code EmailRequest} (which is immutable and not
+ * deserializable) so jobs can be serialized onto and read back off the stream.
+ */
+public record EmailMessage(
+    String senderEmail,
+    String senderName,
+    List<Recipient> recipients,
+    String subject,
+    String htmlContent) {
+
+  public record Recipient(String name, String email) {
+  }
+
+  /** Maps the immutable {@code EmailRequest} into a serializable message. */
+  public static EmailMessage from(EmailRequest request) {
+    List<Recipient> recipients = request.getTo().stream()
+        .map(info -> new Recipient(info.getName(), info.getEmail()))
+        .toList();
+    return new EmailMessage(
+        request.getSender().getEmail(),
+        request.getSender().getName(),
+        recipients,
+        request.getSubject(),
+        request.getHtmlContent());
+  }
+}

--- a/smart-rent/src/main/java/com/smartrent/service/notification/EmailNotificationHandler.java
+++ b/smart-rent/src/main/java/com/smartrent/service/notification/EmailNotificationHandler.java
@@ -1,0 +1,52 @@
+package com.smartrent.service.notification;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.smartrent.infra.connector.model.EmailInfo;
+import com.smartrent.infra.connector.model.EmailRequest;
+import com.smartrent.service.email.EmailService;
+import java.util.List;
+
+/**
+ * Consumes {@link NotificationType#EMAIL} jobs off the queue and performs the
+ * actual (blocking) provider send on the worker thread instead of the request
+ * thread.
+ */
+public class EmailNotificationHandler implements NotificationHandler {
+
+  private final EmailService emailService;
+  private final ObjectMapper objectMapper;
+
+  public EmailNotificationHandler(EmailService emailService, ObjectMapper objectMapper) {
+    this.emailService = emailService;
+    this.objectMapper = objectMapper;
+  }
+
+  @Override
+  public NotificationType supportedType() {
+    return NotificationType.EMAIL;
+  }
+
+  @Override
+  public void handle(NotificationJob job) {
+    EmailMessage message;
+    try {
+      message = objectMapper.readValue(job.payload(), EmailMessage.class);
+    } catch (JsonProcessingException e) {
+      throw new IllegalArgumentException("Invalid email notification payload", e);
+    }
+    emailService.sendEmail(toEmailRequest(message));
+  }
+
+  private EmailRequest toEmailRequest(EmailMessage message) {
+    List<EmailInfo> recipients = message.recipients().stream()
+        .map(r -> EmailInfo.builder().name(r.name()).email(r.email()).build())
+        .toList();
+    return EmailRequest.builder()
+        .sender(EmailInfo.builder().email(message.senderEmail()).name(message.senderName()).build())
+        .to(recipients)
+        .subject(message.subject())
+        .htmlContent(message.htmlContent())
+        .build();
+  }
+}

--- a/smart-rent/src/main/java/com/smartrent/service/notification/NotificationDispatcher.java
+++ b/smart-rent/src/main/java/com/smartrent/service/notification/NotificationDispatcher.java
@@ -1,0 +1,28 @@
+package com.smartrent.service.notification;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * Routes a {@link NotificationJob} to the {@link NotificationHandler} that
+ * supports its type.
+ */
+public class NotificationDispatcher {
+
+  private final Map<NotificationType, NotificationHandler> handlersByType;
+
+  public NotificationDispatcher(List<NotificationHandler> handlers) {
+    this.handlersByType = handlers.stream()
+        .collect(Collectors.toMap(NotificationHandler::supportedType, Function.identity()));
+  }
+
+  public void dispatch(NotificationJob job) {
+    NotificationHandler handler = handlersByType.get(job.type());
+    if (handler == null) {
+      throw new IllegalStateException("No handler registered for notification type: " + job.type());
+    }
+    handler.handle(job);
+  }
+}

--- a/smart-rent/src/main/java/com/smartrent/service/notification/NotificationHandler.java
+++ b/smart-rent/src/main/java/com/smartrent/service/notification/NotificationHandler.java
@@ -1,0 +1,11 @@
+package com.smartrent.service.notification;
+
+/**
+ * Performs the actual send for one {@link NotificationType}. Implementations run
+ * on the consumer (worker) thread, off the request path.
+ */
+public interface NotificationHandler {
+  NotificationType supportedType();
+
+  void handle(NotificationJob job);
+}

--- a/smart-rent/src/main/java/com/smartrent/service/notification/NotificationJob.java
+++ b/smart-rent/src/main/java/com/smartrent/service/notification/NotificationJob.java
@@ -1,0 +1,9 @@
+package com.smartrent.service.notification;
+
+/**
+ * A unit of work placed on the notification queue. {@code payload} is the
+ * JSON body whose shape depends on {@link #type()} (e.g. an EmailMessage for
+ * {@link NotificationType#EMAIL}).
+ */
+public record NotificationJob(NotificationType type, String payload) {
+}

--- a/smart-rent/src/main/java/com/smartrent/service/notification/NotificationPublisher.java
+++ b/smart-rent/src/main/java/com/smartrent/service/notification/NotificationPublisher.java
@@ -1,0 +1,40 @@
+package com.smartrent.service.notification;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.smartrent.infra.connector.model.EmailRequest;
+import org.springframework.stereotype.Service;
+
+/**
+ * Producer-facing API for callers that want to send a notification
+ * asynchronously. Hides the job serialization and queue details.
+ */
+@Service
+public class NotificationPublisher {
+
+  private final NotificationQueue queue;
+  private final ObjectMapper objectMapper;
+
+  public NotificationPublisher(NotificationQueue queue, ObjectMapper objectMapper) {
+    this.queue = queue;
+    this.objectMapper = objectMapper;
+  }
+
+  /** Enqueue an email to be sent on a worker thread instead of the caller's. */
+  public void publishEmail(EmailRequest request) {
+    queue.enqueue(new NotificationJob(NotificationType.EMAIL, serialize(EmailMessage.from(request))));
+  }
+
+  /** Enqueue an OTP to be delivered (with channel fallback) on a worker thread. */
+  public void publishOtp(OtpMessage message) {
+    queue.enqueue(new NotificationJob(NotificationType.OTP, serialize(message)));
+  }
+
+  private String serialize(Object message) {
+    try {
+      return objectMapper.writeValueAsString(message);
+    } catch (JsonProcessingException e) {
+      throw new IllegalStateException("Failed to serialize notification payload", e);
+    }
+  }
+}

--- a/smart-rent/src/main/java/com/smartrent/service/notification/NotificationQueue.java
+++ b/smart-rent/src/main/java/com/smartrent/service/notification/NotificationQueue.java
@@ -1,0 +1,9 @@
+package com.smartrent.service.notification;
+
+/**
+ * Producer side of the async notification pipeline. Request threads enqueue a
+ * job and return immediately; a background consumer performs the blocking send.
+ */
+public interface NotificationQueue {
+  void enqueue(NotificationJob job);
+}

--- a/smart-rent/src/main/java/com/smartrent/service/notification/NotificationStreamConsumer.java
+++ b/smart-rent/src/main/java/com/smartrent/service/notification/NotificationStreamConsumer.java
@@ -1,0 +1,44 @@
+package com.smartrent.service.notification;
+
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.connection.stream.MapRecord;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.stream.StreamListener;
+
+/**
+ * Reads notification jobs delivered to the consumer group and hands them to the
+ * {@link NotificationDispatcher}, acknowledging each message when done.
+ */
+@Slf4j
+public class NotificationStreamConsumer
+    implements StreamListener<String, MapRecord<String, String, String>> {
+
+  private final NotificationDispatcher dispatcher;
+  private final StringRedisTemplate redisTemplate;
+  private final String group;
+
+  public NotificationStreamConsumer(
+      NotificationDispatcher dispatcher, StringRedisTemplate redisTemplate, String group) {
+    this.dispatcher = dispatcher;
+    this.redisTemplate = redisTemplate;
+    this.group = group;
+  }
+
+  @Override
+  public void onMessage(MapRecord<String, String, String> message) {
+    try {
+      Map<String, String> body = message.getValue();
+      NotificationJob job =
+          new NotificationJob(NotificationType.valueOf(body.get("type")), body.get("payload"));
+      dispatcher.dispatch(job);
+    } catch (Exception e) {
+      // Acknowledge below regardless: the send path has its own retry, so a
+      // failure here is logged rather than left to poison the consumer group.
+      log.error("Failed to process notification {}: {}", message.getId(), e.getMessage(), e);
+    } finally {
+      redisTemplate.opsForStream()
+          .acknowledge(RedisStreamNotificationQueue.STREAM_KEY, group, message.getId());
+    }
+  }
+}

--- a/smart-rent/src/main/java/com/smartrent/service/notification/NotificationType.java
+++ b/smart-rent/src/main/java/com/smartrent/service/notification/NotificationType.java
@@ -1,0 +1,9 @@
+package com.smartrent.service.notification;
+
+/**
+ * Kind of asynchronous notification carried on the Redis Stream queue.
+ */
+public enum NotificationType {
+  EMAIL,
+  OTP
+}

--- a/smart-rent/src/main/java/com/smartrent/service/notification/OtpMessage.java
+++ b/smart-rent/src/main/java/com/smartrent/service/notification/OtpMessage.java
@@ -1,0 +1,17 @@
+package com.smartrent.service.notification;
+
+import com.smartrent.enums.OtpChannel;
+import java.util.List;
+
+/**
+ * Payload for an {@link NotificationType#OTP} job. Carries everything the
+ * worker needs to run the channel-fallback send (Zalo -> SMS) off the request
+ * thread. The OTP itself has already been hashed and stored before enqueueing.
+ */
+public record OtpMessage(
+    String phone,
+    String otpCode,
+    List<OtpChannel> channelOrder,
+    String requestId,
+    int expiryMinutes) {
+}

--- a/smart-rent/src/main/java/com/smartrent/service/notification/OtpNotificationHandler.java
+++ b/smart-rent/src/main/java/com/smartrent/service/notification/OtpNotificationHandler.java
@@ -1,0 +1,70 @@
+package com.smartrent.service.notification;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.smartrent.enums.OtpChannel;
+import com.smartrent.service.otp.provider.OtpProvider;
+import com.smartrent.service.otp.provider.OtpProviderResult;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Consumes {@link NotificationType#OTP} jobs and runs the channel-fallback send
+ * (e.g. Zalo -> SMS) on the worker thread, off the request path.
+ */
+@Slf4j
+public class OtpNotificationHandler implements NotificationHandler {
+
+  private final Map<OtpChannel, OtpProvider> providerMap;
+  private final ObjectMapper objectMapper;
+
+  public OtpNotificationHandler(List<OtpProvider> providers, ObjectMapper objectMapper) {
+    this.providerMap = providers.stream()
+        .collect(Collectors.toMap(OtpProvider::getChannel, Function.identity()));
+    this.objectMapper = objectMapper;
+  }
+
+  @Override
+  public NotificationType supportedType() {
+    return NotificationType.OTP;
+  }
+
+  @Override
+  public void handle(NotificationJob job) {
+    OtpMessage message = parse(job);
+
+    Map<String, Object> context = new HashMap<>();
+    context.put("requestId", message.requestId());
+    context.put("expiryMinutes", message.expiryMinutes());
+
+    for (OtpChannel channel : message.channelOrder()) {
+      OtpProvider provider = providerMap.get(channel);
+      if (provider == null || !provider.isAvailable()) {
+        log.warn("OTP provider unavailable for channel {} (requestId={})", channel,
+            message.requestId());
+        continue;
+      }
+      OtpProviderResult result = provider.sendOtp(message.phone(), message.otpCode(), context);
+      if (result.isSuccess()) {
+        log.info("OTP sent via {}: requestId={}, messageId={}", channel, message.requestId(),
+            result.getMessageId());
+        return;
+      }
+      log.warn("Failed to send OTP via {}: requestId={}, error={}", channel, message.requestId(),
+          result.getErrorMessage());
+    }
+    log.error("Failed to send OTP via all channels: requestId={}", message.requestId());
+  }
+
+  private OtpMessage parse(NotificationJob job) {
+    try {
+      return objectMapper.readValue(job.payload(), OtpMessage.class);
+    } catch (JsonProcessingException e) {
+      throw new IllegalArgumentException("Invalid OTP notification payload", e);
+    }
+  }
+}

--- a/smart-rent/src/main/java/com/smartrent/service/notification/RedisStreamNotificationQueue.java
+++ b/smart-rent/src/main/java/com/smartrent/service/notification/RedisStreamNotificationQueue.java
@@ -1,0 +1,29 @@
+package com.smartrent.service.notification;
+
+import java.util.Map;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+/**
+ * Redis Streams implementation of {@link NotificationQueue}. Jobs are appended
+ * to a single stream and consumed by a worker via a consumer group.
+ */
+@Component
+public class RedisStreamNotificationQueue implements NotificationQueue {
+
+  public static final String STREAM_KEY = "notifications:stream";
+
+  private final StringRedisTemplate redisTemplate;
+
+  public RedisStreamNotificationQueue(StringRedisTemplate redisTemplate) {
+    this.redisTemplate = redisTemplate;
+  }
+
+  @Override
+  public void enqueue(NotificationJob job) {
+    Map<String, String> body = Map.of(
+        "type", job.type().name(),
+        "payload", job.payload());
+    redisTemplate.opsForStream().add(STREAM_KEY, body);
+  }
+}

--- a/smart-rent/src/main/java/com/smartrent/service/otp/OtpService.java
+++ b/smart-rent/src/main/java/com/smartrent/service/otp/OtpService.java
@@ -10,8 +10,8 @@ import com.smartrent.infra.exception.OtpException;
 import com.smartrent.infra.exception.OtpNotFoundException;
 import com.smartrent.infra.exception.OtpVerificationException;
 import com.smartrent.infra.exception.model.DomainCode;
-import com.smartrent.service.otp.provider.OtpProvider;
-import com.smartrent.service.otp.provider.OtpProviderResult;
+import com.smartrent.service.notification.NotificationPublisher;
+import com.smartrent.service.notification.OtpMessage;
 import com.smartrent.service.otp.store.OtpData;
 import com.smartrent.service.otp.store.OtpStore;
 import com.smartrent.service.otp.util.OtpUtil;
@@ -25,8 +25,9 @@ import java.time.Instant;
 import java.util.*;
 
 /**
- * Main OTP service handling send and verify operations
- * Implements channel fallback logic: Zalo -> SMS
+ * Main OTP service handling send and verify operations.
+ * Sending is delegated to a worker thread (Redis Streams) which runs the
+ * channel fallback logic: Zalo -> SMS.
  */
 @Slf4j
 @Service
@@ -37,34 +38,31 @@ public class OtpService {
     private final OtpUtil otpUtil;
     private final PhoneNumberUtil phoneNumberUtil;
     private final RateLimitService rateLimitService;
-    private final List<OtpProvider> providers;
-    private final Map<OtpChannel, OtpProvider> providerMap;
-    
+    private final NotificationPublisher notificationPublisher;
+
     // Metrics
     private final Counter otpSendSuccessCounter;
     private final Counter otpSendFailureCounter;
     private final Counter otpVerifySuccessCounter;
     private final Counter otpVerifyFailureCounter;
-    private final Counter otpFallbackCounter;
 
     public OtpService(OtpProperties otpProperties,
                      OtpStore otpStore,
                      OtpUtil otpUtil,
                      PhoneNumberUtil phoneNumberUtil,
                      RateLimitService rateLimitService,
-                     List<OtpProvider> providers,
+                     NotificationPublisher notificationPublisher,
                      MeterRegistry meterRegistry) {
         this.otpProperties = otpProperties;
         this.otpStore = otpStore;
         this.otpUtil = otpUtil;
         this.phoneNumberUtil = phoneNumberUtil;
         this.rateLimitService = rateLimitService;
-        this.providers = providers;
-        this.providerMap = buildProviderMap(providers);
-        
+        this.notificationPublisher = notificationPublisher;
+
         // Initialize metrics
         this.otpSendSuccessCounter = Counter.builder("otp.send.success")
-            .description("Number of successful OTP sends")
+            .description("Number of OTPs accepted and enqueued for delivery")
             .register(meterRegistry);
         this.otpSendFailureCounter = Counter.builder("otp.send.failure")
             .description("Number of failed OTP sends")
@@ -75,14 +73,14 @@ public class OtpService {
         this.otpVerifyFailureCounter = Counter.builder("otp.verify.failure")
             .description("Number of failed OTP verifications")
             .register(meterRegistry);
-        this.otpFallbackCounter = Counter.builder("otp.fallback")
-            .description("Number of OTP fallbacks to secondary channel")
-            .register(meterRegistry);
     }
 
     /**
-     * Send OTP to phone number
-     * Implements fallback logic: Zalo -> SMS
+     * Send OTP to phone number.
+     *
+     * <p>The OTP is generated and stored synchronously, then the actual delivery
+     * (with Zalo -> SMS fallback) is dispatched to a worker thread so the request
+     * thread is not blocked on the provider call.
      *
      * @param request OTP send request
      * @param ipAddress Client IP address for rate limiting
@@ -90,8 +88,8 @@ public class OtpService {
      */
     public OtpSendResponse sendOtp(OtpSendRequest request, String ipAddress) {
         String requestId = UUID.randomUUID().toString();
-        
-        log.info("OTP send request: requestId={}, phone={}", requestId, 
+
+        log.info("OTP send request: requestId={}, phone={}", requestId,
             phoneNumberUtil.maskPhoneNumber(request.getPhone()));
 
         try {
@@ -110,58 +108,15 @@ public class OtpService {
 
             // 4. Determine channel order
             List<OtpChannel> channelOrder = determineChannelOrder(request.getPreferredChannels());
+            OtpChannel primaryChannel = channelOrder.get(0);
 
-            // 5. Try sending via channels with fallback
-            OtpProviderResult result = null;
-            OtpChannel usedChannel = null;
-            
-            for (int i = 0; i < channelOrder.size(); i++) {
-                OtpChannel channel = channelOrder.get(i);
-                OtpProvider provider = providerMap.get(channel);
-                
-                if (provider == null || !provider.isAvailable()) {
-                    log.warn("Provider not available for channel: {}", channel);
-                    continue;
-                }
-
-                log.info("Attempting to send OTP via {}: requestId={}", channel, requestId);
-                
-                Map<String, Object> context = new HashMap<>();
-                context.put("requestId", requestId);
-                context.put("expiryMinutes", otpProperties.getTtlSeconds() / 60);
-                
-                result = provider.sendOtp(normalizedPhone, otpCode, context);
-                
-                if (result.isSuccess()) {
-                    usedChannel = channel;
-                    log.info("OTP sent successfully via {}: requestId={}, messageId={}", 
-                        channel, requestId, result.getMessageId());
-                    break;
-                } else {
-                    log.warn("Failed to send OTP via {}: requestId={}, error={}", 
-                        channel, requestId, result.getErrorMessage());
-                    
-                    // If this is not the last channel and error is not retryable, try fallback
-                    if (i < channelOrder.size() - 1) {
-                        otpFallbackCounter.increment();
-                        log.info("Falling back to next channel: {}", channelOrder.get(i + 1));
-                    }
-                }
-            }
-
-            // 6. Check if any channel succeeded
-            if (result == null || !result.isSuccess() || usedChannel == null) {
-                log.error("Failed to send OTP via all channels: requestId={}", requestId);
-                otpSendFailureCounter.increment();
-                throw new OtpException(DomainCode.OTP_SEND_FAILED);
-            }
-
-            // 7. Store OTP data
+            // 5. Store OTP data BEFORE dispatching so verification works regardless
+            //    of async send timing.
             OtpData otpData = OtpData.builder()
                 .hashedCode(hashedCode)
                 .phone(normalizedPhone)
                 .requestId(requestId)
-                .channel(usedChannel)
+                .channel(primaryChannel)
                 .attempts(0)
                 .maxAttempts(otpProperties.getMaxVerificationAttempts())
                 .createdAt(Instant.now())
@@ -175,11 +130,15 @@ public class OtpService {
                 throw new OtpException(DomainCode.OTP_GENERATION_FAILED);
             }
 
-            // 8. Build response
+            // 6. Dispatch the actual delivery (Zalo -> SMS fallback) to a worker.
+            notificationPublisher.publishOtp(new OtpMessage(
+                normalizedPhone, otpCode, channelOrder, requestId,
+                otpProperties.getTtlSeconds() / 60));
             otpSendSuccessCounter.increment();
-            
+
+            // 7. Build response
             return OtpSendResponse.builder()
-                .channel(usedChannel.getValue())
+                .channel(primaryChannel.getValue())
                 .requestId(requestId)
                 .ttlSeconds(otpProperties.getTtlSeconds())
                 .maskedPhone(phoneNumberUtil.maskPhoneNumber(normalizedPhone))
@@ -201,7 +160,7 @@ public class OtpService {
      * @return OTP verify response
      */
     public OtpVerifyResponse verifyOtp(OtpVerifyRequest request) {
-        log.info("OTP verify request: requestId={}, phone={}", 
+        log.info("OTP verify request: requestId={}, phone={}",
             request.getRequestId(), phoneNumberUtil.maskPhoneNumber(request.getPhone()));
 
         try {
@@ -211,7 +170,7 @@ public class OtpService {
             // 2. Retrieve OTP data
             Optional<OtpData> otpDataOpt = otpStore.retrieve(normalizedPhone, request.getRequestId());
             if (otpDataOpt.isEmpty()) {
-                log.warn("OTP not found: requestId={}, phone={}", 
+                log.warn("OTP not found: requestId={}, phone={}",
                     request.getRequestId(), phoneNumberUtil.maskPhoneNumber(normalizedPhone));
                 otpVerifyFailureCounter.increment();
                 throw new OtpNotFoundException();
@@ -246,10 +205,10 @@ public class OtpService {
                 // Success: mark as verified and delete
                 otpData.setVerified(true);
                 otpStore.delete(normalizedPhone, request.getRequestId());
-                
+
                 log.info("OTP verified successfully: requestId={}", request.getRequestId());
                 otpVerifySuccessCounter.increment();
-                
+
                 return OtpVerifyResponse.builder()
                     .verified(true)
                     .message("OTP verified successfully")
@@ -259,12 +218,12 @@ public class OtpService {
                 otpData.setAttempts(otpData.getAttempts() + 1);
                 int remainingSeconds = (int) (otpData.getExpiresAt().getEpochSecond() - Instant.now().getEpochSecond());
                 otpStore.update(otpData, Math.max(0, remainingSeconds));
-                
+
                 int remainingAttempts = otpData.getMaxAttempts() - otpData.getAttempts();
-                log.warn("OTP verification failed: requestId={}, remainingAttempts={}", 
+                log.warn("OTP verification failed: requestId={}, remainingAttempts={}",
                     request.getRequestId(), remainingAttempts);
                 otpVerifyFailureCounter.increment();
-                
+
                 return OtpVerifyResponse.builder()
                     .verified(false)
                     .message("Invalid OTP code")
@@ -287,7 +246,7 @@ public class OtpService {
      */
     private List<OtpChannel> determineChannelOrder(List<String> preferredChannels) {
         List<OtpChannel> channelOrder = new ArrayList<>();
-        
+
         if (preferredChannels != null && !preferredChannels.isEmpty()) {
             for (String channelStr : preferredChannels) {
                 try {
@@ -300,7 +259,7 @@ public class OtpService {
                 }
             }
         }
-        
+
         // Add default channels if not specified
         if (!channelOrder.contains(OtpChannel.ZALO)) {
             channelOrder.add(OtpChannel.ZALO);
@@ -308,21 +267,7 @@ public class OtpService {
         if (!channelOrder.contains(OtpChannel.SMS)) {
             channelOrder.add(OtpChannel.SMS);
         }
-        
+
         return channelOrder;
     }
-
-    /**
-     * Build provider map from provider list
-     */
-    private Map<OtpChannel, OtpProvider> buildProviderMap(List<OtpProvider> providers) {
-        Map<OtpChannel, OtpProvider> map = new HashMap<>();
-        for (OtpProvider provider : providers) {
-            map.put(provider.getChannel(), provider);
-            log.info("Registered OTP provider: {} for channel: {}", 
-                provider.getProviderName(), provider.getChannel());
-        }
-        return map;
-    }
 }
-

--- a/smart-rent/src/test/java/com/smartrent/service/notification/EmailNotificationHandlerTest.java
+++ b/smart-rent/src/test/java/com/smartrent/service/notification/EmailNotificationHandlerTest.java
@@ -1,0 +1,51 @@
+package com.smartrent.service.notification;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.smartrent.infra.connector.model.EmailRequest;
+import com.smartrent.service.email.EmailService;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+
+class EmailNotificationHandlerTest {
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  @Test
+  void handle_parsesEmailPayload_andCallsEmailService() throws Exception {
+    AtomicReference<EmailRequest> sent = new AtomicReference<>();
+    EmailService fakeEmailService = req -> {
+      sent.set(req);
+      return null; // EmailResponse is unused by the async send path
+    };
+    EmailNotificationHandler handler =
+        new EmailNotificationHandler(fakeEmailService, objectMapper);
+
+    EmailMessage message = new EmailMessage(
+        "from@smartrent.vn", "SmartRent",
+        List.of(new EmailMessage.Recipient("Alice", "alice@example.com")),
+        "Verify your account", "<p>code 123456</p>");
+    NotificationJob job =
+        new NotificationJob(NotificationType.EMAIL, objectMapper.writeValueAsString(message));
+
+    handler.handle(job);
+
+    EmailRequest result = sent.get();
+    assertThat(result).isNotNull();
+    assertThat(result.getSubject()).isEqualTo("Verify your account");
+    assertThat(result.getHtmlContent()).isEqualTo("<p>code 123456</p>");
+    assertThat(result.getSender().getEmail()).isEqualTo("from@smartrent.vn");
+    assertThat(result.getSender().getName()).isEqualTo("SmartRent");
+    assertThat(result.getTo()).hasSize(1);
+    assertThat(result.getTo().get(0).getEmail()).isEqualTo("alice@example.com");
+    assertThat(result.getTo().get(0).getName()).isEqualTo("Alice");
+  }
+
+  @Test
+  void supportedType_isEmail() {
+    EmailNotificationHandler handler = new EmailNotificationHandler(null, objectMapper);
+    assertThat(handler.supportedType()).isEqualTo(NotificationType.EMAIL);
+  }
+}

--- a/smart-rent/src/test/java/com/smartrent/service/notification/NotificationDispatcherTest.java
+++ b/smart-rent/src/test/java/com/smartrent/service/notification/NotificationDispatcherTest.java
@@ -1,0 +1,46 @@
+package com.smartrent.service.notification;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class NotificationDispatcherTest {
+
+  private static NotificationHandler handlerFor(NotificationType type, List<NotificationJob> sink) {
+    return new NotificationHandler() {
+      @Override
+      public NotificationType supportedType() {
+        return type;
+      }
+
+      @Override
+      public void handle(NotificationJob job) {
+        sink.add(job);
+      }
+    };
+  }
+
+  @Test
+  void dispatch_routesJobToHandlerOfMatchingType() {
+    List<NotificationJob> handled = new ArrayList<>();
+    NotificationDispatcher dispatcher =
+        new NotificationDispatcher(List.of(handlerFor(NotificationType.EMAIL, handled)));
+    NotificationJob job = new NotificationJob(NotificationType.EMAIL, "{}");
+
+    dispatcher.dispatch(job);
+
+    assertThat(handled).containsExactly(job);
+  }
+
+  @Test
+  void dispatch_throwsWhenNoHandlerRegisteredForType() {
+    NotificationDispatcher dispatcher = new NotificationDispatcher(List.of());
+    NotificationJob job = new NotificationJob(NotificationType.EMAIL, "{}");
+
+    assertThatThrownBy(() -> dispatcher.dispatch(job))
+        .isInstanceOf(IllegalStateException.class);
+  }
+}

--- a/smart-rent/src/test/java/com/smartrent/service/notification/NotificationPublisherTest.java
+++ b/smart-rent/src/test/java/com/smartrent/service/notification/NotificationPublisherTest.java
@@ -1,0 +1,67 @@
+package com.smartrent.service.notification;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.smartrent.enums.OtpChannel;
+import com.smartrent.infra.connector.model.EmailInfo;
+import com.smartrent.infra.connector.model.EmailRequest;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class NotificationPublisherTest {
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  @Test
+  void publishEmail_enqueuesEmailJobWithSerializedMessage() throws Exception {
+    List<NotificationJob> enqueued = new ArrayList<>();
+    NotificationQueue queue = enqueued::add;
+    NotificationPublisher publisher = new NotificationPublisher(queue, objectMapper);
+
+    EmailRequest request = EmailRequest.builder()
+        .sender(EmailInfo.builder().email("from@smartrent.vn").name("SmartRent").build())
+        .to(List.of(EmailInfo.builder().name("Alice").email("alice@example.com").build()))
+        .subject("Verify your account")
+        .htmlContent("<p>code 123456</p>")
+        .build();
+
+    publisher.publishEmail(request);
+
+    assertThat(enqueued).hasSize(1);
+    NotificationJob job = enqueued.get(0);
+    assertThat(job.type()).isEqualTo(NotificationType.EMAIL);
+
+    EmailMessage message = objectMapper.readValue(job.payload(), EmailMessage.class);
+    assertThat(message.senderEmail()).isEqualTo("from@smartrent.vn");
+    assertThat(message.subject()).isEqualTo("Verify your account");
+    assertThat(message.htmlContent()).isEqualTo("<p>code 123456</p>");
+    assertThat(message.recipients()).hasSize(1);
+    assertThat(message.recipients().get(0).email()).isEqualTo("alice@example.com");
+    assertThat(message.recipients().get(0).name()).isEqualTo("Alice");
+  }
+
+  @Test
+  void publishOtp_enqueuesOtpJobWithSerializedMessage() throws Exception {
+    List<NotificationJob> enqueued = new ArrayList<>();
+    NotificationQueue queue = enqueued::add;
+    NotificationPublisher publisher = new NotificationPublisher(queue, objectMapper);
+
+    OtpMessage message = new OtpMessage(
+        "+84900000000", "123456", List.of(OtpChannel.ZALO, OtpChannel.SMS), "req-1", 5);
+
+    publisher.publishOtp(message);
+
+    assertThat(enqueued).hasSize(1);
+    NotificationJob job = enqueued.get(0);
+    assertThat(job.type()).isEqualTo(NotificationType.OTP);
+
+    OtpMessage parsed = objectMapper.readValue(job.payload(), OtpMessage.class);
+    assertThat(parsed.phone()).isEqualTo("+84900000000");
+    assertThat(parsed.otpCode()).isEqualTo("123456");
+    assertThat(parsed.channelOrder()).containsExactly(OtpChannel.ZALO, OtpChannel.SMS);
+    assertThat(parsed.requestId()).isEqualTo("req-1");
+    assertThat(parsed.expiryMinutes()).isEqualTo(5);
+  }
+}

--- a/smart-rent/src/test/java/com/smartrent/service/notification/NotificationStreamConsumerTest.java
+++ b/smart-rent/src/test/java/com/smartrent/service/notification/NotificationStreamConsumerTest.java
@@ -1,0 +1,111 @@
+package com.smartrent.service.notification;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.ServerSocket;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.connection.stream.Consumer;
+import org.springframework.data.redis.connection.stream.MapRecord;
+import org.springframework.data.redis.connection.stream.ReadOffset;
+import org.springframework.data.redis.connection.stream.StreamOffset;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.stream.StreamMessageListenerContainer;
+import org.springframework.data.redis.stream.StreamMessageListenerContainer.StreamMessageListenerContainerOptions;
+import redis.embedded.RedisServer;
+
+class NotificationStreamConsumerTest {
+
+  private static final String GROUP = "notification-workers";
+
+  private static RedisServer redisServer;
+  private static int port;
+
+  private LettuceConnectionFactory connectionFactory;
+  private StringRedisTemplate redisTemplate;
+  private StreamMessageListenerContainer<String, MapRecord<String, String, String>> container;
+
+  @BeforeAll
+  static void startRedis() throws Exception {
+    try (ServerSocket socket = new ServerSocket(0)) {
+      port = socket.getLocalPort();
+    }
+    redisServer = RedisServer.newRedisServer().port(port).build();
+    redisServer.start();
+  }
+
+  @AfterAll
+  static void stopRedis() throws Exception {
+    if (redisServer != null) {
+      redisServer.stop();
+    }
+  }
+
+  @BeforeEach
+  void setUp() {
+    connectionFactory = new LettuceConnectionFactory("localhost", port);
+    connectionFactory.afterPropertiesSet();
+    redisTemplate = new StringRedisTemplate(connectionFactory);
+    redisTemplate.afterPropertiesSet();
+    redisTemplate.getConnectionFactory().getConnection().serverCommands().flushAll();
+    // Materialise the stream then create the group reading only new messages.
+    redisTemplate.opsForStream().add(RedisStreamNotificationQueue.STREAM_KEY, Map.of("init", "1"));
+    redisTemplate.opsForStream()
+        .createGroup(RedisStreamNotificationQueue.STREAM_KEY, ReadOffset.latest(), GROUP);
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (container != null) {
+      container.stop();
+    }
+    connectionFactory.destroy();
+  }
+
+  @Test
+  void consumesEnqueuedJob_andDispatchesToMatchingHandler() throws Exception {
+    CountDownLatch latch = new CountDownLatch(1);
+    AtomicReference<NotificationJob> received = new AtomicReference<>();
+    NotificationHandler emailHandler = new NotificationHandler() {
+      @Override
+      public NotificationType supportedType() {
+        return NotificationType.EMAIL;
+      }
+
+      @Override
+      public void handle(NotificationJob job) {
+        received.set(job);
+        latch.countDown();
+      }
+    };
+    NotificationDispatcher dispatcher = new NotificationDispatcher(List.of(emailHandler));
+    NotificationStreamConsumer consumer =
+        new NotificationStreamConsumer(dispatcher, redisTemplate, GROUP);
+
+    StreamMessageListenerContainerOptions<String, MapRecord<String, String, String>> options =
+        StreamMessageListenerContainerOptions.builder().pollTimeout(Duration.ofMillis(100)).build();
+    container = StreamMessageListenerContainer.create(connectionFactory, options);
+    container.receive(
+        Consumer.from(GROUP, "worker-1"),
+        StreamOffset.create(RedisStreamNotificationQueue.STREAM_KEY, ReadOffset.lastConsumed()),
+        consumer);
+    container.start();
+
+    new RedisStreamNotificationQueue(redisTemplate)
+        .enqueue(new NotificationJob(NotificationType.EMAIL, "{\"subject\":\"hi\"}"));
+
+    assertThat(latch.await(5, TimeUnit.SECONDS)).isTrue();
+    assertThat(received.get().type()).isEqualTo(NotificationType.EMAIL);
+    assertThat(received.get().payload()).isEqualTo("{\"subject\":\"hi\"}");
+  }
+}

--- a/smart-rent/src/test/java/com/smartrent/service/notification/OtpNotificationHandlerTest.java
+++ b/smart-rent/src/test/java/com/smartrent/service/notification/OtpNotificationHandlerTest.java
@@ -1,0 +1,93 @@
+package com.smartrent.service.notification;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.smartrent.enums.OtpChannel;
+import com.smartrent.service.otp.provider.OtpProvider;
+import com.smartrent.service.otp.provider.OtpProviderResult;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class OtpNotificationHandlerTest {
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  private static OtpProvider provider(
+      OtpChannel channel, boolean available, OtpProviderResult result, List<OtpChannel> calls) {
+    return new OtpProvider() {
+      @Override
+      public OtpChannel getChannel() {
+        return channel;
+      }
+
+      @Override
+      public OtpProviderResult sendOtp(String phone, String otpCode, Map<String, Object> context) {
+        calls.add(channel);
+        return result;
+      }
+
+      @Override
+      public boolean isAvailable() {
+        return available;
+      }
+
+      @Override
+      public String getProviderName() {
+        return channel.name();
+      }
+    };
+  }
+
+  private NotificationJob otpJob(OtpMessage message) throws Exception {
+    return new NotificationJob(NotificationType.OTP, objectMapper.writeValueAsString(message));
+  }
+
+  @Test
+  void handle_sendsViaFirstChannel_andDoesNotFallBackOnSuccess() throws Exception {
+    List<OtpChannel> calls = new ArrayList<>();
+    OtpProvider zalo = provider(OtpChannel.ZALO, true, OtpProviderResult.success("msg-1"), calls);
+    OtpProvider sms = provider(OtpChannel.SMS, true, OtpProviderResult.success("msg-2"), calls);
+    OtpNotificationHandler handler = new OtpNotificationHandler(List.of(zalo, sms), objectMapper);
+
+    handler.handle(otpJob(new OtpMessage(
+        "+84900000000", "123456", List.of(OtpChannel.ZALO, OtpChannel.SMS), "req-1", 5)));
+
+    assertThat(calls).containsExactly(OtpChannel.ZALO);
+  }
+
+  @Test
+  void handle_fallsBackToNextChannel_whenFirstFails() throws Exception {
+    List<OtpChannel> calls = new ArrayList<>();
+    OtpProvider zalo =
+        provider(OtpChannel.ZALO, true, OtpProviderResult.failure("E", "down", true), calls);
+    OtpProvider sms = provider(OtpChannel.SMS, true, OtpProviderResult.success("msg-2"), calls);
+    OtpNotificationHandler handler = new OtpNotificationHandler(List.of(zalo, sms), objectMapper);
+
+    handler.handle(otpJob(new OtpMessage(
+        "+84900000000", "123456", List.of(OtpChannel.ZALO, OtpChannel.SMS), "req-1", 5)));
+
+    assertThat(calls).containsExactly(OtpChannel.ZALO, OtpChannel.SMS);
+  }
+
+  @Test
+  void handle_skipsUnavailableProvider() throws Exception {
+    List<OtpChannel> calls = new ArrayList<>();
+    OtpProvider zalo = provider(OtpChannel.ZALO, false, OtpProviderResult.success("x"), calls);
+    OtpProvider sms = provider(OtpChannel.SMS, true, OtpProviderResult.success("msg-2"), calls);
+    OtpNotificationHandler handler = new OtpNotificationHandler(List.of(zalo, sms), objectMapper);
+
+    handler.handle(otpJob(new OtpMessage(
+        "+84900000000", "123456", List.of(OtpChannel.ZALO, OtpChannel.SMS), "req-1", 5)));
+
+    assertThat(calls).containsExactly(OtpChannel.SMS);
+  }
+
+  @Test
+  void supportedType_isOtp() {
+    OtpNotificationHandler handler = new OtpNotificationHandler(List.of(), objectMapper);
+    assertThat(handler.supportedType()).isEqualTo(NotificationType.OTP);
+  }
+}

--- a/smart-rent/src/test/java/com/smartrent/service/notification/RedisStreamNotificationQueueTest.java
+++ b/smart-rent/src/test/java/com/smartrent/service/notification/RedisStreamNotificationQueueTest.java
@@ -1,0 +1,73 @@
+package com.smartrent.service.notification;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.ServerSocket;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Range;
+import org.springframework.data.redis.connection.stream.MapRecord;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import redis.embedded.RedisServer;
+
+class RedisStreamNotificationQueueTest {
+
+  private static RedisServer redisServer;
+  private static int port;
+
+  private LettuceConnectionFactory connectionFactory;
+  private StringRedisTemplate redisTemplate;
+
+  @BeforeAll
+  static void startRedis() throws Exception {
+    try (ServerSocket socket = new ServerSocket(0)) {
+      port = socket.getLocalPort();
+    }
+    redisServer = RedisServer.newRedisServer().port(port).build();
+    redisServer.start();
+  }
+
+  @AfterAll
+  static void stopRedis() throws Exception {
+    if (redisServer != null) {
+      redisServer.stop();
+    }
+  }
+
+  @BeforeEach
+  void setUp() {
+    connectionFactory = new LettuceConnectionFactory("localhost", port);
+    connectionFactory.afterPropertiesSet();
+    redisTemplate = new StringRedisTemplate(connectionFactory);
+    redisTemplate.afterPropertiesSet();
+    redisTemplate.getConnectionFactory().getConnection().serverCommands().flushAll();
+  }
+
+  @AfterEach
+  void tearDown() {
+    connectionFactory.destroy();
+  }
+
+  @Test
+  void enqueue_addsEntryToStream_withTypeAndPayload() {
+    RedisStreamNotificationQueue queue = new RedisStreamNotificationQueue(redisTemplate);
+
+    queue.enqueue(new NotificationJob(NotificationType.EMAIL, "{\"subject\":\"hi\"}"));
+
+    Long size = redisTemplate.opsForStream().size(RedisStreamNotificationQueue.STREAM_KEY);
+    assertThat(size).isEqualTo(1L);
+
+    List<MapRecord<String, Object, Object>> records =
+        redisTemplate.opsForStream().range(RedisStreamNotificationQueue.STREAM_KEY, Range.unbounded());
+    assertThat(records).hasSize(1);
+    Map<Object, Object> value = records.get(0).getValue();
+    assertThat(value.get("type")).isEqualTo("EMAIL");
+    assertThat(value.get("payload")).isEqualTo("{\"subject\":\"hi\"}");
+  }
+}

--- a/smart-rent/src/test/java/com/smartrent/service/otp/OtpServiceSendTest.java
+++ b/smart-rent/src/test/java/com/smartrent/service/otp/OtpServiceSendTest.java
@@ -1,0 +1,95 @@
+package com.smartrent.service.otp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.smartrent.config.otp.OtpProperties;
+import com.smartrent.dto.request.OtpSendRequest;
+import com.smartrent.dto.response.OtpSendResponse;
+import com.smartrent.enums.OtpChannel;
+import com.smartrent.infra.exception.OtpException;
+import com.smartrent.service.notification.NotificationPublisher;
+import com.smartrent.service.notification.OtpMessage;
+import com.smartrent.service.otp.store.OtpData;
+import com.smartrent.service.otp.store.OtpStore;
+import com.smartrent.service.otp.util.OtpUtil;
+import com.smartrent.service.otp.util.PhoneNumberUtil;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class OtpServiceSendTest {
+
+  @Mock OtpProperties otpProperties;
+  @Mock OtpStore otpStore;
+  @Mock OtpUtil otpUtil;
+  @Mock PhoneNumberUtil phoneNumberUtil;
+  @Mock RateLimitService rateLimitService;
+  @Mock NotificationPublisher notificationPublisher;
+
+  private OtpService newService() {
+    return new OtpService(otpProperties, otpStore, otpUtil, phoneNumberUtil,
+        rateLimitService, notificationPublisher, new SimpleMeterRegistry());
+  }
+
+  @Test
+  void sendOtp_storesOtpThenEnqueuesJob_andReturnsPrimaryChannel() {
+    when(phoneNumberUtil.normalizeAndValidate("0900000000")).thenReturn("+84900000000");
+    when(phoneNumberUtil.maskPhoneNumber(anyString())).thenReturn("+84*** masked");
+    when(otpUtil.generateOtpCode()).thenReturn("123456");
+    when(otpUtil.hashOtpCode("123456")).thenReturn("hashed");
+    when(otpProperties.getTtlSeconds()).thenReturn(300);
+    when(otpProperties.getMaxVerificationAttempts()).thenReturn(5);
+    when(otpStore.store(any(OtpData.class), eq(300))).thenReturn(true);
+
+    OtpSendRequest request = OtpSendRequest.builder().phone("0900000000").build();
+
+    OtpSendResponse response = newService().sendOtp(request, "1.2.3.4");
+
+    // OTP must be stored before the delivery job is enqueued.
+    InOrder inOrder = inOrder(otpStore, notificationPublisher);
+    inOrder.verify(otpStore).store(any(OtpData.class), eq(300));
+    inOrder.verify(notificationPublisher).publishOtp(any(OtpMessage.class));
+
+    ArgumentCaptor<OtpMessage> captor = ArgumentCaptor.forClass(OtpMessage.class);
+    verify(notificationPublisher).publishOtp(captor.capture());
+    OtpMessage message = captor.getValue();
+    assertThat(message.phone()).isEqualTo("+84900000000");
+    assertThat(message.otpCode()).isEqualTo("123456");
+    assertThat(message.channelOrder()).containsExactly(OtpChannel.ZALO, OtpChannel.SMS);
+    assertThat(message.expiryMinutes()).isEqualTo(5);
+
+    assertThat(response.getChannel()).isEqualTo(OtpChannel.ZALO.getValue());
+    assertThat(response.getTtlSeconds()).isEqualTo(300);
+    assertThat(response.getRequestId()).isNotBlank();
+  }
+
+  @Test
+  void sendOtp_doesNotEnqueue_whenStoreFails() {
+    when(phoneNumberUtil.normalizeAndValidate(anyString())).thenReturn("+84900000000");
+    when(phoneNumberUtil.maskPhoneNumber(anyString())).thenReturn("masked");
+    when(otpUtil.generateOtpCode()).thenReturn("123456");
+    when(otpUtil.hashOtpCode(anyString())).thenReturn("hashed");
+    when(otpProperties.getTtlSeconds()).thenReturn(300);
+    when(otpProperties.getMaxVerificationAttempts()).thenReturn(5);
+    when(otpStore.store(any(OtpData.class), eq(300))).thenReturn(false);
+
+    OtpSendRequest request = OtpSendRequest.builder().phone("0900000000").build();
+
+    assertThatThrownBy(() -> newService().sendOtp(request, "1.2.3.4"))
+        .isInstanceOf(OtpException.class);
+    verify(notificationPublisher, never()).publishOtp(any());
+  }
+}

--- a/smart-rent/src/test/resources/application-test.yml
+++ b/smart-rent/src/test/resources/application-test.yml
@@ -22,6 +22,10 @@ spring:
     compatibility-verifier:
       enabled: false
 
+notifications:
+  async:
+    enabled: false
+
 # Mock environment variables for testing
 IDENTITY_SERVICE_DB_URL: "jdbc:h2:mem:testdb"
 DB_USERNAME: "sa"


### PR DESCRIPTION
## What

Moves the blocking email/OTP provider calls (Brevo, Twilio, Zalo ZNS) off the
request thread onto a **Redis Streams** consumer group. Request threads enqueue
a job and return immediately; a worker performs the actual send.

## Why

Email/OTP were sent synchronously in the request thread:
- `ResilientEmailServiceImpl` uses `Thread.sleep` for retry backoff,
- `ZaloZnsProvider` does `.block()` with a 10s timeout,
- `TwilioVerifyProvider` calls the SDK synchronously.

Under load this saturates the Tomcat thread pool.

## Changes

- **Email**: `VerificationEmailServiceImpl.sendCode` enqueues via
  `NotificationPublisher` instead of calling `emailService.sendEmail` directly.
- **OTP**: `OtpService.sendOtp` stores the OTP first, then enqueues; the
  Zalo → SMS fallback now runs in `OtpNotificationHandler` on the worker thread.
- New `service/notification` package: producer
  (`NotificationQueue` / `RedisStreamNotificationQueue`), worker
  (`NotificationStreamConsumer` + `NotificationDispatcher` + handlers), and a
  producer-facing `NotificationPublisher`.
- `NotificationStreamConfig`: `StreamMessageListenerContainer` + consumer group
  `notification-workers`, gated by `notifications.async.enabled`
  (on by default, disabled in tests).
- Test embedded-redis swapped `it.ozimov` (Redis 2.8, no Streams) →
  `codemonstur` (Redis ≥ 6).

## Behaviour change

Email/OTP send failures now surface **asynchronously** (logged on the worker)
rather than thrown back to the caller — the API returns success once the job is
enqueued. Email keeps its internal retry via `ResilientEmailServiceImpl`.

## Operational notes

- `notifications.consumer-name` defaults to `worker-1`; set it per-instance if
  running multiple replicas.
- Failed jobs are acknowledged (logged, not infinitely retried) to avoid a
  poison message stalling the consumer group.

## Testing

`./gradlew test` — full suite green (7 new test classes, including an
embedded-Redis end-to-end consumer test that exercises enqueue → container →
dispatch → handler → ack).
