### PR TITLE
fix(membership): expire old membership on renewal + expose packageSal…

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/dto/response/UserMembershipResponse.java
+++ b/smart-rent/src/main/java/com/smartrent/dto/response/UserMembershipResponse.java
@@ -26,6 +26,7 @@ public class UserMembershipResponse {
     Long daysRemaining;
     String status;
     BigDecimal totalPaid;
+    BigDecimal packageSalePrice;
     List<UserMembershipBenefitResponse> benefits;
     LocalDateTime createdAt;
     LocalDateTime updatedAt;

--- a/smart-rent/src/main/java/com/smartrent/service/membership/impl/MembershipServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/membership/impl/MembershipServiceImpl.java
@@ -629,6 +629,7 @@ public class MembershipServiceImpl implements MembershipService {
                 .daysRemaining(userMembership.getDaysRemaining())
                 .status(userMembership.getStatus().name())
                 .totalPaid(userMembership.getTotalPaid())
+                .packageSalePrice(userMembership.getMembershipPackage().getSalePrice())
                 .benefits(benefits)
                 .createdAt(userMembership.getCreatedAt())
                 .updatedAt(userMembership.getUpdatedAt())
@@ -1128,6 +1129,13 @@ public class MembershipServiceImpl implements MembershipService {
                 .build();
 
         renewed = userMembershipRepository.save(renewed);
+
+        // Expire the previous membership so only one ACTIVE record exists per user.
+        // Without this, findActiveUserMembership throws NonUniqueResultException.
+        if (previous != null && previous.getStatus() == MembershipStatus.ACTIVE) {
+            previous.setStatus(MembershipStatus.EXPIRED);
+            userMembershipRepository.save(previous);
+        }
 
         List<UserMembershipBenefit> benefits = grantBenefits(renewed, pkg);
         userBenefitRepository.saveAll(benefits);


### PR DESCRIPTION
…ePrice

- completeMembershipRenewal: set previous membership EXPIRED after creating the renewed record. Without this, two ACTIVE rows exist and findActiveUserMembership throws NonUniqueResultException ("Query did not return a unique result: 2 results were returned").
- UserMembershipResponse: add packageSalePrice field (current package sale price) so the frontend shows the correct renewal price instead of the historical totalPaid.