### PR TITLE
fix(transaction): serialize createdAt/completedAt/expiredAt as UTC in…

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/dto/response/TransactionDetailResponse.java
+++ b/smart-rent/src/main/java/com/smartrent/dto/response/TransactionDetailResponse.java
@@ -5,7 +5,7 @@ import lombok.*;
 import lombok.experimental.FieldDefaults;
 
 import java.math.BigDecimal;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.List;
 
 @Getter
@@ -27,9 +27,9 @@ public class TransactionDetailResponse {
     String gatewayResponseCode;
     String status;
     String paymentType;
-    LocalDateTime createdAt;
-    LocalDateTime completedAt;
-    LocalDateTime expiredAt;
+    Instant createdAt;
+    Instant completedAt;
+    Instant expiredAt;
     TransactionInvoiceResponse invoice;
     TransactionRoomResponse room;
     TransactionPartyResponse customer;

--- a/smart-rent/src/main/java/com/smartrent/dto/response/TransactionHistoryItemResponse.java
+++ b/smart-rent/src/main/java/com/smartrent/dto/response/TransactionHistoryItemResponse.java
@@ -5,7 +5,7 @@ import lombok.*;
 import lombok.experimental.FieldDefaults;
 
 import java.math.BigDecimal;
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 @Getter
 @Setter
@@ -24,8 +24,8 @@ public class TransactionHistoryItemResponse {
     String gatewayTransactionCode;
     String status;
     String paymentType;
-    LocalDateTime createdAt;
-    LocalDateTime completedAt;
+    Instant createdAt;
+    Instant completedAt;
     TransactionInvoiceResponse invoice;
     TransactionRoomResponse room;
     TransactionPartyResponse customer;

--- a/smart-rent/src/main/java/com/smartrent/dto/response/TransactionResponse.java
+++ b/smart-rent/src/main/java/com/smartrent/dto/response/TransactionResponse.java
@@ -4,7 +4,7 @@ import lombok.*;
 import lombok.experimental.FieldDefaults;
 
 import java.math.BigDecimal;
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 @Getter
 @Setter
@@ -26,7 +26,7 @@ public class TransactionResponse {
     String status;
     String paymentProvider;
     String providerTransactionId;
-    LocalDateTime createdAt;
-    LocalDateTime updatedAt;
+    Instant createdAt;
+    Instant updatedAt;
 }
 

--- a/smart-rent/src/main/java/com/smartrent/dto/response/TransactionTimelineResponse.java
+++ b/smart-rent/src/main/java/com/smartrent/dto/response/TransactionTimelineResponse.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.*;
 import lombok.experimental.FieldDefaults;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 @Getter
 @Setter
@@ -15,7 +15,7 @@ import java.time.LocalDateTime;
 @FieldDefaults(level = AccessLevel.PRIVATE)
 public class TransactionTimelineResponse {
     String status;
-    LocalDateTime at;
+    Instant at;
     String actorType;
     String actorId;
     String note;

--- a/smart-rent/src/main/java/com/smartrent/service/payment/impl/PaymentServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/payment/impl/PaymentServiceImpl.java
@@ -26,6 +26,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -170,9 +172,19 @@ public class PaymentServiceImpl implements PaymentService {
                 .status(updated.getStatus() != null ? updated.getStatus().name() : null)
                 .paymentProvider(updated.getPaymentProvider() != null ? updated.getPaymentProvider().name() : null)
                 .providerTransactionId(updated.getProviderTransactionId())
-                .createdAt(updated.getCreatedAt())
-                .updatedAt(updated.getUpdatedAt())
+                .createdAt(toInstant(updated.getCreatedAt()))
+                .updatedAt(toInstant(updated.getUpdatedAt()))
                 .build();
+    }
+
+    /**
+     * {@code Transaction.createdAt}/{@code updatedAt} are naive {@link LocalDateTime} values but
+     * the DB/Hibernate session is pinned to UTC (see application.yml), so the stored value already
+     * represents a UTC instant. Convert explicitly when exposing it on the wire so Jackson
+     * serializes it with a proper {@code Z} suffix instead of a timezone-less string.
+     */
+    private static java.time.Instant toInstant(LocalDateTime localDateTime) {
+        return localDateTime == null ? null : localDateTime.atZone(ZoneOffset.UTC).toInstant();
     }
 
     // Provider Management Methods

--- a/smart-rent/src/main/java/com/smartrent/service/transaction/impl/TransactionHistoryServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/transaction/impl/TransactionHistoryServiceImpl.java
@@ -27,7 +27,9 @@ import org.springframework.transaction.annotation.Transactional;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -232,8 +234,8 @@ public class TransactionHistoryServiceImpl implements TransactionHistoryService 
                 .gatewayTransactionCode(transaction.getProviderTransactionId())
                 .status(toApiStatus(transaction.getStatus()))
                 .paymentType(transaction.getTransactionType() != null ? transaction.getTransactionType().name() : null)
-                .createdAt(transaction.getCreatedAt())
-                .completedAt(resolveCompletedAt(transaction))
+                .createdAt(toInstant(transaction.getCreatedAt()))
+                .completedAt(toInstant(resolveCompletedAt(transaction)))
                 .invoice(toInvoice(transaction))
                 .room(toRoom(transaction, listing))
                 .customer(includeCustomer ? toCustomer(transaction, customer) : null)
@@ -256,9 +258,9 @@ public class TransactionHistoryServiceImpl implements TransactionHistoryService 
                 .gatewayResponseCode(includeAdminFields ? transaction.getGatewayResponseCode() : null)
                 .status(toApiStatus(transaction.getStatus()))
                 .paymentType(transaction.getTransactionType() != null ? transaction.getTransactionType().name() : null)
-                .createdAt(transaction.getCreatedAt())
+                .createdAt(toInstant(transaction.getCreatedAt()))
                 .completedAt(item.getCompletedAt())
-                .expiredAt(transaction.getExpiredAt())
+                .expiredAt(toInstant(transaction.getExpiredAt()))
                 .invoice(item.getInvoice())
                 .room(item.getRoom())
                 .customer(item.getCustomer())
@@ -276,14 +278,17 @@ public class TransactionHistoryServiceImpl implements TransactionHistoryService 
             List<TransactionTimelineResponse> timeline = new ArrayList<>();
             timeline.add(TransactionTimelineResponse.builder()
                     .status("PENDING")
-                    .at(transaction.getCreatedAt())
+                    .at(toInstant(transaction.getCreatedAt()))
                     .actorType("SYSTEM")
                     .note("Payment created")
                     .build());
             if (transaction.getStatus() != TransactionStatus.PENDING) {
+                LocalDateTime completedOrUpdatedAt = resolveCompletedAt(transaction) != null
+                        ? resolveCompletedAt(transaction)
+                        : transaction.getUpdatedAt();
                 timeline.add(TransactionTimelineResponse.builder()
                         .status(toApiStatus(transaction.getStatus()))
-                        .at(resolveCompletedAt(transaction) != null ? resolveCompletedAt(transaction) : transaction.getUpdatedAt())
+                        .at(toInstant(completedOrUpdatedAt))
                         .actorType("GATEWAY")
                         .note(resolveFailureReason(transaction))
                         .build());
@@ -293,7 +298,7 @@ public class TransactionHistoryServiceImpl implements TransactionHistoryService 
         return audits.stream()
                 .map(audit -> TransactionTimelineResponse.builder()
                         .status(toApiStatus(audit.getNewStatus()))
-                        .at(audit.getCreatedAt())
+                        .at(toInstant(audit.getCreatedAt()))
                         .actorType(audit.getActorType())
                         .actorId(audit.getActorId())
                         .note(audit.getReason())
@@ -383,6 +388,17 @@ public class TransactionHistoryServiceImpl implements TransactionHistoryService 
             return transaction.getCompletedAt();
         }
         return transaction.getStatus() == TransactionStatus.COMPLETED ? transaction.getUpdatedAt() : null;
+    }
+
+    /**
+     * {@code Transaction}/{@code TransactionAudit} timestamp columns are persisted as naive
+     * {@link LocalDateTime} values, but the DB/Hibernate session is pinned to UTC (see
+     * application.yml), so the stored value already represents a UTC instant. Convert explicitly
+     * when exposing it on the wire so Jackson serializes it with a proper {@code Z} suffix instead
+     * of a timezone-less string that the frontend would misinterpret as browser-local time.
+     */
+    private static Instant toInstant(LocalDateTime localDateTime) {
+        return localDateTime == null ? null : localDateTime.atZone(ZoneOffset.UTC).toInstant();
     }
 
     private String resolveFailureReason(Transaction transaction) {

--- a/smart-rent/src/main/java/com/smartrent/service/transaction/impl/TransactionServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/transaction/impl/TransactionServiceImpl.java
@@ -21,6 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -305,9 +306,19 @@ public class TransactionServiceImpl implements TransactionService {
                 .paymentProvider(transaction.getPaymentProvider() != null ? transaction.getPaymentProvider().name() : null)
                 .providerTransactionId(transaction.getProviderTransactionId())
                 .additionalInfo(transaction.getAdditionalInfo())
-                .createdAt(transaction.getCreatedAt())
-                .updatedAt(transaction.getUpdatedAt())
+                .createdAt(toInstant(transaction.getCreatedAt()))
+                .updatedAt(toInstant(transaction.getUpdatedAt()))
                 .build();
+    }
+
+    /**
+     * The {@code createdAt}/{@code updatedAt} columns are persisted as naive {@link LocalDateTime}
+     * values but the DB/Hibernate session is pinned to UTC (see application.yml), so the stored
+     * value already represents a UTC instant. Convert explicitly when exposing it on the wire so
+     * Jackson serializes it with a proper {@code Z} suffix instead of a timezone-less string.
+     */
+    private static java.time.Instant toInstant(LocalDateTime localDateTime) {
+        return localDateTime == null ? null : localDateTime.atZone(ZoneOffset.UTC).toInstant();
     }
 }
 


### PR DESCRIPTION
…stants

Transaction timestamps were exposed via LocalDateTime, which Jackson serializes without a timezone marker even though the stored value is UTC (DB/Hibernate session pinned to UTC). Clients parsing the naive string as local time saw created_at shifted by their UTC offset, e.g. 7 hours off on the seller transactions page for VN users. Convert to Instant at the DTO boundary so the wire format carries an explicit Z suffix; entities stay LocalDateTime since query/filter code depends on it and the DB session guarantees UTC semantics.