### PR TITLE
fix(listing): remove listing.detail cache from public GET endpoint

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/service/listing/impl/ListingServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/listing/impl/ListingServiceImpl.java
@@ -553,9 +553,6 @@ public class ListingServiceImpl implements ListingService {
 
     @Override
     @Transactional(readOnly = true)
-    @Cacheable(cacheNames = com.smartrent.config.Constants.CacheNames.LISTING_DETAIL,
-            key = "#id",
-            unless = "#result == null")
     public ListingResponse getListingById(Long id) {
         log.info("getListingById called for id={}", id);
 


### PR DESCRIPTION
Redis kept serving stale ListingResponse for up to 3 minutes after a listing's moderation status changed outside the normal service methods (no matching @CacheEvict fired), so the public detail page kept showing listings that should now be hidden. Read the listing fresh on every request instead.