### PR TITLE
fix: evict listing.search cache when owner update reverts listing to …

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/service/listing/impl/ListingServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/listing/impl/ListingServiceImpl.java
@@ -615,8 +615,9 @@ public class ListingServiceImpl implements ListingService {
     @Override
     @Transactional
     @Caching(evict = {
-            @CacheEvict(cacheNames = com.smartrent.config.Constants.CacheNames.LISTING_DETAIL, key = "#id"),
-            @CacheEvict(cacheNames = com.smartrent.config.Constants.CacheNames.LISTING_BROWSE, allEntries = true)
+            @CacheEvict(cacheNames = com.smartrent.config.Constants.CacheNames.LISTING_SEARCH, allEntries = true),
+            @CacheEvict(cacheNames = com.smartrent.config.Constants.CacheNames.LISTING_BROWSE, allEntries = true),
+            @CacheEvict(cacheNames = com.smartrent.config.Constants.CacheNames.LISTING_DETAIL, key = "#id")
     })
     public ListingResponse updateListing(Long id, ListingRequest request, String userId) {
         Listing existing = listingRepository.findById(id)


### PR DESCRIPTION
…review

updateListing() resets verified/isVerify/moderationStatus to PENDING_REVIEW when an owner edits an APPROVED listing, but the @Caching eviction only cleared listing.detail and listing.browse. listing.search kept serving the stale verified entry until its TTL expired, matching the same gap already fixed for push/moderation flows.