### PR TITLE
fix(notification): serialize createdAt with UTC timezone to prevent 7…

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/dto/response/NotificationResponse.java
+++ b/smart-rent/src/main/java/com/smartrent/dto/response/NotificationResponse.java
@@ -1,5 +1,6 @@
 package com.smartrent.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.*;
 import lombok.experimental.FieldDefaults;
@@ -21,5 +22,6 @@ public class NotificationResponse {
     Long referenceId;
     String referenceType;
     Boolean isRead;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss'Z'", timezone = "UTC")
     LocalDateTime createdAt;
 }


### PR DESCRIPTION
…-hour offset in browser

LocalDateTime has no timezone info, so Jackson was serializing it without a 'Z' suffix. Browsers interpret timezone-less ISO strings as local time (UTC+7), causing notification timestamps to appear 7 hours older than they actually are. Adding @JsonFormat with UTC timezone ensures the output includes a literal 'Z', so JavaScript correctly parses it as UTC.