### PR TITLE
fix(listing): exclude expired listings from personalized homepage feed

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/cronjob/ListingPushScheduler.java
+++ b/smart-rent/src/main/java/com/smartrent/cronjob/ListingPushScheduler.java
@@ -1,11 +1,14 @@
 package com.smartrent.cronjob;
 
+import com.smartrent.config.Constants;
 import com.smartrent.infra.repository.ListingRepository;
 import com.smartrent.service.push.PushService;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Caching;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -56,6 +59,12 @@ public class ListingPushScheduler {
      * Mark listings whose expiryDate has passed as expired.
      * Runs every hour, aligned with the push scheduler.
      */
+    @Caching(evict = {
+            @CacheEvict(cacheNames = Constants.CacheNames.LISTING_SEARCH, allEntries = true),
+            @CacheEvict(cacheNames = Constants.CacheNames.LISTING_BROWSE, allEntries = true),
+            @CacheEvict(cacheNames = Constants.CacheNames.LISTING_RECOMMENDATION_PERSONALIZED, allEntries = true),
+            @CacheEvict(cacheNames = Constants.CacheNames.LISTING_RECOMMENDATION_SIMILAR, allEntries = true)
+    })
     @Scheduled(cron = "0 0 * * * *")
     public void expireListings() {
         int count = listingRepository.markExpiredListings(LocalDateTime.now());

--- a/smart-rent/src/main/java/com/smartrent/infra/repository/ListingRepository.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/ListingRepository.java
@@ -646,6 +646,7 @@ public interface ListingRepository extends JpaRepository<Listing, Long>, JpaSpec
         AND l.price BETWEEN :minPrice AND :maxPrice
         AND l.listingId NOT IN :excludedIds
         AND l.isDraft = false AND l.isShadow = false AND l.verified = true AND l.expired = false
+        AND (l.expiryDate IS NULL OR l.expiryDate > CURRENT_TIMESTAMP)
         ORDER BY l.pushedAt DESC NULLS LAST, l.postDate DESC
     """)
     List<Listing> findPersonalizedPriceCandidates(
@@ -668,6 +669,7 @@ public interface ListingRepository extends JpaRepository<Listing, Long>, JpaSpec
         AND l.isShadow = false
         AND l.verified = true
         AND l.expired = false
+        AND (l.expiryDate IS NULL OR l.expiryDate > CURRENT_TIMESTAMP)
         ORDER BY l.pushedAt DESC NULLS LAST, l.postDate DESC
     """)
     List<Listing> findCandidatesForPersonalizedByLegacyProvince(
@@ -687,6 +689,7 @@ public interface ListingRepository extends JpaRepository<Listing, Long>, JpaSpec
         AND l.isShadow = false
         AND l.verified = true
         AND l.expired = false
+        AND (l.expiryDate IS NULL OR l.expiryDate > CURRENT_TIMESTAMP)
         ORDER BY l.pushedAt DESC NULLS LAST, l.postDate DESC
     """)
     List<Listing> findCandidatesForPersonalizedByNewProvince(
@@ -706,6 +709,7 @@ public interface ListingRepository extends JpaRepository<Listing, Long>, JpaSpec
         AND l.isShadow = false
         AND l.verified = true
         AND l.expired = false
+        AND (l.expiryDate IS NULL OR l.expiryDate > CURRENT_TIMESTAMP)
         ORDER BY l.pushedAt DESC NULLS LAST, l.postDate DESC
     """)
     List<Listing> findCandidatesByLegacyWard(
@@ -725,6 +729,7 @@ public interface ListingRepository extends JpaRepository<Listing, Long>, JpaSpec
         AND l.isShadow = false
         AND l.verified = true
         AND l.expired = false
+        AND (l.expiryDate IS NULL OR l.expiryDate > CURRENT_TIMESTAMP)
         ORDER BY l.pushedAt DESC NULLS LAST, l.postDate DESC
     """)
     List<Listing> findCandidatesByNewWard(
@@ -744,6 +749,7 @@ public interface ListingRepository extends JpaRepository<Listing, Long>, JpaSpec
         AND l.isShadow = false
         AND l.verified = true
         AND l.expired = false
+        AND (l.expiryDate IS NULL OR l.expiryDate > CURRENT_TIMESTAMP)
         ORDER BY l.pushedAt DESC NULLS LAST, l.postDate DESC
     """)
     List<Listing> findCandidatesByDistrict(
@@ -763,6 +769,7 @@ public interface ListingRepository extends JpaRepository<Listing, Long>, JpaSpec
         AND l.isShadow = false
         AND l.verified = true
         AND l.expired = false
+        AND (l.expiryDate IS NULL OR l.expiryDate > CURRENT_TIMESTAMP)
         ORDER BY l.pushedAt DESC NULLS LAST, l.postDate DESC
     """)
     List<Listing> findCandidatesForPersonalizedGlobal(


### PR DESCRIPTION
The "Bất động sản dành cho bạn" candidate-pool queries only filtered on the expired flag, which is flipped by an hourly cron. A listing past its expiryDate could still surface for up to ~1h (plus the 2min Redis TTL) before the flag caught up. Add the same real-time expiryDate > NOW() check already used by the VIP-tier homepage query, and evict the search/browse/recommendation caches when the cron runs so the remaining TTL window doesn't compound the delay.