### PR TITLE
feat(logging): emit ECS JSON logs to stdout

### DIFF
--- a/smart-rent/src/main/resources/application.yml
+++ b/smart-rent/src/main/resources/application.yml
@@ -59,6 +59,16 @@ logging:
     org.springframework.web: WARN
     org.springframework.security: WARN
     org.springframework.boot.actuate: WARN
+  # Emit logs as ECS JSON to stdout so the platform (Dokploy) aggregates
+  # machine-parseable, searchable logs. Spring Boot 3.4 native structured
+  # logging — no extra dependency. The console pattern below is the fallback
+  # used when structured format is disabled (e.g. LOGGING_STRUCTURED_FORMAT_CONSOLE=).
+  structured:
+    format:
+      console: ${LOGGING_STRUCTURED_FORMAT_CONSOLE:ecs}
+    ecs:
+      service:
+        name: smartrent-backend
   pattern:
     console: "%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n"
     file: "%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n"


### PR DESCRIPTION
## What

Emit logs as **ECS JSON** to stdout using Spring Boot 3.4 native structured
logging, so the platform (Dokploy) aggregates machine-parseable, searchable
logs instead of plain console text.

## Why

The architecture review flagged centralized logging beyond Langfuse (AI traces).
Dokploy already aggregates each container's stdout; this makes that output
**structured** (ECS) so it is queryable, without standing up ELK/Loki.

## Details

- A single property in `application.yml`: `logging.structured.format.console`
  (Spring Boot 3.4 built-in — no new dependency, no separate profile file).
- Overridable via `LOGGING_STRUCTURED_FORMAT_CONSOLE` — set it empty to fall
  back to the human-readable console pattern for local debugging.
- ECS metadata `service.name=smartrent-backend`.

## Verification

Booted the jar; the first log line is ECS JSON:

```
{"@timestamp":"...","log.level":"INFO","service.name":"smartrent-backend","service.version":"0.0.1-SNAPSHOT","log.logger":"com.smartrent.SmartRentApplication","message":"Starting SmartRentApplication...","ecs.version":"8.11"}
```

Full `./gradlew test` suite green.