### PR TITLE
perf(map): stop joining listing_amenities on the map-bounds endpoint

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/dto/response/MapListingsResponse.java
+++ b/smart-rent/src/main/java/com/smartrent/dto/response/MapListingsResponse.java
@@ -25,10 +25,10 @@ import java.util.List;
 public class MapListingsResponse {
 
     @Schema(
-        description = "Danh sách bài đăng trong vùng bản đồ. Đã được sắp xếp theo VIP type (DIAMOND > GOLD > SILVER > NORMAL) và updatedAt (mới nhất trước).",
+        description = "Danh sách bài đăng trong vùng bản đồ (dạng card, không kèm amenities). Đã được sắp xếp theo VIP type (DIAMOND > GOLD > SILVER > NORMAL) và updatedAt (mới nhất trước).",
         example = "[...]"
     )
-    List<ListingResponse> listings;
+    List<ListingCardResponse> listings;
 
     @Schema(
         description = "Tổng số lượng bài đăng trong vùng (có thể nhiều hơn số lượng trả về do limit)",

--- a/smart-rent/src/main/java/com/smartrent/service/listing/impl/ListingServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/listing/impl/ListingServiceImpl.java
@@ -3179,8 +3179,13 @@ public class ListingServiceImpl implements ListingService {
                 request.getVipType()
         );
 
-        // Batch-load all relationships and map to DTOs (avoids N+1)
-        List<ListingResponse> listings = batchMapListings(page.getContent());
+        // Card DTO: the map only ever renders pins/cards (title, price, area,
+        // first-image thumbnail) — never amenities. batchMapListings() joins
+        // listing_amenities (a @ManyToMany), which multiplies the result set by
+        // amenity count per listing and was pure overhead here. batchMapCardListings()
+        // skips that join entirely, which is the dominant cost at high zoom-out
+        // levels where the query returns close to the 500-listing cap.
+        List<ListingCardResponse> listings = batchMapCardListings(page.getContent());
 
         // Build bounds info
         com.smartrent.dto.response.MapListingsResponse.MapBoundsInfo boundsInfo =

--- a/smart-rent/src/test/java/com/smartrent/service/listing/impl/ListingServiceImplMapBoundsTest.java
+++ b/smart-rent/src/test/java/com/smartrent/service/listing/impl/ListingServiceImplMapBoundsTest.java
@@ -1,0 +1,85 @@
+package com.smartrent.service.listing.impl;
+
+import com.smartrent.dto.request.MapBoundsRequest;
+import com.smartrent.dto.response.ListingCardResponse;
+import com.smartrent.dto.response.MapListingsResponse;
+import com.smartrent.infra.repository.ListingRepository;
+import com.smartrent.infra.repository.UserRepository;
+import com.smartrent.infra.repository.entity.Listing;
+import com.smartrent.mapper.ListingMapper;
+import com.smartrent.service.listing.ListingQueryService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * GET /v1/listings/map-bounds was slow because it mapped results through
+ * batchMapListings(), which LEFT JOIN FETCHes listing_amenities (a
+ * @ManyToMany) even though the map only ever renders card-level fields
+ * (title, price, area, first-image thumbnail). That join multiplies the
+ * result set by amenity count per listing for data the map never displays.
+ * Locks in the fix: the endpoint must use the card path and must never
+ * touch the amenities batch-load.
+ */
+@ExtendWith(MockitoExtension.class)
+class ListingServiceImplMapBoundsTest {
+
+    @Mock
+    ListingQueryService listingQueryService;
+
+    @Mock
+    ListingRepository listingRepository;
+
+    @Mock
+    UserRepository userRepository;
+
+    @Mock
+    ListingMapper listingMapper;
+
+    @InjectMocks
+    ListingServiceImpl service;
+
+    @Test
+    void mapBoundsUsesCardResponseAndSkipsAmenitiesFetch() {
+        Listing listing = Listing.builder()
+                .listingId(1L)
+                .build();
+
+        when(listingQueryService.queryByMapBounds(
+                any(), any(), any(), any(), any(), any(), any(), any()))
+                .thenReturn(new PageImpl<>(List.of(listing), Pageable.unpaged(), 1));
+        when(listingRepository.findByIdsWithMedia(anyCollection()))
+                .thenReturn(List.of(listing));
+        when(listingMapper.toCardResponse(any(), any(), any()))
+                .thenReturn(ListingCardResponse.builder().listingId(1L).build());
+
+        MapBoundsRequest request = MapBoundsRequest.builder()
+                .neLat(BigDecimal.valueOf(10.823))
+                .neLng(BigDecimal.valueOf(106.701))
+                .swLat(BigDecimal.valueOf(10.705))
+                .swLng(BigDecimal.valueOf(106.590))
+                .zoom(14)
+                .limit(100)
+                .build();
+
+        MapListingsResponse response = service.getListingsByMapBounds(request);
+
+        assertEquals(1, response.getListings().size());
+        assertEquals(1L, response.getListings().get(0).getListingId());
+        verify(listingRepository, never()).findByIdsWithAmenities(anyCollection());
+    }
+}


### PR DESCRIPTION
POST /v1/listings/map-bounds mapped results through batchMapListings(), which runs findByIdsWithAmenities() — a LEFT JOIN FETCH on the listing_amenities @ManyToMany table. For up to 500 listings per request (the endpoint's cap) that join multiplies the result set by amenity count per listing, all to populate a field the interactive map never renders (MapPropertyCard/MapMarker on the frontend only ever read title, price, area, vip tier, address summary, and the first media thumbnail — never amenities). That extra join scales with viewport size and is the main cost once a viewport gets close to the cap.

Switch to batchMapCardListings()/ListingCardResponse, the same lightweight card path already used by search and my-listings, which fetches media but skips the amenities join entirely.