### PR TITLE
fix: renewal charges correct package price when user has mixed expire…

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/service/membership/impl/MembershipServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/membership/impl/MembershipServiceImpl.java
@@ -1049,15 +1049,22 @@ public class MembershipServiceImpl implements MembershipService {
         userRepository.findById(userId)
                 .orElseThrow(() -> new RuntimeException("User not found: " + userId));
 
-        // Accept active memberships OR memberships that expired within the last 7 days
-        LocalDateTime renewalCutoff = LocalDateTime.now().minusDays(7);
+        // Prefer the current ACTIVE membership; only fall back to recently expired (≤7 days)
+        // when no active membership exists. This prevents charging for a wrong/old package
+        // when the user has an expired membership with a far-future endDate alongside a new
+        // active one with a closer endDate.
+        LocalDateTime now = LocalDateTime.now();
         UserMembership currentMembership = userMembershipRepository
-                .findByUserIdOrderByEndDateDesc(userId)
-                .stream()
-                .filter(um -> um.isActive()
-                        || (um.isExpired() && um.getEndDate().isAfter(renewalCutoff)))
-                .findFirst()
-                .orElseThrow(() -> new AppException(DomainCode.NO_RENEWABLE_MEMBERSHIP));
+                .findActiveUserMembership(userId, now)
+                .orElseGet(() -> {
+                    LocalDateTime renewalCutoff = now.minusDays(7);
+                    return userMembershipRepository
+                            .findByUserIdOrderByEndDateDesc(userId)
+                            .stream()
+                            .filter(um -> um.isExpired() && um.getEndDate().isAfter(renewalCutoff))
+                            .findFirst()
+                            .orElseThrow(() -> new AppException(DomainCode.NO_RENEWABLE_MEMBERSHIP));
+                });
 
         MembershipPackage pkg = currentMembership.getMembershipPackage();
         if (!pkg.getIsActive()) {


### PR DESCRIPTION
…d/active memberships

Previously initiateMembershipRenewal used findByUserIdOrderByEndDateDesc which could pick a cleared (EXPIRED) membership with a far-future endDate over the new ACTIVE one, resulting in a price mismatch between the dialog (showing the active package) and the payment gateway (charged for the expired package).

Now prioritises findActiveUserMembership and only falls back to recently-expired (≤7 days) when no active membership exists.