### PR TITLE
feat(ai): proxy chat SSE through the backend (auth + rate limit)

### DIFF
--- a/smart-rent/build.gradle
+++ b/smart-rent/build.gradle
@@ -48,6 +48,7 @@ dependencies {
     implementation 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'io.projectreactor:reactor-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     // Cloudflare R2 (AWS S3 compatible) SDK
     implementation 'software.amazon.awssdk:s3:2.25.32'

--- a/smart-rent/src/main/java/com/smartrent/config/ai/AiWebClientConfig.java
+++ b/smart-rent/src/main/java/com/smartrent/config/ai/AiWebClientConfig.java
@@ -1,0 +1,26 @@
+package com.smartrent.config.ai;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+/**
+ * WebClient for the FastAPI AI service. Used to relay the chat SSE stream.
+ * Sends the internal shared secret (when configured) so the AI service can
+ * reject public callers.
+ */
+@Configuration
+public class AiWebClientConfig {
+
+  @Bean
+  public WebClient aiWebClient(
+      @Value("${ai.base-url}") String baseUrl,
+      @Value("${ai.internal-api-key:}") String internalApiKey) {
+    WebClient.Builder builder = WebClient.builder().baseUrl(baseUrl);
+    if (internalApiKey != null && !internalApiKey.isBlank()) {
+      builder.defaultHeader("X-Internal-Api-Key", internalApiKey);
+    }
+    return builder.build();
+  }
+}

--- a/smart-rent/src/main/java/com/smartrent/controller/ChatController.java
+++ b/smart-rent/src/main/java/com/smartrent/controller/ChatController.java
@@ -3,7 +3,9 @@ package com.smartrent.controller;
 import com.smartrent.dto.request.ChatRequest;
 import com.smartrent.dto.response.ApiResponse;
 import com.smartrent.dto.response.ChatResponse;
+import com.smartrent.service.ai.ChatRateLimitService;
 import com.smartrent.service.ai.ChatService;
+import com.smartrent.service.ai.ChatStreamService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
@@ -12,12 +14,17 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.codec.ServerSentEvent;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+import reactor.core.publisher.Flux;
 
 @RestController
 @RequestMapping("/v1/ai/chat")
@@ -26,6 +33,8 @@ import org.springframework.web.bind.annotation.RestController;
 public class ChatController {
 
   private final ChatService chatService;
+  private final ChatStreamService chatStreamService;
+  private final ChatRateLimitService chatRateLimitService;
 
   @PostMapping
   @Operation(
@@ -139,5 +148,33 @@ public class ChatController {
     }
     ChatResponse response = chatService.processChat(request);
     return ApiResponse.<ChatResponse>builder().data(response).build();
+  }
+
+  @PostMapping(value = "/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+  @Operation(
+      summary = "Chat streaming (SSE) — biến thể streaming của /v1/ai/chat",
+      description = "Relay Server-Sent Events từ AI service. Yêu cầu đăng nhập; "
+          + "user_id + JWT được inject từ phiên xác thực, có rate limit theo người dùng.")
+  public Flux<ServerSentEvent<String>> chatStream(
+      @Valid @RequestBody ChatRequest request,
+      HttpServletRequest httpRequest) {
+    Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+    String identity = (auth != null && auth.isAuthenticated()
+        && !"anonymousUser".equals(auth.getName()))
+        ? auth.getName()
+        : httpRequest.getRemoteAddr();
+
+    if (!chatRateLimitService.tryConsume(identity)) {
+      throw new ResponseStatusException(HttpStatus.TOO_MANY_REQUESTS, "Chat rate limit exceeded");
+    }
+
+    if (auth != null && auth.isAuthenticated() && !"anonymousUser".equals(auth.getName())) {
+      request.setUser_id(auth.getName());
+      String authHeader = httpRequest.getHeader("Authorization");
+      if (authHeader != null && authHeader.startsWith("Bearer ")) {
+        request.setAuth_token(authHeader.substring(7));
+      }
+    }
+    return chatStreamService.streamChat(request);
   }
 }

--- a/smart-rent/src/main/java/com/smartrent/service/ai/ChatRateLimitService.java
+++ b/smart-rent/src/main/java/com/smartrent/service/ai/ChatRateLimitService.java
@@ -1,0 +1,40 @@
+package com.smartrent.service.ai;
+
+import java.time.Duration;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+/**
+ * Per-identity fixed-window rate limiter for the chat SSE endpoint. Each chat
+ * call costs LLM tokens, so this caps usage per user/IP on top of Caddy's
+ * coarser per-IP gateway limit.
+ */
+@Service
+public class ChatRateLimitService {
+
+  private static final String KEY_PREFIX = "chat:ratelimit:";
+
+  private final StringRedisTemplate redisTemplate;
+  private final int maxPerWindow;
+  private final int windowSeconds;
+
+  public ChatRateLimitService(
+      StringRedisTemplate redisTemplate,
+      @Value("${chat.rate-limit.max-per-window:20}") int maxPerWindow,
+      @Value("${chat.rate-limit.window-seconds:60}") int windowSeconds) {
+    this.redisTemplate = redisTemplate;
+    this.maxPerWindow = maxPerWindow;
+    this.windowSeconds = windowSeconds;
+  }
+
+  /** Returns true when the call is within the limit for the current window. */
+  public boolean tryConsume(String identity) {
+    String key = KEY_PREFIX + identity;
+    Long count = redisTemplate.opsForValue().increment(key);
+    if (count != null && count == 1L) {
+      redisTemplate.expire(key, Duration.ofSeconds(windowSeconds));
+    }
+    return count != null && count <= maxPerWindow;
+  }
+}

--- a/smart-rent/src/main/java/com/smartrent/service/ai/ChatStreamService.java
+++ b/smart-rent/src/main/java/com/smartrent/service/ai/ChatStreamService.java
@@ -1,0 +1,36 @@
+package com.smartrent.service.ai;
+
+import com.smartrent.dto.request.ChatRequest;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.MediaType;
+import org.springframework.http.codec.ServerSentEvent;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Flux;
+
+/**
+ * Relays the AI service's chat SSE stream so the browser talks only to the
+ * backend (authenticated + rate-limited) instead of the AI service directly.
+ */
+@Service
+public class ChatStreamService {
+
+  private static final ParameterizedTypeReference<ServerSentEvent<String>> SSE_TYPE =
+      new ParameterizedTypeReference<>() {};
+
+  private final WebClient aiWebClient;
+
+  public ChatStreamService(WebClient aiWebClient) {
+    this.aiWebClient = aiWebClient;
+  }
+
+  public Flux<ServerSentEvent<String>> streamChat(ChatRequest request) {
+    return aiWebClient.post()
+        .uri("/api/v1/chat/stream")
+        .contentType(MediaType.APPLICATION_JSON)
+        .accept(MediaType.TEXT_EVENT_STREAM)
+        .bodyValue(request)
+        .retrieve()
+        .bodyToFlux(SSE_TYPE);
+  }
+}

--- a/smart-rent/src/main/resources/application.yml
+++ b/smart-rent/src/main/resources/application.yml
@@ -292,6 +292,12 @@ application:
 google:
   maps:
     api-key: ${GOOGLE_API_KEY}
+
+# AI service (FastAPI) — used by the WebClient that relays chat SSE.
+ai:
+  base-url: "${AI_SERVICE_BASE_URL:http://localhost:8000}"
+  internal-api-key: "${INTERNAL_AI_API_KEY:}"
+
 feign:
   client:
     config:

--- a/smart-rent/src/main/resources/application.yml
+++ b/smart-rent/src/main/resources/application.yml
@@ -298,6 +298,13 @@ ai:
   base-url: "${AI_SERVICE_BASE_URL:http://localhost:8000}"
   internal-api-key: "${INTERNAL_AI_API_KEY:}"
 
+# Per-user rate limit for the chat SSE endpoint (each call costs LLM tokens).
+# Caddy already caps /v1/* at 120/min/IP; this is a tighter per-identity cap.
+chat:
+  rate-limit:
+    max-per-window: ${CHAT_RATE_LIMIT_MAX:20}
+    window-seconds: ${CHAT_RATE_LIMIT_WINDOW_SECONDS:60}
+
 feign:
   client:
     config:

--- a/smart-rent/src/test/java/com/smartrent/service/ai/ChatRateLimitServiceTest.java
+++ b/smart-rent/src/test/java/com/smartrent/service/ai/ChatRateLimitServiceTest.java
@@ -1,0 +1,55 @@
+package com.smartrent.service.ai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.ServerSocket;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import redis.embedded.RedisServer;
+
+class ChatRateLimitServiceTest {
+
+  private static RedisServer redisServer;
+  private static int port;
+  private StringRedisTemplate redisTemplate;
+
+  @BeforeAll
+  static void startRedis() throws Exception {
+    try (ServerSocket socket = new ServerSocket(0)) {
+      port = socket.getLocalPort();
+    }
+    redisServer = RedisServer.newRedisServer().port(port).build();
+    redisServer.start();
+  }
+
+  @AfterAll
+  static void stopRedis() throws Exception {
+    if (redisServer != null) {
+      redisServer.stop();
+    }
+  }
+
+  @BeforeEach
+  void setUp() {
+    LettuceConnectionFactory cf = new LettuceConnectionFactory("localhost", port);
+    cf.afterPropertiesSet();
+    redisTemplate = new StringRedisTemplate(cf);
+    redisTemplate.afterPropertiesSet();
+    redisTemplate.getConnectionFactory().getConnection().serverCommands().flushAll();
+  }
+
+  @Test
+  void tryConsume_allowsUpToLimitThenBlocks() {
+    ChatRateLimitService service = new ChatRateLimitService(redisTemplate, 3, 60);
+
+    assertThat(service.tryConsume("user-1")).isTrue();
+    assertThat(service.tryConsume("user-1")).isTrue();
+    assertThat(service.tryConsume("user-1")).isTrue();
+    assertThat(service.tryConsume("user-1")).isFalse(); // 4th in window -> blocked
+    assertThat(service.tryConsume("user-2")).isTrue(); // separate identity unaffected
+  }
+}

--- a/smart-rent/src/test/java/com/smartrent/service/ai/ChatStreamServiceTest.java
+++ b/smart-rent/src/test/java/com/smartrent/service/ai/ChatStreamServiceTest.java
@@ -1,0 +1,53 @@
+package com.smartrent.service.ai;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.smartrent.dto.request.ChatRequest;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.codec.ServerSentEvent;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.test.StepVerifier;
+
+class ChatStreamServiceTest {
+
+  private WireMockServer wireMock;
+  private ChatStreamService service;
+
+  @BeforeEach
+  void setUp() {
+    wireMock = new WireMockServer(0);
+    wireMock.start();
+    WebClient client = WebClient.builder().baseUrl("http://localhost:" + wireMock.port()).build();
+    service = new ChatStreamService(client);
+  }
+
+  @AfterEach
+  void tearDown() {
+    wireMock.stop();
+  }
+
+  @Test
+  void streamChat_relaysSseEventsFromAiService() {
+    wireMock.stubFor(post(urlEqualTo("/api/v1/chat/stream"))
+        .willReturn(aResponse()
+            .withHeader("Content-Type", "text/event-stream")
+            .withBody("event: status\ndata: {\"phase\":\"thinking\"}\n\n"
+                + "event: text\ndata: {\"delta\":\"hello\"}\n\n"
+                + "event: done\ndata: {}\n\n")));
+
+    ChatRequest request = new ChatRequest();
+    request.setMessages(List.of());
+
+    StepVerifier.create(service.streamChat(request).map(ServerSentEvent::event))
+        .expectNext("status")
+        .expectNext("text")
+        .expectNext("done")
+        .verifyComplete();
+  }
+}


### PR DESCRIPTION
Streaming sibling of the existing `/v1/ai/chat` proxy. Routes chat SSE through the backend (authenticated + rate-limited) instead of the browser hitting the AI service directly.

- `ChatStreamService` relays AI `/api/v1/chat/stream` via `WebClient` as `Flux<ServerSentEvent>` (WireMock + StepVerifier).
- `ChatRateLimitService`: per-user Redis fixed-window cap (each chat call costs LLM tokens).
- `POST /v1/ai/chat/stream`: injects `user_id` + JWT from the session, 429 on over-rate, relays the SSE. **Authenticated → streaming chat now requires login.**
- `AiWebClientConfig` sends `X-Internal-Api-Key` when `ai.internal-api-key` is set.

Part of **Option A** (close the direct-to-AI chat exposure). Deploy must set `INTERNAL_AI_API_KEY`; the smartrent-fe PR repoints to this endpoint and should deploy **after** this.

Verified: `./gradlew test` full suite green.