### PR TITLE
fix(listing): stop enum-crash leak and block non-public listings from…

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/infra/repository/entity/Listing.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/entity/Listing.java
@@ -138,7 +138,7 @@ public class Listing {
 
 
     // ── Moderation fields (nullable for backward compatibility) ──
-    @Enumerated(EnumType.STRING)
+    @Convert(converter = com.smartrent.infra.repository.entity.converter.ModerationStatusConverter.class)
     @Column(name = "moderation_status", length = 30)
     ModerationStatus moderationStatus;
 

--- a/smart-rent/src/main/java/com/smartrent/infra/repository/entity/converter/ModerationStatusConverter.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/entity/converter/ModerationStatusConverter.java
@@ -1,0 +1,37 @@
+package com.smartrent.infra.repository.entity.converter;
+
+import com.smartrent.enums.ModerationStatus;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * A legacy/manual DB write can leave {@code moderation_status} holding a value that isn't a
+ * {@link ModerationStatus} constant (e.g. the display-only {@code ListingStatus.IN_REVIEW} name
+ * used instead of {@code ModerationStatus.PENDING_REVIEW}). Without this converter, Hibernate's
+ * default enum mapping throws {@link IllegalArgumentException} while hydrating the row, which
+ * crashes every code path that reads that listing. Fall back to PENDING_REVIEW instead so a
+ * single bad row degrades to "needs review" rather than a 500.
+ */
+@Slf4j
+@Converter
+public class ModerationStatusConverter implements AttributeConverter<ModerationStatus, String> {
+
+    @Override
+    public String convertToDatabaseColumn(ModerationStatus attribute) {
+        return attribute == null ? null : attribute.name();
+    }
+
+    @Override
+    public ModerationStatus convertToEntityAttribute(String dbData) {
+        if (dbData == null) {
+            return null;
+        }
+        try {
+            return ModerationStatus.valueOf(dbData);
+        } catch (IllegalArgumentException e) {
+            log.error("Unknown moderation_status value '{}' found in DB; defaulting to PENDING_REVIEW", dbData);
+            return ModerationStatus.PENDING_REVIEW;
+        }
+    }
+}

--- a/smart-rent/src/main/java/com/smartrent/service/listing/impl/ListingServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/listing/impl/ListingServiceImpl.java
@@ -25,6 +25,7 @@ import com.smartrent.dto.response.ListingResponseWithAdmin;
 import com.smartrent.dto.response.PaymentResponse;
 import com.smartrent.dto.response.ProvinceListingStatsResponse;
 import com.smartrent.enums.BenefitType;
+import com.smartrent.enums.ListingStatus;
 import com.smartrent.enums.ModerationStatus;
 import com.smartrent.enums.PostSource;
 import com.smartrent.infra.exception.AppException;
@@ -561,6 +562,17 @@ public class ListingServiceImpl implements ListingService {
         // Fetch listing with amenities first
         Listing listing = listingRepository.findByIdWithAmenities(id)
                 .orElseThrow(() -> new DomainException(DomainCode.LISTING_NOT_FOUND));
+
+        // This endpoint is public (no auth) — only listings currently visible to the public
+        // (not pending review, rejected, suspended, expired, etc.) may be served here. Anything
+        // else is indistinguishable from "not found" to an anonymous caller.
+        ListingStatus listingStatus = listing.computeListingStatus();
+        boolean isPubliclyVisible = listingStatus == ListingStatus.DISPLAYING
+                || listingStatus == ListingStatus.EXPIRING_SOON
+                || listingStatus == ListingStatus.VERIFIED;
+        if (!isPubliclyVisible) {
+            throw new DomainException(DomainCode.LISTING_NOT_FOUND);
+        }
 
         // Fetch media separately to avoid MultipleBagFetchException
         listingRepository.findByIdWithMedia(id);

--- a/smart-rent/src/test/java/com/smartrent/infra/repository/entity/converter/ModerationStatusConverterTest.java
+++ b/smart-rent/src/test/java/com/smartrent/infra/repository/entity/converter/ModerationStatusConverterTest.java
@@ -1,0 +1,31 @@
+package com.smartrent.infra.repository.entity.converter;
+
+import com.smartrent.enums.ModerationStatus;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class ModerationStatusConverterTest {
+
+    private final ModerationStatusConverter converter = new ModerationStatusConverter();
+
+    @Test
+    void convertsKnownValue() {
+        assertEquals(ModerationStatus.APPROVED, converter.convertToEntityAttribute("APPROVED"));
+    }
+
+    @Test
+    void nullPassesThrough() {
+        assertNull(converter.convertToEntityAttribute(null));
+        assertNull(converter.convertToDatabaseColumn(null));
+    }
+
+    @Test
+    void unknownLegacyValueFallsBackToPendingReviewInsteadOfThrowing() {
+        // Regression: a stray DB row held "IN_REVIEW" (the ListingStatus display name, not a
+        // ModerationStatus constant), which used to crash Hibernate hydration with
+        // IllegalArgumentException on every read (report flow, listing detail, etc).
+        assertEquals(ModerationStatus.PENDING_REVIEW, converter.convertToEntityAttribute("IN_REVIEW"));
+    }
+}

--- a/smart-rent/src/test/java/com/smartrent/service/listing/impl/ListingServiceImplGetByIdTest.java
+++ b/smart-rent/src/test/java/com/smartrent/service/listing/impl/ListingServiceImplGetByIdTest.java
@@ -1,8 +1,10 @@
 package com.smartrent.service.listing.impl;
 
+import com.smartrent.enums.ModerationStatus;
 import com.smartrent.infra.exception.DomainException;
 import com.smartrent.infra.exception.model.DomainCode;
 import com.smartrent.infra.repository.ListingRepository;
+import com.smartrent.infra.repository.entity.Listing;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -35,6 +37,19 @@ class ListingServiceImplGetByIdTest {
 
         DomainException ex = assertThrows(DomainException.class,
                 () -> service.getListingById(123L));
+        assertEquals(DomainCode.LISTING_NOT_FOUND, ex.getDomainCode());
+    }
+
+    @Test
+    void throwsListingNotFoundWhenNotPubliclyVisible() {
+        Listing pendingReview = Listing.builder()
+                .listingId(456L)
+                .moderationStatus(ModerationStatus.PENDING_REVIEW)
+                .build();
+        when(listingRepository.findByIdWithAmenities(456L)).thenReturn(Optional.of(pendingReview));
+
+        DomainException ex = assertThrows(DomainException.class,
+                () -> service.getListingById(456L));
         assertEquals(DomainCode.LISTING_NOT_FOUND, ex.getDomainCode());
     }
 }


### PR DESCRIPTION
… public detail API

A stray moderation_status DB value (e.g. "IN_REVIEW", which is the ListingStatus display name rather than a ModerationStatus constant) crashed Hibernate hydration with IllegalArgumentException on every read, and GlobalExceptionHandler leaked that raw Java message straight to clients (surfaced on report submission). Add a defensive AttributeConverter that falls back to PENDING_REVIEW instead of throwing, and make getListingById reject listings that aren't publicly visible (DISPLAYING/EXPIRING_SOON/ VERIFIED) with the existing LISTING_NOT_FOUND response, matching the same check already used by the report flow.