### PR TITLE
Add public view-tracking endpoint and fix owner analytics aggregates

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/controller/PhoneClickDetailController.java
+++ b/smart-rent/src/main/java/com/smartrent/controller/PhoneClickDetailController.java
@@ -2,6 +2,7 @@ package com.smartrent.controller;
 
 import com.smartrent.dto.request.PhoneClickRequest;
 import com.smartrent.dto.response.ApiResponse;
+import com.smartrent.dto.response.OwnerPhoneClickStatsResponse;
 import com.smartrent.dto.response.PageResponse;
 import com.smartrent.dto.response.PhoneClickResponse;
 import com.smartrent.dto.response.PhoneClickStatsResponse;
@@ -659,6 +660,59 @@ public class PhoneClickDetailController {
         return ApiResponse.<PageResponse<PhoneClickResponse>>builder()
                 .code("999999")
                 .data(responses)
+                .build();
+    }
+
+    @GetMapping("/my-listings/stats")
+    @Operation(
+            summary = "Get aggregate phone click statistics for my listings",
+            description = """
+                    Get total phone clicks and unique interested users across ALL of the
+                    authenticated user's listings, independent of pagination.
+
+                    **Use Case:**
+                    - Customer management dashboard summary cards
+                    """,
+            security = @SecurityRequirement(name = "Bearer Authentication")
+    )
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "Successfully retrieved owner-wide statistics",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ApiResponse.class),
+                            examples = @ExampleObject(
+                                    name = "Success Response",
+                                    value = """
+                                            {
+                                              "code": "999999",
+                                              "message": "Success",
+                                              "data": {
+                                                "totalClicks": 137,
+                                                "uniqueUsers": 42
+                                              }
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "Unauthorized - User not authenticated"
+            )
+    })
+    public ApiResponse<OwnerPhoneClickStatsResponse> getOwnerPhoneClickStats() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String userId = authentication.getName();
+
+        log.info("Getting owner-wide phone click stats for user {}", userId);
+
+        OwnerPhoneClickStatsResponse response = phoneClickDetailService.getOwnerPhoneClickStats(userId);
+
+        return ApiResponse.<OwnerPhoneClickStatsResponse>builder()
+                .code("999999")
+                .data(response)
                 .build();
     }
 

--- a/smart-rent/src/main/java/com/smartrent/controller/ViewController.java
+++ b/smart-rent/src/main/java/com/smartrent/controller/ViewController.java
@@ -1,0 +1,155 @@
+package com.smartrent.controller;
+
+import com.smartrent.dto.request.ViewTrackRequest;
+import com.smartrent.dto.response.ApiResponse;
+import com.smartrent.dto.response.ViewTrackResponse;
+import com.smartrent.service.view.ViewService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.FieldDefaults;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/v1/views")
+@RequiredArgsConstructor
+@FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
+@Slf4j
+@Tag(
+        name = "View Tracking",
+        description = "Public API for tracking listing detail page views. No authentication required."
+)
+public class ViewController {
+
+    ViewService viewService;
+
+    @PostMapping
+    @Operation(
+            summary = "Track a listing detail page view",
+            description = """
+                    Track when a user opens a listing's detail page.
+
+                    **Behavior:**
+                    - Public endpoint, no authentication required
+                    - Records the view with timestamp and IP address
+                    - Deduped per IP address within a short time window so page
+                      reloads don't inflate the count
+                    """,
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "View tracking request",
+                    required = true,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ViewTrackRequest.class),
+                            examples = @ExampleObject(
+                                    name = "Track View",
+                                    value = """
+                                            {
+                                              "listingId": 123
+                                            }
+                                            """
+                            )
+                    )
+            )
+    )
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "View tracked successfully",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ApiResponse.class),
+                            examples = @ExampleObject(
+                                    name = "Success Response",
+                                    value = """
+                                            {
+                                              "code": "999999",
+                                              "message": "Success",
+                                              "data": {
+                                                "listingId": 123,
+                                                "recorded": true,
+                                                "viewedAt": "2024-01-15T10:30:00"
+                                              }
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "Listing not found",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "Not Found Error",
+                                    value = """
+                                            {
+                                              "code": "404001",
+                                              "message": "Listing not found",
+                                              "data": null
+                                            }
+                                            """
+                            )
+                    )
+            )
+    })
+    public ApiResponse<ViewTrackResponse> trackView(
+            @Valid @RequestBody ViewTrackRequest request,
+            HttpServletRequest httpRequest
+    ) {
+        String userId = currentUserIdOrNull();
+        String ipAddress = extractIpAddress(httpRequest);
+        String userAgent = httpRequest.getHeader("User-Agent");
+
+        log.debug("Tracking view for listing {} from IP {}", request.getListingId(), ipAddress);
+
+        ViewTrackResponse response = viewService.trackView(request, userId, ipAddress, userAgent);
+
+        return ApiResponse.<ViewTrackResponse>builder()
+                .code("999999")
+                .data(response)
+                .build();
+    }
+
+    private String currentUserIdOrNull() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null || !auth.isAuthenticated() || "anonymousUser".equals(auth.getPrincipal())) {
+            return null;
+        }
+        return auth.getName();
+    }
+
+    /**
+     * Extract IP address from HTTP request, handling proxy headers
+     */
+    private String extractIpAddress(HttpServletRequest request) {
+        String ipAddress = request.getHeader("X-Forwarded-For");
+
+        if (ipAddress == null || ipAddress.isEmpty() || "unknown".equalsIgnoreCase(ipAddress)) {
+            ipAddress = request.getHeader("X-Real-IP");
+        }
+
+        if (ipAddress == null || ipAddress.isEmpty() || "unknown".equalsIgnoreCase(ipAddress)) {
+            ipAddress = request.getRemoteAddr();
+        }
+
+        if (ipAddress != null && ipAddress.contains(",")) {
+            ipAddress = ipAddress.split(",")[0].trim();
+        }
+
+        return ipAddress;
+    }
+}

--- a/smart-rent/src/main/java/com/smartrent/dto/request/ViewTrackRequest.java
+++ b/smart-rent/src/main/java/com/smartrent/dto/request/ViewTrackRequest.java
@@ -1,0 +1,29 @@
+package com.smartrent.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.FieldDefaults;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@FieldDefaults(level = AccessLevel.PRIVATE)
+@Schema(description = "Request to track a listing detail page view")
+public class ViewTrackRequest {
+
+    @NotNull(message = "Listing ID is required")
+    @Schema(
+            description = "ID of the listing that was viewed",
+            example = "123",
+            required = true
+    )
+    Long listingId;
+}

--- a/smart-rent/src/main/java/com/smartrent/dto/response/OwnerPhoneClickStatsResponse.java
+++ b/smart-rent/src/main/java/com/smartrent/dto/response/OwnerPhoneClickStatsResponse.java
@@ -1,0 +1,28 @@
+package com.smartrent.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.FieldDefaults;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@FieldDefaults(level = AccessLevel.PRIVATE)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "Statistics about phone clicks across all listings owned by a user")
+public class OwnerPhoneClickStatsResponse {
+
+    @Schema(description = "Total number of phone clicks across all of the owner's listings", example = "137")
+    Long totalClicks;
+
+    @Schema(description = "Number of unique users who clicked across all of the owner's listings", example = "42")
+    Long uniqueUsers;
+}

--- a/smart-rent/src/main/java/com/smartrent/dto/response/ViewTrackResponse.java
+++ b/smart-rent/src/main/java/com/smartrent/dto/response/ViewTrackResponse.java
@@ -1,0 +1,31 @@
+package com.smartrent.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.FieldDefaults;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@FieldDefaults(level = AccessLevel.PRIVATE)
+@Schema(description = "Result of tracking a listing detail page view")
+public class ViewTrackResponse {
+
+    @Schema(description = "ID of the listing that was viewed", example = "123")
+    Long listingId;
+
+    @Schema(description = "Whether a new view was recorded (false when deduped)", example = "true")
+    boolean recorded;
+
+    @Schema(description = "Timestamp of the view", example = "2024-01-15T10:30:00")
+    LocalDateTime viewedAt;
+}

--- a/smart-rent/src/main/java/com/smartrent/infra/repository/PhoneClickDetailRepository.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/PhoneClickDetailRepository.java
@@ -234,6 +234,19 @@ public interface PhoneClickDetailRepository extends JpaRepository<PhoneClickDeta
     Page<Object[]> countClicksPerListingForOwnerPagedWithSearch(
             @Param("ownerId") String ownerId, @Param("keyword") String keyword, Pageable pageable);
 
+    /**
+     * Count total phone clicks across ALL listings owned by a user (not paginated).
+     * Used for owner-wide dashboard/customer stats, independent of page size.
+     */
+    @Query("SELECT COUNT(pc) FROM phone_clicks pc WHERE pc.listing.userId = :ownerId")
+    long countByListingOwnerId(@Param("ownerId") String ownerId);
+
+    /**
+     * Count distinct users who clicked on any listing owned by a user (not paginated).
+     */
+    @Query("SELECT COUNT(DISTINCT pc.user.userId) FROM phone_clicks pc WHERE pc.listing.userId = :ownerId")
+    long countDistinctUsersByListingOwnerId(@Param("ownerId") String ownerId);
+
     // ─── Recommendation Signal Queries ───
 
     /**

--- a/smart-rent/src/main/java/com/smartrent/infra/repository/SavedListingRepository.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/SavedListingRepository.java
@@ -49,6 +49,12 @@ public interface SavedListingRepository extends JpaRepository<SavedListing, Save
             "GROUP BY sl.listing_id ORDER BY save_count DESC", nativeQuery = true)
     List<Object[]> countSavesPerListingForOwner(@Param("ownerId") String ownerId);
 
+    @Query(value = "SELECT COUNT(*) " +
+            "FROM saved_listings sl " +
+            "JOIN listings l ON sl.listing_id = l.listing_id " +
+            "WHERE l.user_id = :ownerId", nativeQuery = true)
+    long countTotalSavesForOwner(@Param("ownerId") String ownerId);
+
     @Query(value = "SELECT sl.listing_id, COUNT(*) AS save_count " +
             "FROM saved_listings sl " +
             "JOIN listings l ON sl.listing_id = l.listing_id " +

--- a/smart-rent/src/main/java/com/smartrent/infra/repository/ViewRepository.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/ViewRepository.java
@@ -4,8 +4,15 @@ import com.smartrent.infra.repository.entity.View;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
+
 @Repository
 public interface ViewRepository extends JpaRepository<View, Long> {
 
     long countByListing_ListingId(Long listingId);
+
+    long countByListing_ListingIdAndViewedAtBetween(Long listingId, LocalDateTime start, LocalDateTime end);
+
+    boolean existsByIpAddressAndListing_ListingIdAndViewedAtAfter(
+            String ipAddress, Long listingId, LocalDateTime after);
 }

--- a/smart-rent/src/main/java/com/smartrent/service/analytics/impl/AnalyticsServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/analytics/impl/AnalyticsServiceImpl.java
@@ -53,22 +53,27 @@ public class AnalyticsServiceImpl implements AnalyticsService {
         }
 
         long totalClicks;
-        long totalViews = viewRepository.countByListing_ListingId(listingId);
+        long totalViews;
         List<DailyClickCount> clicksOverTime;
         Map<String, Long> clicksByDayOfWeek;
 
         if (since != null) {
+            LocalDateTime now = LocalDateTime.now();
             totalClicks = phoneClickDetailRepository.countByListing_ListingIdAndClickedAtBetween(
-                    listingId, since, LocalDateTime.now());
+                    listingId, since, now);
+            totalViews = viewRepository.countByListing_ListingIdAndViewedAtBetween(listingId, since, now);
             clicksOverTime = buildClicksOverTimeSince(listingId, since);
             clicksByDayOfWeek = buildClicksByDayOfWeekSince(listingId, since);
         } else {
             totalClicks = phoneClickDetailRepository.countByListing_ListingId(listingId);
+            totalViews = viewRepository.countByListing_ListingId(listingId);
             clicksOverTime = buildClicksOverTime(listingId);
             clicksByDayOfWeek = buildClicksByDayOfWeek(listingId);
         }
 
-        double conversionRate = totalViews > 0 ? (double) totalClicks / totalViews : 0.0;
+        // Views can undercount relative to clicks (ad blockers, JS errors dropping the
+        // tracking beacon), so cap the displayed rate at 100% instead of showing e.g. 340%.
+        double conversionRate = totalViews > 0 ? Math.min(1.0, (double) totalClicks / totalViews) : 0.0;
 
         return ListingAnalyticsResponse.builder()
                 .listingId(listingId)
@@ -160,7 +165,10 @@ public class AnalyticsServiceImpl implements AnalyticsService {
         } else {
             page = savedListingRepository.countSavesPerListingForOwnerPaged(ownerId, pageable);
         }
-        long totalSavesAcrossAll = 0;
+
+        // Computed independently of the page size so it reflects saves across
+        // ALL of the owner's listings, not just the current page.
+        long totalSavesAcrossAll = savedListingRepository.countTotalSavesForOwner(ownerId);
 
         List<ListingSaveSummary> summaries = page.getContent().stream()
                 .map(row -> {
@@ -176,10 +184,6 @@ public class AnalyticsServiceImpl implements AnalyticsService {
                             .build();
                 })
                 .collect(Collectors.toList());
-
-        for (ListingSaveSummary s : summaries) {
-            totalSavesAcrossAll += s.getTotalSaves();
-        }
 
         return OwnerSavedListingsAnalyticsResponse.builder()
                 .listings(summaries)

--- a/smart-rent/src/main/java/com/smartrent/service/phoneclickdetail/PhoneClickDetailService.java
+++ b/smart-rent/src/main/java/com/smartrent/service/phoneclickdetail/PhoneClickDetailService.java
@@ -1,6 +1,7 @@
 package com.smartrent.service.phoneclickdetail;
 
 import com.smartrent.dto.request.PhoneClickRequest;
+import com.smartrent.dto.response.OwnerPhoneClickStatsResponse;
 import com.smartrent.dto.response.PageResponse;
 import com.smartrent.dto.response.PhoneClickResponse;
 import com.smartrent.dto.response.PhoneClickStatsResponse;
@@ -107,5 +108,14 @@ public interface PhoneClickDetailService {
      * @return Paginated user phone click detail responses
      */
     PageResponse<UserPhoneClickDetailResponse> searchUsersWhoClickedOnMyListings(String ownerId, String keyword, int page, int size);
+
+    /**
+     * Get aggregate phone click statistics across ALL listings owned by a user,
+     * independent of pagination (total clicks and total unique interested users).
+     *
+     * @param ownerId Owner/renter user ID
+     * @return Owner-wide phone click statistics
+     */
+    OwnerPhoneClickStatsResponse getOwnerPhoneClickStats(String ownerId);
 }
 

--- a/smart-rent/src/main/java/com/smartrent/service/phoneclickdetail/impl/PhoneClickDetailServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/phoneclickdetail/impl/PhoneClickDetailServiceImpl.java
@@ -2,6 +2,7 @@ package com.smartrent.service.phoneclickdetail.impl;
 
 import com.smartrent.dto.request.PhoneClickRequest;
 import com.smartrent.dto.response.ListingClickInfo;
+import com.smartrent.dto.response.OwnerPhoneClickStatsResponse;
 import com.smartrent.dto.response.PageResponse;
 import com.smartrent.dto.response.PhoneClickResponse;
 import com.smartrent.dto.response.PhoneClickStatsResponse;
@@ -459,6 +460,20 @@ public class PhoneClickDetailServiceImpl implements PhoneClickDetailService {
                 .totalPages(userIdsPage.getTotalPages())
                 .totalElements(userIdsPage.getTotalElements())
                 .data(responses)
+                .build();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public OwnerPhoneClickStatsResponse getOwnerPhoneClickStats(String ownerId) {
+        log.info("Getting owner-wide phone click stats for user {}", ownerId);
+
+        long totalClicks = phoneClickDetailRepository.countByListingOwnerId(ownerId);
+        long uniqueUsers = phoneClickDetailRepository.countDistinctUsersByListingOwnerId(ownerId);
+
+        return OwnerPhoneClickStatsResponse.builder()
+                .totalClicks(totalClicks)
+                .uniqueUsers(uniqueUsers)
                 .build();
     }
 

--- a/smart-rent/src/main/java/com/smartrent/service/view/ViewService.java
+++ b/smart-rent/src/main/java/com/smartrent/service/view/ViewService.java
@@ -1,0 +1,23 @@
+package com.smartrent.service.view;
+
+import com.smartrent.dto.request.ViewTrackRequest;
+import com.smartrent.dto.response.ViewTrackResponse;
+
+/**
+ * Service for tracking listing detail page views
+ */
+public interface ViewService {
+
+    /**
+     * Track a view on a listing's detail page. Callable anonymously; no
+     * authentication required. Deduped per IP address within a short window
+     * so page refreshes/reloads don't inflate the count.
+     *
+     * @param request   View tracking request containing listing ID
+     * @param userId    Authenticated user ID if present, otherwise null
+     * @param ipAddress IP address of the request
+     * @param userAgent User agent string
+     * @return View tracking response
+     */
+    ViewTrackResponse trackView(ViewTrackRequest request, String userId, String ipAddress, String userAgent);
+}

--- a/smart-rent/src/main/java/com/smartrent/service/view/impl/ViewServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/view/impl/ViewServiceImpl.java
@@ -1,0 +1,69 @@
+package com.smartrent.service.view.impl;
+
+import com.smartrent.dto.request.ViewTrackRequest;
+import com.smartrent.dto.response.ViewTrackResponse;
+import com.smartrent.infra.repository.ListingRepository;
+import com.smartrent.infra.repository.ViewRepository;
+import com.smartrent.infra.repository.entity.Listing;
+import com.smartrent.infra.repository.entity.View;
+import com.smartrent.service.view.ViewService;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.FieldDefaults;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+@FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
+@Slf4j
+public class ViewServiceImpl implements ViewService {
+
+    private static final int DEDUPE_WINDOW_MINUTES = 30;
+
+    ListingRepository listingRepository;
+    ViewRepository viewRepository;
+
+    @Override
+    @Transactional
+    public ViewTrackResponse trackView(ViewTrackRequest request, String userId, String ipAddress, String userAgent) {
+        Long listingId = request.getListingId();
+
+        Listing listing = listingRepository.findById(listingId)
+                .orElseThrow(() -> new RuntimeException("Listing not found with ID: " + listingId));
+
+        if (ipAddress != null) {
+            LocalDateTime windowStart = LocalDateTime.now().minusMinutes(DEDUPE_WINDOW_MINUTES);
+            boolean alreadyViewed = viewRepository
+                    .existsByIpAddressAndListing_ListingIdAndViewedAtAfter(ipAddress, listingId, windowStart);
+            if (alreadyViewed) {
+                log.debug("Duplicate view from IP {} on listing {} within {} minutes, ignoring",
+                        ipAddress, listingId, DEDUPE_WINDOW_MINUTES);
+                return ViewTrackResponse.builder()
+                        .listingId(listingId)
+                        .recorded(false)
+                        .viewedAt(LocalDateTime.now())
+                        .build();
+            }
+        }
+
+        View view = View.builder()
+                .listing(listing)
+                .userId(userId)
+                .ipAddress(ipAddress)
+                .userAgent(userAgent)
+                .build();
+
+        View saved = viewRepository.save(view);
+        log.debug("View tracked for listing {} with ID: {}", listingId, saved.getId());
+
+        return ViewTrackResponse.builder()
+                .listingId(listingId)
+                .recorded(true)
+                .viewedAt(saved.getViewedAt())
+                .build();
+    }
+}

--- a/smart-rent/src/main/resources/application.yml
+++ b/smart-rent/src/main/resources/application.yml
@@ -235,6 +235,7 @@ application:
         - "/v1/listings/stats/categories"
         - "/v1/listings/map-bounds"
         - "/v1/listings/search-suggestions/click"
+        - "/v1/views"
   authentication:
     jwt:
       access-signer-key: "${ACCESS_SIGNER_KEY}"


### PR DESCRIPTION
Seller dashboard showed "Tổng lượt xem" always as 0 while phone-click count was nonzero — no code path ever inserted rows into the `views` table. Adds POST /v1/views (no auth required) so the frontend can record a view when a listing detail page opens.

While auditing owner analytics for correctness:
- totalViews always used all-time data even when a period filter (7d/30d/...) scoped totalClicks, making conversionRate meaningless for anything but "all time" — now both use the same window.
- Conversion rate is now capped at 100%, since views can legitimately undercount clicks (blocked/dropped tracking beacon).
- totalSavesAcrossAll on the saved-listings dashboard only summed the current page (default size 10) instead of all of the owner's listings — now backed by a dedicated COUNT query.
- Customer management stat cards (total clicks / unique users) were computed from the current page of results instead of all of the owner's listings — added GET /v1/phone-click-details/my-listings/stats for true aggregates.