### PR TITLE
fix(listing-search): bound page/size + @Valid on /listings/search

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/controller/ListingSearchController.java
+++ b/smart-rent/src/main/java/com/smartrent/controller/ListingSearchController.java
@@ -152,7 +152,7 @@ public class ListingSearchController {
         }
     )
     public ApiResponse<ListingCardListResponse> searchListings(
-            @RequestBody(required = false) ListingFilterRequest filter,
+            @Valid @RequestBody(required = false) ListingFilterRequest filter,
             Authentication authentication) {
 
         if (filter == null) {

--- a/smart-rent/src/main/java/com/smartrent/dto/request/ListingFilterRequest.java
+++ b/smart-rent/src/main/java/com/smartrent/dto/request/ListingFilterRequest.java
@@ -2,6 +2,8 @@ package com.smartrent.dto.request;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -300,10 +302,13 @@ public class ListingFilterRequest {
 
     // ============ PAGINATION & SORTING ============
     @Schema(description = "Page number (one-based)", example = "1", defaultValue = "1")
+    @Min(value = 1, message = "page must be >= 1")
     @Builder.Default
     Integer page = 1;
 
     @Schema(description = "Page size (max 100)", example = "20", defaultValue = "20")
+    @Min(value = 1, message = "size must be >= 1")
+    @Max(value = 100, message = "size must be <= 100")
     @Builder.Default
     Integer size = 20;
 

--- a/smart-rent/src/test/java/com/smartrent/dto/request/ListingFilterRequestValidationTest.java
+++ b/smart-rent/src/test/java/com/smartrent/dto/request/ListingFilterRequestValidationTest.java
@@ -1,0 +1,42 @@
+package com.smartrent.dto.request;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Bounds on page/size so a bad client (e.g. the AI tool) gets a clear 400 via
+ * @Valid on the controller instead of a runaway full-table scan.
+ */
+class ListingFilterRequestValidationTest {
+
+    private final Validator validator =
+            Validation.buildDefaultValidatorFactory().getValidator();
+
+    @Test
+    void rejectsSizeAboveMax() {
+        Set<ConstraintViolation<ListingFilterRequest>> v =
+                validator.validate(ListingFilterRequest.builder().size(999).build());
+        assertFalse(v.isEmpty());
+    }
+
+    @Test
+    void rejectsPageBelowOne() {
+        Set<ConstraintViolation<ListingFilterRequest>> v =
+                validator.validate(ListingFilterRequest.builder().page(0).build());
+        assertFalse(v.isEmpty());
+    }
+
+    @Test
+    void acceptsInRangePageAndSize() {
+        Set<ConstraintViolation<ListingFilterRequest>> v =
+                validator.validate(ListingFilterRequest.builder().page(1).size(20).build());
+        assertTrue(v.isEmpty());
+    }
+}


### PR DESCRIPTION
Tier 1 hardening for the listing search endpoint.

## Changes
- `ListingFilterRequest`: `@Min(1)` on `page`; `@Min(1)` + `@Max(100)` on `size`.
- `ListingSearchController.searchListings`: add `@Valid` so those bounds are enforced → out-of-range page/size returns a clear **400** instead of a runaway full-table scan. `@Valid` is a no-op when the body is null (the method already handles that).

FE-safe: the FE/AI send in-range values; only genuinely out-of-range requests are rejected. `@Min/@Max` skip null, so an omitted size is unaffected.

## Tests
`ListingFilterRequestValidationTest` (Validator-based): rejects size=999, rejects page=0, accepts page=1/size=20. Listing service tests still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
