### PR TITLE
fix(membership): restore missing adminClearUserMembership implementation

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/service/membership/impl/MembershipServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/membership/impl/MembershipServiceImpl.java
@@ -1234,6 +1234,21 @@ public class MembershipServiceImpl implements MembershipService {
         return mapToUserMembershipResponse(renewed);
     }
 
+    @Override
+    @Transactional
+    public void adminClearUserMembership(String userId) {
+        log.info("Admin clearing all active memberships for user: {}", userId);
+        List<UserMembership> active = userMembershipRepository
+                .findByUserIdAndStatus(userId, MembershipStatus.ACTIVE);
+        if (active.isEmpty()) {
+            log.info("No active memberships found for user: {}", userId);
+            return;
+        }
+        active.forEach(um -> um.setStatus(MembershipStatus.EXPIRED));
+        userMembershipRepository.saveAll(active);
+        log.info("Expired {} active membership(s) for user: {}", active.size(), userId);
+    }
+
     // =====================================================
     // UPGRADE HELPER METHODS
     // =====================================================


### PR DESCRIPTION
MembershipServiceImpl was missing this method entirely, likely dropped during the large renewal/upgrade rewrite — MembershipService declares it and AdminMembershipController calls it, but nothing implemented it, so compileJava failed with "is not abstract and does not override abstract method". This broke gradle bootJar in the Docker build, silently blocking every CD deploy since (backend production has been stuck on the pre-renewal image for 2+ days as a result).