### PR TITLE
feat(report): re-check listing status before accepting a report

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/infra/exception/model/DomainCode.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/exception/model/DomainCode.java
@@ -148,7 +148,9 @@ public enum DomainCode {
   VIP_TIER_VIDEO_LIMIT_EXCEEDED("21002", HttpStatus.BAD_REQUEST,
       "Số lượng video vượt quá giới hạn của gói %s. Tối đa %d video, bạn đang muốn đăng %d video."),
   VIP_TIER_NOT_CONFIGURED("21003", HttpStatus.INTERNAL_SERVER_ERROR,
-      "Không tìm thấy cấu hình giới hạn cho gói VIP: %s")
+      "Không tìm thấy cấu hình giới hạn cho gói VIP: %s"),
+  //    Listing Report Error 22xxx
+  LISTING_REPORT_NOT_AVAILABLE("22001", HttpStatus.BAD_REQUEST, "Listing is no longer available and cannot be reported")
   ;
 
   private final String value;

--- a/smart-rent/src/main/java/com/smartrent/service/report/impl/ListingReportServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/report/impl/ListingReportServiceImpl.java
@@ -5,6 +5,7 @@ import com.smartrent.dto.request.ResolveReportRequest;
 import com.smartrent.dto.response.ListingReportResponse;
 import com.smartrent.dto.response.PageResponse;
 import com.smartrent.dto.response.ReportReasonResponse;
+import com.smartrent.enums.ListingStatus;
 import com.smartrent.enums.NotificationType;
 import com.smartrent.enums.RecipientType;
 import com.smartrent.enums.ReportCategory;
@@ -84,6 +85,16 @@ public class ListingReportServiceImpl implements ListingReportService {
         // Validate listing exists
         Listing listing = listingRepository.findById(listingId)
                 .orElseThrow(() -> new ResourceNotFoundException("Listing not found with ID: " + listingId));
+
+        // Re-check the listing is currently published; reject reports on listings that are
+        // no longer publicly visible (expired, rejected, pending review/payment, etc.)
+        ListingStatus listingStatus = listing.computeListingStatus();
+        boolean isReportable = listingStatus == ListingStatus.DISPLAYING
+                || listingStatus == ListingStatus.EXPIRING_SOON
+                || listingStatus == ListingStatus.VERIFIED;
+        if (!isReportable) {
+            throw new DomainException(DomainCode.LISTING_REPORT_NOT_AVAILABLE);
+        }
 
         // Validate report category
         ReportCategory category;


### PR DESCRIPTION
Prevent reporting listings that are no longer publicly visible (expired, rejected, pending review/payment, resubmitted). The listing's status is now re-validated server-side at submission time, since it may have changed since the report dialog was opened on the frontend. Returns a dedicated LISTING_REPORT_NOT_AVAILABLE (22001) error code so clients can show a clear message instead of a generic failure.