### PR TITLE
fix(listing-search): resolve districtCode to PK, validate location codes, 404 on missing listing

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/dto/request/ListingFilterRequest.java
+++ b/smart-rent/src/main/java/com/smartrent/dto/request/ListingFilterRequest.java
@@ -87,8 +87,16 @@ public class ListingFilterRequest {
     @Schema(hidden = true)
     List<String> resolvedNewProvinceCodes; // Populated by service layer when legacy provinceId is sent — NOT from API
 
-    @Schema(description = "District ID (OLD structure)", example = "5")
+    @Schema(description = "District ID (OLD structure) — the legacy_districts surrogate PK, "
+            + "NOT the GSO administrative code. Emitted by the FE district dropdown.", example = "5")
     Integer districtId;
+
+    @Schema(description = """
+            District GSO administrative code (e.g. '760' = Quận 1, '765' = Bình Thạnh).
+            Use this when you only know the official district code, not the internal
+            legacy_districts PK. The service resolves it to districtId before filtering.
+            """, example = "760")
+    String districtCode;
 
     @JsonIgnore
     @Schema(hidden = true)

--- a/smart-rent/src/main/java/com/smartrent/infra/exception/model/DomainCode.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/exception/model/DomainCode.java
@@ -22,6 +22,8 @@ public enum DomainCode {
   PASSWORD_SAME("2008", HttpStatus.BAD_REQUEST, "The same password"),
   INVALID_PAGE("2009", HttpStatus.BAD_REQUEST, "Invalid page"),
   INVALID_PAGE_SIZE("2010", HttpStatus.BAD_REQUEST, "Invalid page size"),
+  INVALID_DISTRICT_CODE("2011", HttpStatus.BAD_REQUEST, "Unknown district code '%s'. Provide a valid GSO district code."),
+  INVALID_PROVINCE_CODE("2012", HttpStatus.BAD_REQUEST, "Unknown province code '%s'. Provide a valid province code."),
   //    Existing Error 3xxx
   EMAIL_EXISTING("3001", HttpStatus.CONFLICT, "Email already exists"),
   PHONE_EXISTING("3002", HttpStatus.CONFLICT, "Phone already exists"),

--- a/smart-rent/src/main/java/com/smartrent/service/listing/impl/ListingServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/listing/impl/ListingServiceImpl.java
@@ -560,7 +560,7 @@ public class ListingServiceImpl implements ListingService {
 
         // Fetch listing with amenities first
         Listing listing = listingRepository.findByIdWithAmenities(id)
-                .orElseThrow(() -> new RuntimeException("Listing not found"));
+                .orElseThrow(() -> new DomainException(DomainCode.LISTING_NOT_FOUND));
 
         // Fetch media separately to avoid MultipleBagFetchException
         listingRepository.findByIdWithMedia(id);
@@ -1487,6 +1487,35 @@ public class ListingServiceImpl implements ListingService {
      * /properties listing-page total for the same navigation params.
      */
     private void resolveAddressMappings(ListingFilterRequest filter) {
+        // Resolve districtCode (GSO administrative code, e.g. "760" = Quận 1) to the
+        // legacy_districts surrogate PK that the spec actually filters on. Callers
+        // that only know the official code — the AI chatbot tool, external API
+        // clients — send districtCode; the FE dropdown sends the PK as districtId.
+        // legacy_districts.district_code is globally UNIQUE so the lookup is exact.
+        // Only fill districtId when it is absent so an explicit PK always wins.
+        if (filter.getDistrictId() == null
+                && filter.getDistrictCode() != null && !filter.getDistrictCode().isBlank()) {
+            String code = filter.getDistrictCode().trim();
+            District district = legacyDistrictRepository.findByCode(code).orElse(null);
+            if (district == null) {
+                // Seed stores codes without leading zeros (e.g. "1" not "001"), but a
+                // caller may send the zero-padded GSO form — retry on the stripped code.
+                String stripped = code.replaceFirst("^0+(?!$)", "");
+                if (!stripped.equals(code)) {
+                    district = legacyDistrictRepository.findByCode(stripped).orElse(null);
+                }
+            }
+            if (district != null) {
+                filter.setDistrictId(district.getId());
+                log.info("Resolved districtCode {} → legacy_district_id PK {}", code, district.getId());
+            } else {
+                // Fail loudly: a silently-dropped district filter returns
+                // over-broad/zero results that hide the caller's mistake.
+                log.warn("districtCode {} not found in legacy_districts — rejecting request", code);
+                throw new DomainException(DomainCode.INVALID_DISTRICT_CODE, code);
+            }
+        }
+
         // Merge single provinceCode into provinceCodes list (FE typically sends provinceCode singular)
         if (filter.getProvinceCode() != null && !filter.getProvinceCode().isBlank()) {
             List<String> merged = new ArrayList<>();
@@ -1529,7 +1558,12 @@ public class ListingServiceImpl implements ListingService {
                 if (!legacyIds.isEmpty()) {
                     log.info("Resolved province codes {} → legacy IDs {} (via direct LegacyProvince lookup)", codesToQuery, legacyIds);
                 } else {
-                    log.warn("No legacy IDs resolved for province codes {} — old-structure listings won't be included", codesToQuery);
+                    // Neither address_mapping nor a direct legacy lookup knows this
+                    // code → it is genuinely invalid. Fail loudly (400) instead of
+                    // returning a silent 0-result search that hides the mistake.
+                    log.warn("No legacy IDs resolved for province codes {} — rejecting request", codesToQuery);
+                    throw new DomainException(DomainCode.INVALID_PROVINCE_CODE,
+                            String.join(",", filter.getProvinceCodes()));
                 }
             }
             if (!legacyIds.isEmpty()) {

--- a/smart-rent/src/test/java/com/smartrent/service/listing/impl/ListingServiceImplDistrictCodeTest.java
+++ b/smart-rent/src/test/java/com/smartrent/service/listing/impl/ListingServiceImplDistrictCodeTest.java
@@ -1,0 +1,101 @@
+package com.smartrent.service.listing.impl;
+
+import com.smartrent.dto.request.ListingFilterRequest;
+import com.smartrent.infra.exception.DomainException;
+import com.smartrent.infra.exception.model.DomainCode;
+import com.smartrent.infra.repository.AddressMappingRepository;
+import com.smartrent.infra.repository.LegacyDistrictRepository;
+import com.smartrent.infra.repository.LegacyProvinceRepository;
+import com.smartrent.infra.repository.entity.District;
+import com.smartrent.service.listing.ListingQueryService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+
+import java.util.Collections;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
+
+/**
+ * Regression for the chatbot "tìm trọ quận 1 → 0 results" bug.
+ *
+ * <p>The AI tool knows districts by their GSO administrative code (760 = Quận 1),
+ * but {@link com.smartrent.infra.repository.specification.ListingSpecification}
+ * matches {@code addresses.legacy_district_id} against the legacy_districts
+ * surrogate PK (Quận 1 = 541). Sending the code 760 as districtId matched no
+ * address, so every Quận 1 listing was filtered out. The service must resolve a
+ * districtCode to the surrogate PK before building the specification.
+ */
+@ExtendWith(MockitoExtension.class)
+class ListingServiceImplDistrictCodeTest {
+
+    @Mock
+    LegacyDistrictRepository legacyDistrictRepository;
+    @Mock
+    LegacyProvinceRepository legacyProvinceRepository;
+    @Mock
+    AddressMappingRepository addressMappingRepository;
+    @Mock
+    ListingQueryService listingQueryService;
+
+    @InjectMocks
+    ListingServiceImpl service;
+
+    @Test
+    void resolvesDistrictCodeToLegacyDistrictSurrogatePk() {
+        // Quận 1: GSO district_code "760" → legacy_districts PK 541 (see V37 seed / DB).
+        when(legacyDistrictRepository.findByCode("760"))
+                .thenReturn(Optional.of(District.builder().id(541).code("760").build()));
+        lenient().when(addressMappingRepository.findNewWardCodesByLegacyDistrictId(541))
+                .thenReturn(Collections.emptyList());
+
+        ArgumentCaptor<ListingFilterRequest> captor =
+                ArgumentCaptor.forClass(ListingFilterRequest.class);
+        when(listingQueryService.executeQuery(captor.capture())).thenReturn(Page.empty());
+
+        service.searchListings(ListingFilterRequest.builder().districtCode("760").build());
+
+        // The specification only understands the surrogate PK, so the resolved
+        // districtId — not the raw GSO code — is what reaches the query.
+        assertEquals(Integer.valueOf(541), captor.getValue().getDistrictId());
+    }
+
+    @Test
+    void throwsBadRequestOnUnknownDistrictCode() {
+        // An unknown code must fail loudly (400) instead of silently dropping the
+        // district filter and returning over-broad/zero results that hide the
+        // AI's mistake.
+        when(legacyDistrictRepository.findByCode("999")).thenReturn(Optional.empty());
+        lenient().when(listingQueryService.executeQuery(org.mockito.ArgumentMatchers.any()))
+                .thenReturn(Page.empty());
+
+        DomainException ex = assertThrows(DomainException.class, () ->
+                service.searchListings(ListingFilterRequest.builder().districtCode("999").build()));
+        assertEquals(DomainCode.INVALID_DISTRICT_CODE, ex.getDomainCode());
+    }
+
+    @Test
+    void throwsBadRequestOnUnknownProvinceCode() {
+        // A province code that resolves to no legacy id AND no direct province is
+        // genuinely unknown → 400, not a silent 0-result search.
+        when(addressMappingRepository.findNewCodeToLegacyIdPairs(anyList()))
+                .thenReturn(Collections.emptyList());
+        when(legacyProvinceRepository.findByCodeIn(anyList()))
+                .thenReturn(Collections.emptyList());
+        lenient().when(listingQueryService.executeQuery(org.mockito.ArgumentMatchers.any()))
+                .thenReturn(Page.empty());
+
+        DomainException ex = assertThrows(DomainException.class, () ->
+                service.searchListings(ListingFilterRequest.builder().provinceCode("ZZ").build()));
+        assertEquals(DomainCode.INVALID_PROVINCE_CODE, ex.getDomainCode());
+    }
+}

--- a/smart-rent/src/test/java/com/smartrent/service/listing/impl/ListingServiceImplGetByIdTest.java
+++ b/smart-rent/src/test/java/com/smartrent/service/listing/impl/ListingServiceImplGetByIdTest.java
@@ -1,0 +1,40 @@
+package com.smartrent.service.listing.impl;
+
+import com.smartrent.infra.exception.DomainException;
+import com.smartrent.infra.exception.model.DomainCode;
+import com.smartrent.infra.repository.ListingRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+/**
+ * A non-existent listing id must surface as 404 LISTING_NOT_FOUND, not a 500.
+ * The AI's get_listing_detail tool has dedicated 404 handling that never fired
+ * because the service threw a plain RuntimeException (→ catch-all 500).
+ */
+@ExtendWith(MockitoExtension.class)
+class ListingServiceImplGetByIdTest {
+
+    @Mock
+    ListingRepository listingRepository;
+
+    @InjectMocks
+    ListingServiceImpl service;
+
+    @Test
+    void throwsListingNotFoundWhenMissing() {
+        when(listingRepository.findByIdWithAmenities(123L)).thenReturn(Optional.empty());
+
+        DomainException ex = assertThrows(DomainException.class,
+                () -> service.getListingById(123L));
+        assertEquals(DomainCode.LISTING_NOT_FOUND, ex.getDomainCode());
+    }
+}


### PR DESCRIPTION
## What & why

The AI chatbot filters listings by district using the **GSO administrative code** (e.g. `760` = Quận 1), but `ListingSpecification` matches `addresses.legacy_district_id` against the **legacy_districts surrogate PK** (Quận 1 = `541`). Sending `760` matched no address, so every Quận 1 listing was silently filtered out ("tìm trọ quận 1 → 0 kết quả"). This PR fixes the resolution and makes the whole class of bad-param mistakes fail loudly.

## Changes

- **Resolve `districtCode` → PK.** New `districtCode` field on `ListingFilterRequest`; `resolveAddressMappings` looks it up via `legacy_districts.district_code` (UNIQUE) and sets the real `districtId` before the spec runs. Backward compatible — the FE keeps sending the PK as `districtId`.
- **Fail loudly on unknown location codes.** Unknown `districtCode`/`provinceCode` now return **400** (`INVALID_DISTRICT_CODE` / `INVALID_PROVINCE_CODE`) instead of silently dropping the filter or returning an empty set.
- **404 not 500 for missing listing.** `getListingById` throws `DomainException(LISTING_NOT_FOUND)` (404) instead of a plain `RuntimeException` (500), so clients' 404 handling works.

## Tests

- `ListingServiceImplDistrictCodeTest` — districtCode → PK 541 resolution; 400 on unknown district/province code.
- `ListingServiceImplGetByIdTest` — 404 on missing listing.
- `./gradlew test --tests "com.smartrent.service.listing.*"` green.

## Note for reviewer

`resolveAddressMappings` is shared with homepage stats / cursor search. The FE only sends valid codes, so the new 400s are safe — worth a smoke test of those paths after merge.

