### PR TITLE
fix: return empty results for cursor search when keyword normalizes t…

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/service/listing/impl/ListingServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/listing/impl/ListingServiceImpl.java
@@ -1371,6 +1371,19 @@ public class ListingServiceImpl implements ListingService {
             ListingFilterRequest filter, String cursor, int size) {
         int safeSize = Math.min(Math.max(size, 1), 100);
 
+        // Same keyword guard as the offset search path: a non-blank keyword that
+        // normalizes away (e.g. "(((") must return no results, not an unfiltered query.
+        String normalizedKeyword = TextNormalizer.normalize(filter.getKeyword());
+        if (filter.getKeyword() != null && !filter.getKeyword().trim().isEmpty()
+                && (normalizedKeyword == null || normalizedKeyword.length() < 3)) {
+            return com.smartrent.dto.response.ListingCursorResponse.builder()
+                    .items(Collections.emptyList())
+                    .nextCursor(null)
+                    .hasNext(false)
+                    .size(safeSize)
+                    .build();
+        }
+
         // Same filter resolution + specification as the offset search path.
         resolveAddressMappings(filter);
         Specification<Listing> spec = listingQueryService.buildSpecification(filter);


### PR DESCRIPTION
…o nothing

searchListings (offset) already short-circuits to an empty result when a non-blank keyword normalizes to null/too-short (e.g. "((("), but searchListingsByCursor lacked the same guard — it went straight to buildSpecification, which silently skips the keyword predicate in that case, causing the cursor search to return unfiltered listings for garbage/special- character-only queries.