### PR TITLE
fix(listing): gate homepage-tier carousel on moderationStatus, not ju…

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/infra/repository/ListingRepository.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/ListingRepository.java
@@ -138,6 +138,13 @@ public interface ListingRepository extends JpaRepository<Listing, Long>, JpaSpec
      */
     @Query("SELECT l FROM listings l LEFT JOIN FETCH l.address " +
            "WHERE l.vipType = :vipType AND l.verified = true " +
+           // Defense-in-depth: verified is the leading equality idx_listings_public_vip_tier
+           // (vip_type, verified, is_draft, is_shadow, updated_at) seeks on — keep it so the
+           // index scan + backward-order LIMIT still avoids a filesort on the huge NORMAL tier.
+           // moderationStatus is the canonical visibility gate (see ListingSpecification);
+           // added on top so this query can't drift from it even if verified/moderationStatus
+           // ever fall out of sync on a row.
+           "AND l.moderationStatus = com.smartrent.enums.ModerationStatus.APPROVED " +
            "AND l.isDraft = false AND l.isShadow = false " +
            "AND l.expired = false " +
            "AND (l.expiryDate IS NULL OR l.expiryDate > CURRENT_TIMESTAMP) " +


### PR DESCRIPTION
…st verified

"Tin mới" and the VIP-tier carousels ("Tin đề xuất") both read from findHomepageTier, which only checked verified=true. Every other public listing query (ListingSpecification.fromFilterRequest) treats verified as a trust badge and gates visibility on moderationStatus=APPROVED instead, so this was a third, divergent copy of the visibility rule with no defense if a row's verified/moderationStatus ever fall out of sync. Add the moderationStatus=APPROVED check on top of verified=true (kept so idx_listings_public_vip_tier, which seeks on verified, still avoids a filesort on the large NORMAL tier).