### PR TITLE
perf(ai-moderation): parallel verify+duplicate and dedicated I/O thre…

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/cronjob/AiListingAutoModerationScheduler.java
+++ b/smart-rent/src/main/java/com/smartrent/cronjob/AiListingAutoModerationScheduler.java
@@ -5,8 +5,10 @@ import com.smartrent.infra.repository.ListingRepository;
 import com.smartrent.infra.repository.entity.Listing;
 import com.smartrent.infra.repository.entity.ListingAiModeration;
 import com.smartrent.infra.repository.entity.enums.VerificationStatus;
+import com.smartrent.service.ai.AiModerationExecutor;
 import com.smartrent.service.ai.AiModerationProcessorService;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -16,9 +18,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.IntStream;
-import org.springframework.beans.factory.annotation.Value;
 
 @Component
 @Slf4j
@@ -38,6 +40,8 @@ public class AiListingAutoModerationScheduler {
      */
     private final AiModerationProcessorService aiModerationProcessorService;
 
+    private final AiModerationExecutor aiModerationExecutor;
+
     /**
      * Runtime toggle — controlled via the admin API.
      * Initialized from config so AI_SCHEDULER_ENABLED=false at startup
@@ -49,10 +53,12 @@ public class AiListingAutoModerationScheduler {
             ListingRepository listingRepository,
             ListingAiModerationRepository listingAiModerationRepository,
             AiModerationProcessorService aiModerationProcessorService,
+            AiModerationExecutor aiModerationExecutor,
             @Value("${smartrent.ai.verification.scheduler.enabled:true}") boolean initiallyEnabled) {
         this.listingRepository = listingRepository;
         this.listingAiModerationRepository = listingAiModerationRepository;
         this.aiModerationProcessorService = aiModerationProcessorService;
+        this.aiModerationExecutor = aiModerationExecutor;
         this.aiAutoModerationEnabled = new AtomicBoolean(initiallyEnabled);
     }
 
@@ -100,9 +106,12 @@ public class AiListingAutoModerationScheduler {
      * <p>Strategy:
      * <ol>
      *   <li>Load a page of pending listings in a single read transaction.</li>
-     *   <li>Mark each as IN_PROGRESS (batch commit) before dispatching to AI.</li>
+     *   <li>Batch-mark all as IN_PROGRESS in one query before dispatching.</li>
      *   <li>Call {@link AiModerationProcessorService#processSingleListing} for each listing
-     *       via the Spring proxy so each item runs in its own {@code REQUIRES_NEW} transaction.</li>
+     *       via the Spring proxy so each item runs in its own {@code REQUIRES_NEW} transaction.
+     *       Tasks run concurrently on {@link AiModerationExecutor#batchPool()} — a dedicated
+     *       I/O pool sized for the batch — instead of the shared ForkJoinPool which is
+     *       designed for CPU-bound work and limited to {@code cores - 1} threads.</li>
      * </ol>
      */
     @Scheduled(fixedDelayString = "${smartrent.ai.verification.scheduler.delay:300000}")
@@ -114,7 +123,6 @@ public class AiListingAutoModerationScheduler {
         log.info("Starting AI Auto Moderation Scheduler...");
 
         try {
-            // Process in batches of 20
             Page<Listing> pendingListings = listingRepository.findListingsNeedingAiVerification(PageRequest.of(0, 20));
             List<Listing> listings = pendingListings.getContent();
 
@@ -125,29 +133,35 @@ public class AiListingAutoModerationScheduler {
 
             log.info("Found {} listings to process", listings.size());
 
-            // 1. Mark each listing as IN_PROGRESS before dispatching
-            List<ListingAiModeration> moderations = listings.stream().map(listing -> {
-                ListingAiModeration moderation = listingAiModerationRepository.findById(listing.getListingId())
-                    .orElse(ListingAiModeration.builder()
+            // 1. Upsert moderation records, then batch-mark all as IN_PROGRESS in one query.
+            List<ListingAiModeration> moderations = listings.stream().map(listing ->
+                listingAiModerationRepository.findById(listing.getListingId())
+                    .orElseGet(() -> ListingAiModeration.builder()
                         .listingId(listing.getListingId())
                         .retryCount(0)
                         .manualOverride(false)
-                        .build());
-                moderation.setVerificationStatus(VerificationStatus.IN_PROGRESS);
-                return listingAiModerationRepository.saveAndFlush(moderation);
-            }).toList();
+                        .build())
+            ).toList();
+            listingAiModerationRepository.saveAll(moderations);
 
-            // 2. Process listings in parallel.
+            List<Long> listingIds = listings.stream().map(Listing::getListingId).toList();
+            listingAiModerationRepository.markListingsAsInProgress(listingIds);
+
+            // 2. Process listings concurrently on the dedicated I/O thread pool.
             //    Each call goes through the Spring AOP proxy on aiModerationProcessorService,
             //    so @Transactional(REQUIRES_NEW) is correctly applied per listing.
-            IntStream.range(0, listings.size()).parallel().forEach(i -> {
-                try {
-                    aiModerationProcessorService.processSingleListing(listings.get(i), moderations.get(i));
-                } catch (Exception e) {
-                    log.error("Failed to process listing ID: {} in parallel batch",
-                        listings.get(i).getListingId(), e);
-                }
-            });
+            List<CompletableFuture<Void>> futures = IntStream.range(0, listings.size())
+                .mapToObj(i -> CompletableFuture.runAsync(() -> {
+                    try {
+                        aiModerationProcessorService.processSingleListing(listings.get(i), moderations.get(i));
+                    } catch (Exception e) {
+                        log.error("Failed to process listing ID: {} in parallel batch",
+                            listings.get(i).getListingId(), e);
+                    }
+                }, aiModerationExecutor.batchPool()))
+                .toList();
+
+            CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
 
         } catch (Exception e) {
             log.error("Error in AI Auto Moderation Scheduler", e);

--- a/smart-rent/src/main/java/com/smartrent/infra/repository/ListingAiModerationRepository.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/ListingAiModerationRepository.java
@@ -6,12 +6,14 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
 @Repository
 public interface ListingAiModerationRepository extends JpaRepository<ListingAiModeration, Long> {
 
+    @Transactional
     @Modifying
     @Query("""
         UPDATE listing_ai_moderation lam
@@ -21,6 +23,7 @@ public interface ListingAiModerationRepository extends JpaRepository<ListingAiMo
     """)
     int markListingsAsInProgress(@Param("listingIds") List<Long> listingIds);
 
+    @Transactional
     @Modifying
     @Query("""
         UPDATE listing_ai_moderation lam

--- a/smart-rent/src/main/java/com/smartrent/service/ai/AiModerationExecutor.java
+++ b/smart-rent/src/main/java/com/smartrent/service/ai/AiModerationExecutor.java
@@ -1,0 +1,86 @@
+package com.smartrent.service.ai;
+
+import jakarta.annotation.PreDestroy;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Dedicated thread pools for AI-driven listing moderation.
+ *
+ * <p>Two isolated pools prevent the deadlock that would occur if the batch-level
+ * parallelism and the per-listing fan-out shared a single pool:
+ *
+ * <ul>
+ *   <li>{@link #batchPool()} — runs one task per listing in the scheduler batch (up to 20
+ *       concurrent listings).  Each task blocks while waiting for the AI service to respond,
+ *       so the pool is sized for I/O concurrency rather than CPU cores.</li>
+ *   <li>{@link #taskPool()} — runs the verify + duplicate-check fan-out within each listing
+ *       (2 tasks per listing). Kept separate to avoid the deadlock that would arise if
+ *       batch-pool threads blocked waiting for sub-tasks queued on the same pool.</li>
+ * </ul>
+ *
+ * <p>{@link ThreadPoolExecutor.CallerRunsPolicy} provides graceful back-pressure: when a pool
+ * is saturated the calling thread executes the task directly, preventing queue overflow and
+ * maintaining forward progress without throwing {@link java.util.concurrent.RejectedExecutionException}.
+ * Daemon threads ensure neither pool blocks JVM shutdown.
+ */
+@Slf4j
+@Component
+public class AiModerationExecutor {
+
+    private final ThreadPoolExecutor batchPool = new ThreadPoolExecutor(
+            20, 20,
+            60L, TimeUnit.SECONDS,
+            new ArrayBlockingQueue<>(40),
+            r -> {
+                Thread t = new Thread(r, "ai-mod-batch");
+                t.setDaemon(true);
+                return t;
+            },
+            new ThreadPoolExecutor.CallerRunsPolicy());
+
+    private final ThreadPoolExecutor taskPool = new ThreadPoolExecutor(
+            16, 32,
+            60L, TimeUnit.SECONDS,
+            new ArrayBlockingQueue<>(128),
+            r -> {
+                Thread t = new Thread(r, "ai-mod-task");
+                t.setDaemon(true);
+                return t;
+            },
+            new ThreadPoolExecutor.CallerRunsPolicy());
+
+    /** For parallel processing of multiple listings in the scheduler batch. */
+    public Executor batchPool() {
+        return batchPool;
+    }
+
+    /** For parallel verify + duplicate-check fan-out within a single listing. */
+    public Executor taskPool() {
+        return taskPool;
+    }
+
+    @PreDestroy
+    void shutdown() {
+        shutdownPool(batchPool, "ai-mod-batch");
+        shutdownPool(taskPool, "ai-mod-task");
+    }
+
+    private void shutdownPool(ThreadPoolExecutor pool, String name) {
+        pool.shutdown();
+        try {
+            if (!pool.awaitTermination(10, TimeUnit.SECONDS)) {
+                pool.shutdownNow();
+                log.warn("Thread pool '{}' did not terminate gracefully.", name);
+            }
+        } catch (InterruptedException e) {
+            pool.shutdownNow();
+            Thread.currentThread().interrupt();
+        }
+    }
+}

--- a/smart-rent/src/main/java/com/smartrent/service/ai/impl/AiModerationProcessorServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/ai/impl/AiModerationProcessorServiceImpl.java
@@ -18,6 +18,7 @@ import com.smartrent.infra.repository.entity.Listing;
 import com.smartrent.infra.repository.entity.ListingAiModeration;
 import com.smartrent.infra.repository.entity.enums.VerificationStatus;
 import com.smartrent.service.ai.AiListingVerificationService;
+import com.smartrent.service.ai.AiModerationExecutor;
 import com.smartrent.service.ai.AiModerationProcessorService;
 import com.smartrent.service.notification.NotificationService;
 import lombok.RequiredArgsConstructor;
@@ -30,6 +31,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 
 @Service
 @RequiredArgsConstructor
@@ -42,6 +44,7 @@ public class AiModerationProcessorServiceImpl implements AiModerationProcessorSe
     private final NotificationService notificationService;
     private final SmartRentAiConnector smartRentAiConnector;
     private final ObjectMapper objectMapper;
+    private final AiModerationExecutor aiModerationExecutor;
 
     /**
      * Processes a single listing in its own independent transaction.
@@ -71,7 +74,19 @@ public class AiModerationProcessorServiceImpl implements AiModerationProcessorSe
 
             AiListingVerificationRequest request =
                     aiVerificationService.buildVerificationRequest(listing.getListingId());
-            AiListingVerificationResponse response = aiVerificationService.verifyListing(request);
+
+            // Verify and duplicate-check are independent — run them concurrently.
+            CompletableFuture<AiListingVerificationResponse> verifyFuture =
+                    CompletableFuture.supplyAsync(
+                            () -> aiVerificationService.verifyListing(request),
+                            aiModerationExecutor.taskPool());
+            CompletableFuture<DuplicateCheckResponse> duplicateFuture =
+                    CompletableFuture.supplyAsync(
+                            () -> runDuplicateCheck(listing, request),
+                            aiModerationExecutor.taskPool());
+
+            AiListingVerificationResponse response = verifyFuture.join();
+            DuplicateCheckResponse duplicateResult = duplicateFuture.join();
 
             moderation.setAiScore(response.getScore());
 
@@ -95,10 +110,6 @@ public class AiModerationProcessorServiceImpl implements AiModerationProcessorSe
                 // Keep isVerify=true so owner can see it as IN_REVIEW
                 listing.setModerationStatus(ModerationStatus.PENDING_REVIEW);
             }
-
-            // Duplicate detection — flag-for-admin, never hard-block. Best-effort:
-            // any failure or AI downtime leaves the verification decision untouched.
-            DuplicateCheckResponse duplicateResult = runDuplicateCheck(listing, request);
             if (duplicateResult != null
                     && ("DUPLICATE".equals(duplicateResult.getDecision())
                         || "SUSPICIOUS".equals(duplicateResult.getDecision()))) {


### PR DESCRIPTION
…ad pool

- Introduce AiModerationExecutor with two isolated pools: batchPool (20 threads for scheduler) and taskPool (16-32 threads for per-listing fan-out) — avoids deadlock and replaces ForkJoinPool.commonPool() which is CPU-sized and ill-suited for blocking AI HTTP calls
- Run verifyListing + runDuplicateCheck concurrently via CompletableFuture in AiModerationProcessorServiceImpl, cutting per-listing wall-clock time by ~50% when both calls are in-flight simultaneously
- Replace IntStream.parallel() in AiListingAutoModerationScheduler with CompletableFuture.runAsync on batchPool; add allOf().join() so scheduler waits for all listings to complete before the next fixed-delay tick
- Replace per-listing saveAndFlush loop with saveAll + markListingsAsInProgress bulk UPDATE (single query instead of N round-trips)
- Add @Transactional to @Modifying queries in ListingAiModerationRepository (required for modifying queries called outside an active transaction)