### PR TITLE
feat(ai-moderation): prioritize VIP listings in AI verification batch

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/infra/repository/ListingRepository.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/ListingRepository.java
@@ -75,7 +75,7 @@ public interface ListingRepository extends JpaRepository<Listing, Long>, JpaSpec
         AND (l.moderationStatus IS NULL
              OR l.moderationStatus = com.smartrent.enums.ModerationStatus.PENDING_REVIEW
              OR l.moderationStatus = com.smartrent.enums.ModerationStatus.RESUBMITTED)
-        ORDER BY l.createdAt DESC
+        ORDER BY l.vipTypeSortOrder ASC, l.createdAt DESC
     """)
     Page<Listing> findListingsNeedingAiVerification(Pageable pageable);
 


### PR DESCRIPTION
Sort by vipTypeSortOrder ASC before createdAt DESC so Diamond > Gold > Silver > Normal listings are processed first in each 20-listing batch.