### PR TITLE
fix(db): add MEMBERSHIP_RENEWAL to transaction_type ENUM (V95)

### DIFF
--- a/smart-rent/src/main/resources/db/migration/V95__Add_membership_renewal_to_transaction_type.sql
+++ b/smart-rent/src/main/resources/db/migration/V95__Add_membership_renewal_to_transaction_type.sql
@@ -1,0 +1,19 @@
+-- Add MEMBERSHIP_RENEWAL to transaction_type ENUM
+-- This was missing, causing "Data truncated for column 'transaction_type'" on renewal.
+
+ALTER TABLE transactions
+MODIFY COLUMN transaction_type ENUM(
+    'MEMBERSHIP_PURCHASE',
+    'MEMBERSHIP_UPGRADE',
+    'MEMBERSHIP_RENEWAL',
+    'POST_FEE',
+    'PUSH_FEE',
+    'REPOST_FEE',
+    'WALLET_TOPUP',
+    'ROOM_RENT',
+    'DEPOSIT',
+    'MONTHLY_INVOICE',
+    'UTILITY_BILL',
+    'SERVICE_FEE',
+    'REFUND'
+) NOT NULL;


### PR DESCRIPTION
Missing enum value caused "Data truncated for column 'transaction_type'" on every membership renewal attempt.