### PR TITLE
perf(recommendation): denormalize location onto listings to kill candidate-retrieval filesort (63s → sub-second)

### DIFF
--- a/smart-rent/docs/superpowers/specs/2026-07-06-recommendation-candidate-retrieval-optimization-design.md
+++ b/smart-rent/docs/superpowers/specs/2026-07-06-recommendation-candidate-retrieval-optimization-design.md
@@ -1,0 +1,114 @@
+# Tối ưu candidate retrieval của recommendation (personalized + similar)
+
+- **Ngày:** 2026-07-06
+- **Phạm vi:** `RecommendationServiceImpl.getPersonalizedFeed` ("Bất động sản dành cho bạn")
+  và `getSimilarListings` ("Bất động sản tương tự").
+- **Trạng thái:** đã duyệt, đang implement.
+
+## 1. Bối cảnh & nguyên nhân (đã xác minh bằng đo đạc)
+
+Endpoint `/v1/recommendations/personalized` mất **63–81 giây**. Dòng log
+`[PerfTrace]` sẵn có trong `RecommendationServiceImpl` chia nhỏ latency và cho thấy
+toàn bộ thời gian nằm ở **stage `candidateRetrieval`** (≈63–81s), còn mọi stage khác
+là mili-giây (`feignAi`≈17ms, `cfGlobal+features`≈15ms, `interactions`≈250–650ms).
+→ Không phải AI, không phải payload — 100% là các query DB lấy candidate pool.
+
+`EXPLAIN ANALYZE` một channel candidate trên chính DB app:
+`-> Sort row IDs: l.pushed_at DESC, l.post_date DESC` → **filesort**, ~2s khi chạy
+đơn lẻ (cache ấm, không tranh chấp). Trong thực tế mỗi request chạy **3 channel song
+song** filesort tập lớn trên **DB DigitalOcean Managed 1GB / 1 vCPU với
+`innodb_buffer_pool_size = 32MB`** → thrash buffer pool + đói I/O → 63s. Query
+tra-theo-id (stage `interactions`) chỉ chạm vài trang nên vẫn nhanh → giải thích vì
+sao chậm *có chọn lọc*.
+
+### Root cause: filter và sort ở hai bảng khác nhau
+
+Query candidate **lọc trên `addresses`** (`new_province_code` / `new_ward_code` /
+`legacy_district_id` / `legacy_ward_id` / `legacy_province_id`) nhưng **sắp xếp trên
+`listings`** (`pushed_at`, `post_date`). Không B-tree index nào phục vụ được đồng thời
+"lọc bảng X, sort bảng Y" → MySQL buộc filesort toàn bộ tập matched của cả tỉnh
+(HCMC ~chục nghìn dòng) chỉ để lấy 100. Index `idx_listings_pushed_at` (V81, tạo đúng
+cho recommendation) **vô dụng** vì bảng lái query là `addresses`.
+
+Đây là schema chuẩn hoá cho write nhưng **chưa thiết kế read-model cho hot path** —
+không phải index thiếu, mà thiếu điều kiện để index tồn tại. Vì `addresses` là dữ
+liệu **cố định** (không đổi trong tương lai), denormalize là an toàn và sạch.
+
+Ghi chú: `innodb_buffer_pool_size` **không sửa được** vì đây là DO Managed DB (không
+cấp SUPER, buffer pool cố định theo plan). Nên phải trị ở tầng query để chạy nhanh
+ngay cả với buffer pool 32MB.
+
+## 2. Giải pháp: denormalize location key + composite index (single-table)
+
+### 2.1 Schema — 5 cột copy nguyên trạng từ `addresses` sang `listings`
+
+| Cột (`listings`) | Kiểu | Nguồn |
+|---|---|---|
+| `new_province_code` | `VARCHAR(10)` NULL | `addresses.new_province_code` |
+| `new_ward_code` | `VARCHAR(10)` NULL | `addresses.new_ward_code` |
+| `legacy_province_id` | `INT` NULL | `addresses.legacy_province_id` |
+| `legacy_district_id` | `INT` NULL | `addresses.legacy_district_id` |
+| `legacy_ward_id` | `INT` NULL | `addresses.legacy_ward_id` |
+
+Chỉ copy các cột dùng để **lọc**; không copy lat/lon (chỉ dùng lúc build DTO, không
+nằm trong `WHERE`).
+
+### 2.2 Index — 1 composite / mỗi shape location, mirror pattern `idx_listings_public_default_sort` (V82)
+
+Mẫu: `(location_col, is_draft, is_shadow, verified, expired, pushed_at, post_date)`.
+4 boolean visibility là equality → nằm giữa; `pushed_at, post_date` ở đuôi cho
+**index-ordered scan → 0 filesort**. `expiry_date`, `NOT IN(excluded)`, `product_type`,
+`listing_type`, `price` là residual filter (không phá thứ tự).
+
+1. `idx_listings_reco_new_prov`  = `(new_province_code, is_draft, is_shadow, verified, expired, pushed_at, post_date)`
+2. `idx_listings_reco_new_ward`  = `(new_ward_code, …)`
+3. `idx_listings_reco_legacy_dist` = `(legacy_district_id, …)`
+4. `idx_listings_reco_legacy_ward` = `(legacy_ward_id, …)`
+5. `idx_listings_reco_legacy_prov` = `(legacy_province_id, …)`
+6. `idx_listings_reco_fresh`     = `(is_draft, is_shadow, verified, expired, pushed_at, post_date)` (global / cold-start / top-up)
+
+Cùng 6 index phục vụ **cả hai endpoint**; `similar` thêm `product_type`/`listing_type`
+làm residual.
+
+### 2.3 Viết lại query (signature-preserving)
+
+Trong `ListingRepository`, mỗi query candidate: đổi filter `a.<col>` →
+**`l.<col>`** (cột denormalized), giữ `LEFT JOIN FETCH l.address` để hydrate ~LIMIT
+dòng cuối, bỏ `NULLS LAST` (MySQL DESC vốn để NULL cuối; Hibernate đã compile bỏ nên
+SQL không đổi — dọn cho sạch). **Không đổi tên/tham số method** → không lan sang
+`RecommendationServiceImpl` hay test.
+
+Điều kiện OR `(new_province_code OR legacy_province_id)` ở price/similar channel tạm
+**giữ nguyên nhưng đổi sang `l.*`** (để không đổi signature). Đây là channel phụ; khi
+lọc đã nằm trên `listings`, MySQL index-merge/residual thay vì filesort xuyên bảng.
+*Tinh chỉnh tương lai (deferred):* tách OR thành 2 query new/legacy + branch trong
+Java để bỏ hẳn filesort ở channel giá.
+
+### 2.4 Đồng bộ + backfill
+
+- **Write-sync:** mở rộng hook `@PrePersist @PreUpdate updateSearchFields()` để copy 5
+  mã từ `address`. Idempotent; vì address cố định thực chất chỉ cần lúc create.
+- **Backfill (Flyway V97):** thêm cột → `UPDATE listings l JOIN addresses a` copy 5
+  mã cho 94k dòng hiện có → tạo 6 index (tạo index *sau* backfill để nhanh hơn).
+  Guard idempotent bằng `information_schema` theo đúng style V81/82/83.
+- **Thứ tự rollout an toàn:** migration chạy trước, code đọc cột mới deploy sau; code
+  cũ bỏ qua cột mới → không có khoảng gãy.
+
+## 3. Nghiệm thu
+
+- **Tương đương:** bộ candidate trước/sau phải trùng (cùng freshest theo location).
+- **Perf:** `EXPLAIN ANALYZE` từng channel → dùng index mới, **không `Sort row IDs`**;
+  đo lại `[PerfTrace] candidateRetrieval` — mục tiêu **< 300ms**.
+- **Backfill đúng:** `COUNT(*)` các dòng `l.new_province_code <> a.new_province_code`
+  (và 4 cột kia) = 0.
+- **Integration/regression:** 2 endpoint trả feed đúng; `RecommendationServiceImplTest`
+  xanh.
+
+## 4. Rủi ro & giới hạn
+
+- Ghi thêm 6 index → mỗi lần "đẩy tin" (update `pushed_at`) ghi lại 6 index; chấp nhận
+  với tần suất push thực tế. Tổng dung lượng index thêm ~25MB / 94k dòng (không đáng
+  trên 10GiB).
+- Backfill `UPDATE` 94k dòng khoá bảng ngắn khi deploy — chấp nhận (one-time).
+- Denormalized data lệ thuộc address **cố định**; nếu sau này address đổi hàng loạt
+  độc lập thì cần 1 migration re-sync (ngoài phạm vi hiện tại).

--- a/smart-rent/src/main/java/com/smartrent/infra/repository/ListingRepository.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/ListingRepository.java
@@ -551,14 +551,14 @@ public interface ListingRepository extends JpaRepository<Listing, Long>, JpaSpec
      * Proximity-based candidate pool (same district) for similar listings multi-channel retrieval.
      */
     @Query("""
-        SELECT l FROM listings l JOIN FETCH l.address a
-        WHERE (a.newProvinceCode = :provinceCode OR (a.legacyProvinceId = :provinceId AND :provinceId IS NOT NULL))
-        AND a.legacyDistrictId = :districtId
+        SELECT l FROM listings l LEFT JOIN FETCH l.address
+        WHERE l.legacyDistrictId = :districtId
+        AND (l.newProvinceCode = :provinceCode OR (l.legacyProvinceId = :provinceId AND :provinceId IS NOT NULL))
         AND l.productType = :productType
         AND l.listingType = :listingType
         AND l.listingId <> :excludeId
         AND l.isDraft = false AND l.isShadow = false AND l.verified = true AND l.expired = false
-        ORDER BY l.pushedAt DESC NULLS LAST, l.postDate DESC
+        ORDER BY l.pushedAt DESC, l.postDate DESC
     """)
     List<Listing> findSimilarProximityCandidates(
         @Param("provinceCode") String provinceCode,
@@ -574,14 +574,14 @@ public interface ListingRepository extends JpaRepository<Listing, Long>, JpaSpec
      * Price-based candidate pool (matching price range) for similar listings multi-channel retrieval.
      */
     @Query("""
-        SELECT l FROM listings l JOIN FETCH l.address a
-        WHERE (a.newProvinceCode = :provinceCode OR (a.legacyProvinceId = :provinceId AND :provinceId IS NOT NULL))
+        SELECT l FROM listings l LEFT JOIN FETCH l.address
+        WHERE (l.newProvinceCode = :provinceCode OR (l.legacyProvinceId = :provinceId AND :provinceId IS NOT NULL))
         AND l.price BETWEEN :minPrice AND :maxPrice
         AND l.productType = :productType
         AND l.listingType = :listingType
         AND l.listingId <> :excludeId
         AND l.isDraft = false AND l.isShadow = false AND l.verified = true AND l.expired = false
-        ORDER BY l.pushedAt DESC NULLS LAST, l.postDate DESC
+        ORDER BY l.pushedAt DESC, l.postDate DESC
     """)
     List<Listing> findSimilarPriceCandidates(
         @Param("provinceCode") String provinceCode,
@@ -598,8 +598,8 @@ public interface ListingRepository extends JpaRepository<Listing, Long>, JpaSpec
      * Candidate pool for "similar listings" by legacy province ID.
      */
     @Query("""
-        SELECT l FROM listings l LEFT JOIN FETCH l.address a
-        WHERE a.legacyProvinceId = :provinceId
+        SELECT l FROM listings l LEFT JOIN FETCH l.address
+        WHERE l.legacyProvinceId = :provinceId
         AND l.productType = :productType
         AND l.listingType = :listingType
         AND l.listingId <> :excludeId
@@ -607,7 +607,7 @@ public interface ListingRepository extends JpaRepository<Listing, Long>, JpaSpec
         AND l.isShadow = false
         AND l.verified = true
         AND l.expired = false
-        ORDER BY l.pushedAt DESC NULLS LAST, l.postDate DESC
+        ORDER BY l.pushedAt DESC, l.postDate DESC
     """)
     List<Listing> findCandidatesForSimilarByLegacyProvince(
         @Param("provinceId") Integer provinceId,
@@ -621,8 +621,8 @@ public interface ListingRepository extends JpaRepository<Listing, Long>, JpaSpec
      * Candidate pool for "similar listings" by new province code.
      */
     @Query("""
-        SELECT l FROM listings l LEFT JOIN FETCH l.address a
-        WHERE a.newProvinceCode = :provinceCode
+        SELECT l FROM listings l LEFT JOIN FETCH l.address
+        WHERE l.newProvinceCode = :provinceCode
         AND l.productType = :productType
         AND l.listingType = :listingType
         AND l.listingId <> :excludeId
@@ -630,7 +630,7 @@ public interface ListingRepository extends JpaRepository<Listing, Long>, JpaSpec
         AND l.isShadow = false
         AND l.verified = true
         AND l.expired = false
-        ORDER BY l.pushedAt DESC NULLS LAST, l.postDate DESC
+        ORDER BY l.pushedAt DESC, l.postDate DESC
     """)
     List<Listing> findCandidatesForSimilarByNewProvince(
         @Param("provinceCode") String provinceCode,
@@ -652,7 +652,7 @@ public interface ListingRepository extends JpaRepository<Listing, Long>, JpaSpec
         AND l.isShadow = false
         AND l.verified = true
         AND l.expired = false
-        ORDER BY l.pushedAt DESC NULLS LAST, l.postDate DESC
+        ORDER BY l.pushedAt DESC, l.postDate DESC
     """)
     List<Listing> findCandidatesForSimilarGlobal(
         @Param("productType") Listing.ProductType productType,
@@ -665,13 +665,13 @@ public interface ListingRepository extends JpaRepository<Listing, Long>, JpaSpec
      * Budget-based candidate pool for personalized feed multi-channel retrieval.
      */
     @Query("""
-        SELECT l FROM listings l JOIN FETCH l.address a
-        WHERE (a.newProvinceCode = :provinceCode OR (a.legacyProvinceId = :provinceId AND :provinceId IS NOT NULL))
+        SELECT l FROM listings l LEFT JOIN FETCH l.address
+        WHERE (l.newProvinceCode = :provinceCode OR (l.legacyProvinceId = :provinceId AND :provinceId IS NOT NULL))
         AND l.price BETWEEN :minPrice AND :maxPrice
         AND l.listingId NOT IN :excludedIds
         AND l.isDraft = false AND l.isShadow = false AND l.verified = true AND l.expired = false
         AND (l.expiryDate IS NULL OR l.expiryDate > CURRENT_TIMESTAMP)
-        ORDER BY l.pushedAt DESC NULLS LAST, l.postDate DESC
+        ORDER BY l.pushedAt DESC, l.postDate DESC
     """)
     List<Listing> findPersonalizedPriceCandidates(
         @Param("provinceCode") String provinceCode,
@@ -686,15 +686,15 @@ public interface ListingRepository extends JpaRepository<Listing, Long>, JpaSpec
      * Candidate pool for personalized feed by legacy province ID.
      */
     @Query("""
-        SELECT l FROM listings l LEFT JOIN FETCH l.address a
-        WHERE a.legacyProvinceId = :provinceId
+        SELECT l FROM listings l LEFT JOIN FETCH l.address
+        WHERE l.legacyProvinceId = :provinceId
         AND l.listingId NOT IN :excludedIds
         AND l.isDraft = false
         AND l.isShadow = false
         AND l.verified = true
         AND l.expired = false
         AND (l.expiryDate IS NULL OR l.expiryDate > CURRENT_TIMESTAMP)
-        ORDER BY l.pushedAt DESC NULLS LAST, l.postDate DESC
+        ORDER BY l.pushedAt DESC, l.postDate DESC
     """)
     List<Listing> findCandidatesForPersonalizedByLegacyProvince(
         @Param("provinceId") Integer provinceId,
@@ -706,15 +706,15 @@ public interface ListingRepository extends JpaRepository<Listing, Long>, JpaSpec
      * Candidate pool for personalized feed by new province code.
      */
     @Query("""
-        SELECT l FROM listings l LEFT JOIN FETCH l.address a
-        WHERE a.newProvinceCode = :provinceCode
+        SELECT l FROM listings l LEFT JOIN FETCH l.address
+        WHERE l.newProvinceCode = :provinceCode
         AND l.listingId NOT IN :excludedIds
         AND l.isDraft = false
         AND l.isShadow = false
         AND l.verified = true
         AND l.expired = false
         AND (l.expiryDate IS NULL OR l.expiryDate > CURRENT_TIMESTAMP)
-        ORDER BY l.pushedAt DESC NULLS LAST, l.postDate DESC
+        ORDER BY l.pushedAt DESC, l.postDate DESC
     """)
     List<Listing> findCandidatesForPersonalizedByNewProvince(
         @Param("provinceCode") String provinceCode,
@@ -726,15 +726,15 @@ public interface ListingRepository extends JpaRepository<Listing, Long>, JpaSpec
      * Candidate pool for personalized feed: Same Legacy Ward
      */
     @Query("""
-        SELECT l FROM listings l LEFT JOIN FETCH l.address a
-        WHERE a.legacyWardId = :wardId
+        SELECT l FROM listings l LEFT JOIN FETCH l.address
+        WHERE l.legacyWardId = :wardId
         AND l.listingId NOT IN :excludedIds
         AND l.isDraft = false
         AND l.isShadow = false
         AND l.verified = true
         AND l.expired = false
         AND (l.expiryDate IS NULL OR l.expiryDate > CURRENT_TIMESTAMP)
-        ORDER BY l.pushedAt DESC NULLS LAST, l.postDate DESC
+        ORDER BY l.pushedAt DESC, l.postDate DESC
     """)
     List<Listing> findCandidatesByLegacyWard(
         @Param("wardId") Integer wardId,
@@ -746,15 +746,15 @@ public interface ListingRepository extends JpaRepository<Listing, Long>, JpaSpec
      * Candidate pool for personalized feed: Same New Ward
      */
     @Query("""
-        SELECT l FROM listings l LEFT JOIN FETCH l.address a
-        WHERE a.newWardCode = :wardCode
+        SELECT l FROM listings l LEFT JOIN FETCH l.address
+        WHERE l.newWardCode = :wardCode
         AND l.listingId NOT IN :excludedIds
         AND l.isDraft = false
         AND l.isShadow = false
         AND l.verified = true
         AND l.expired = false
         AND (l.expiryDate IS NULL OR l.expiryDate > CURRENT_TIMESTAMP)
-        ORDER BY l.pushedAt DESC NULLS LAST, l.postDate DESC
+        ORDER BY l.pushedAt DESC, l.postDate DESC
     """)
     List<Listing> findCandidatesByNewWard(
         @Param("wardCode") String wardCode,
@@ -766,15 +766,15 @@ public interface ListingRepository extends JpaRepository<Listing, Long>, JpaSpec
      * Candidate pool for personalized feed: Same District
      */
     @Query("""
-        SELECT l FROM listings l LEFT JOIN FETCH l.address a
-        WHERE a.legacyDistrictId = :districtId
+        SELECT l FROM listings l LEFT JOIN FETCH l.address
+        WHERE l.legacyDistrictId = :districtId
         AND l.listingId NOT IN :excludedIds
         AND l.isDraft = false
         AND l.isShadow = false
         AND l.verified = true
         AND l.expired = false
         AND (l.expiryDate IS NULL OR l.expiryDate > CURRENT_TIMESTAMP)
-        ORDER BY l.pushedAt DESC NULLS LAST, l.postDate DESC
+        ORDER BY l.pushedAt DESC, l.postDate DESC
     """)
     List<Listing> findCandidatesByDistrict(
         @Param("districtId") Integer districtId,
@@ -794,7 +794,7 @@ public interface ListingRepository extends JpaRepository<Listing, Long>, JpaSpec
         AND l.verified = true
         AND l.expired = false
         AND (l.expiryDate IS NULL OR l.expiryDate > CURRENT_TIMESTAMP)
-        ORDER BY l.pushedAt DESC NULLS LAST, l.postDate DESC
+        ORDER BY l.pushedAt DESC, l.postDate DESC
     """)
     List<Listing> findCandidatesForPersonalizedGlobal(
         @Param("excludedIds") java.util.List<Long> excludedIds,

--- a/smart-rent/src/main/java/com/smartrent/infra/repository/entity/Listing.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/entity/Listing.java
@@ -47,7 +47,18 @@ import java.util.List;
                 // Directions (updated_at/listing_id DESC) need MySQL 8; the real index is built by V94.
                 @Index(name = "idx_listings_public_cursor_default", columnList = "moderation_status, is_draft, is_shadow, vip_type_sort_order, updated_at, listing_id"),
                 // Category-filtered cursor feed (?categoryId=…) — leads with category_id. See V94.
-                @Index(name = "idx_listings_public_cursor_category", columnList = "category_id, moderation_status, is_draft, is_shadow, vip_type_sort_order, updated_at, listing_id")
+                @Index(name = "idx_listings_public_cursor_category", columnList = "category_id, moderation_status, is_draft, is_shadow, vip_type_sort_order, updated_at, listing_id"),
+                // Recommendation candidate retrieval (getPersonalizedFeed / getSimilarListings) — see V97.
+                // Location keys are denormalized from addresses (fixed reference data) so filter AND sort
+                // live on listings ⇒ each candidate query is a single-table index-ordered range scan, no
+                // filesort. Equality prefix (location + visibility) + ordered suffix (pushed_at, post_date),
+                // mirroring idx_listings_public_default_sort. product_type/listing_type/price/expiry are residual.
+                @Index(name = "idx_listings_reco_new_prov", columnList = "new_province_code, is_draft, is_shadow, verified, expired, pushed_at, post_date"),
+                @Index(name = "idx_listings_reco_new_ward", columnList = "new_ward_code, is_draft, is_shadow, verified, expired, pushed_at, post_date"),
+                @Index(name = "idx_listings_reco_legacy_dist", columnList = "legacy_district_id, is_draft, is_shadow, verified, expired, pushed_at, post_date"),
+                @Index(name = "idx_listings_reco_legacy_ward", columnList = "legacy_ward_id, is_draft, is_shadow, verified, expired, pushed_at, post_date"),
+                @Index(name = "idx_listings_reco_legacy_prov", columnList = "legacy_province_id, is_draft, is_shadow, verified, expired, pushed_at, post_date"),
+                @Index(name = "idx_listings_reco_fresh", columnList = "is_draft, is_shadow, verified, expired, pushed_at, post_date")
         })
 @Getter
 @Setter
@@ -178,6 +189,27 @@ public class Listing {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "address_id", nullable = false)
     Address address;
+
+    // Denormalized location keys copied from the referenced Address (fixed
+    // reference data). Populated by updateSearchFields() on persist/update and
+    // backfilled in V97. These exist ONLY so the recommendation candidate
+    // queries can filter AND sort on listings alone (see idx_listings_reco_*),
+    // turning a cross-table filter+sort filesort into an index-ordered scan.
+    // Read the Address entity for canonical values; never write these directly.
+    @Column(name = "new_province_code", length = 10)
+    String newProvinceCode;
+
+    @Column(name = "new_ward_code", length = 10)
+    String newWardCode;
+
+    @Column(name = "legacy_province_id")
+    Integer legacyProvinceId;
+
+    @Column(name = "legacy_district_id")
+    Integer legacyDistrictId;
+
+    @Column(name = "legacy_ward_id")
+    Integer legacyWardId;
 
     // Property Specifications
     @Column(name = "area")
@@ -363,6 +395,18 @@ public class Listing {
     @PrePersist
     @PreUpdate
     private void updateSearchFields() {
+        // Keep the denormalized location keys in sync with the referenced address
+        // (see the field comment + idx_listings_reco_*). Address is fixed reference
+        // data, so in practice this only ever fires meaningfully on create; the
+        // address proxy is already initialized below via getDisplayAddress().
+        if (address != null) {
+            newProvinceCode = address.getNewProvinceCode();
+            newWardCode = address.getNewWardCode();
+            legacyProvinceId = address.getLegacyProvinceId();
+            legacyDistrictId = address.getLegacyDistrictId();
+            legacyWardId = address.getLegacyWardId();
+        }
+
         String addressText = address != null ? address.getDisplayAddress() : null;
         String descSnippet = description;
         if (descSnippet != null && descSnippet.length() > 200) {

--- a/smart-rent/src/main/resources/db/migration/V97__Denormalize_location_onto_listings_for_recommendation.sql
+++ b/smart-rent/src/main/resources/db/migration/V97__Denormalize_location_onto_listings_for_recommendation.sql
@@ -1,0 +1,154 @@
+-- Migration V97: Denormalize address location keys onto listings + composite
+-- indexes for the recommendation candidate-retrieval hot path.
+-- ============================================================================
+-- WHY. The recommendation candidate queries (RecommendationServiceImpl,
+-- getPersonalizedFeed / getSimilarListings) FILTER on addresses columns
+-- (new_province_code / new_ward_code / legacy_district_id / legacy_ward_id /
+-- legacy_province_id) but SORT on listings columns (pushed_at, post_date). No
+-- single B-tree index can serve a filter on one table and an ORDER BY on
+-- another, so MySQL filesorts the whole province-matched set (tens of thousands
+-- of rows for a big province) just to return ~100. On the 1GB / 32MB-buffer-pool
+-- prod DB, three such channels running in parallel took 63-81s (measured via the
+-- [PerfTrace] log: candidateRetrieval≈63000ms, everything else in ms).
+--
+-- FIX. Copy the five location keys onto listings (addresses are fixed reference
+-- data — they do not change), then build one composite index per location shape
+-- with the visibility booleans as the equality prefix and (pushed_at, post_date)
+-- as the ordered suffix — mirroring idx_listings_public_default_sort (V82). Each
+-- candidate query becomes a single-table index-ordered range scan: no filesort,
+-- reads only ~LIMIT rows, fast even on a 32MB buffer pool.
+--
+-- Order matters: add columns → backfill → THEN create indexes (indexing populated
+-- columns once is cheaper than maintaining six indexes during the bulk UPDATE).
+-- Idempotent via information_schema checks, matching V81/V82/V83 style.
+-- ============================================================================
+
+-- ---------------------------------------------------------------------------
+-- 1. Add the five denormalized columns (nullable — a listing has either a new
+--    code or only a legacy id, exactly like its address).
+-- ---------------------------------------------------------------------------
+SET @col_exists = (SELECT COUNT(*) FROM information_schema.columns
+                   WHERE table_schema = DATABASE()
+                     AND table_name = 'listings'
+                     AND column_name = 'new_province_code');
+SET @sql = IF(@col_exists = 0,
+    'ALTER TABLE listings ADD COLUMN new_province_code VARCHAR(10) NULL',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @col_exists = (SELECT COUNT(*) FROM information_schema.columns
+                   WHERE table_schema = DATABASE()
+                     AND table_name = 'listings'
+                     AND column_name = 'new_ward_code');
+SET @sql = IF(@col_exists = 0,
+    'ALTER TABLE listings ADD COLUMN new_ward_code VARCHAR(10) NULL',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @col_exists = (SELECT COUNT(*) FROM information_schema.columns
+                   WHERE table_schema = DATABASE()
+                     AND table_name = 'listings'
+                     AND column_name = 'legacy_province_id');
+SET @sql = IF(@col_exists = 0,
+    'ALTER TABLE listings ADD COLUMN legacy_province_id INT NULL',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @col_exists = (SELECT COUNT(*) FROM information_schema.columns
+                   WHERE table_schema = DATABASE()
+                     AND table_name = 'listings'
+                     AND column_name = 'legacy_district_id');
+SET @sql = IF(@col_exists = 0,
+    'ALTER TABLE listings ADD COLUMN legacy_district_id INT NULL',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @col_exists = (SELECT COUNT(*) FROM information_schema.columns
+                   WHERE table_schema = DATABASE()
+                     AND table_name = 'listings'
+                     AND column_name = 'legacy_ward_id');
+SET @sql = IF(@col_exists = 0,
+    'ALTER TABLE listings ADD COLUMN legacy_ward_id INT NULL',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- ---------------------------------------------------------------------------
+-- 2. Backfill from addresses (one-time; addresses are fixed reference data).
+--    Joins on listings.address_id → addresses PK (idx_address on listings),
+--    so this is an efficient PK-join UPDATE. Runs before indexes exist.
+-- ---------------------------------------------------------------------------
+UPDATE listings l
+JOIN addresses a ON l.address_id = a.address_id
+SET l.new_province_code  = a.new_province_code,
+    l.new_ward_code      = a.new_ward_code,
+    l.legacy_province_id = a.legacy_province_id,
+    l.legacy_district_id = a.legacy_district_id,
+    l.legacy_ward_id     = a.legacy_ward_id;
+
+-- ---------------------------------------------------------------------------
+-- 3. Composite indexes — one per location shape. Equality prefix
+--    (location + visibility booleans) + ordered suffix (pushed_at, post_date)
+--    ⇒ index-ordered scan, no filesort. Mirrors idx_listings_public_default_sort.
+-- ---------------------------------------------------------------------------
+SET @idx_exists = (SELECT COUNT(*) FROM information_schema.statistics
+                   WHERE table_schema = DATABASE()
+                     AND table_name = 'listings'
+                     AND index_name = 'idx_listings_reco_new_prov');
+SET @sql = IF(@idx_exists = 0,
+    'CREATE INDEX idx_listings_reco_new_prov ON listings (new_province_code, is_draft, is_shadow, verified, expired, pushed_at, post_date)',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @idx_exists = (SELECT COUNT(*) FROM information_schema.statistics
+                   WHERE table_schema = DATABASE()
+                     AND table_name = 'listings'
+                     AND index_name = 'idx_listings_reco_new_ward');
+SET @sql = IF(@idx_exists = 0,
+    'CREATE INDEX idx_listings_reco_new_ward ON listings (new_ward_code, is_draft, is_shadow, verified, expired, pushed_at, post_date)',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @idx_exists = (SELECT COUNT(*) FROM information_schema.statistics
+                   WHERE table_schema = DATABASE()
+                     AND table_name = 'listings'
+                     AND index_name = 'idx_listings_reco_legacy_dist');
+SET @sql = IF(@idx_exists = 0,
+    'CREATE INDEX idx_listings_reco_legacy_dist ON listings (legacy_district_id, is_draft, is_shadow, verified, expired, pushed_at, post_date)',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @idx_exists = (SELECT COUNT(*) FROM information_schema.statistics
+                   WHERE table_schema = DATABASE()
+                     AND table_name = 'listings'
+                     AND index_name = 'idx_listings_reco_legacy_ward');
+SET @sql = IF(@idx_exists = 0,
+    'CREATE INDEX idx_listings_reco_legacy_ward ON listings (legacy_ward_id, is_draft, is_shadow, verified, expired, pushed_at, post_date)',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @idx_exists = (SELECT COUNT(*) FROM information_schema.statistics
+                   WHERE table_schema = DATABASE()
+                     AND table_name = 'listings'
+                     AND index_name = 'idx_listings_reco_legacy_prov');
+SET @sql = IF(@idx_exists = 0,
+    'CREATE INDEX idx_listings_reco_legacy_prov ON listings (legacy_province_id, is_draft, is_shadow, verified, expired, pushed_at, post_date)',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @idx_exists = (SELECT COUNT(*) FROM information_schema.statistics
+                   WHERE table_schema = DATABASE()
+                     AND table_name = 'listings'
+                     AND index_name = 'idx_listings_reco_fresh');
+SET @sql = IF(@idx_exists = 0,
+    'CREATE INDEX idx_listings_reco_fresh ON listings (is_draft, is_shadow, verified, expired, pushed_at, post_date)',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- ---------------------------------------------------------------------------
+-- 4. Refresh optimizer statistics so the planner immediately sees the new
+--    indexes as selective and picks them (verified via EXPLAIN: the forced plan
+--    is a Backward-index-scan on idx_listings_reco_new_prov with NO filesort;
+--    without fresh stats on a freshly-migrated DB the planner can fall back to
+--    idx_status + filesort). Fast on the ~100k-row table.
+-- ---------------------------------------------------------------------------
+ANALYZE TABLE listings;


### PR DESCRIPTION
## Vấn đề

Endpoint recommendation — "Bất động sản dành cho bạn" (`/v1/recommendations/personalized`) và "Bất động sản tương tự" — chậm **~63–81 giây**. Dòng log `[PerfTrace]` sẵn có khoanh vùng 100% thời gian ở stage **`candidateRetrieval`**; mọi stage khác là mili-giây (AI call `feignAi` chỉ ~17ms).

**Root cause:** các query candidate **lọc trên `addresses`** (province/ward/district) nhưng **sort trên `listings.pushed_at`**. Không index nào phục vụ được filter+sort xuyên bảng → MySQL **filesort** toàn bộ tập matched của cả tỉnh (chục nghìn dòng) chỉ để lấy ~100. Bị khuếch đại bởi DB prod nhỏ (DigitalOcean Managed 1GB / 1vCPU, `innodb_buffer_pool_size=32MB` — không sửa được vì managed DB), khi 3 channel filesort chạy song song.

## Cách sửa

Denormalize 5 khóa vị trí từ `addresses` sang `listings` (address là dữ liệu cố định) + 6 composite index → mỗi query candidate thành **single-table index-ordered range scan, hết filesort**, nhanh kể cả với buffer pool 32MB.

- **V97 migration:** thêm 5 cột + backfill từ `addresses` + 6 index `idx_listings_reco_*` + `ANALYZE TABLE`.
- **`Listing` entity:** 5 field denormalized + 6 `@Index` + đồng bộ từ `address` trong hook `@PrePersist/@PreUpdate updateSearchFields()` sẵn có.
- **`ListingRepository`:** 12 query candidate lọc trên `l.<cột denormalized>` + bỏ `NULLS LAST`. **Giữ nguyên signature** → không đụng service/test.

## Đã verify

| Kiểm tra | Kết quả |
|---|---|
| `./gradlew compileJava` | ✅ |
| Flyway V97 trên MySQL 8 (cột + backfill + 6 index) | ✅ applied |
| Spring context boot (validate JPQL 12 query) | ✅ |
| 6 index reco tạo đủ | ✅ |
| Backfill khớp addresses | ✅ 0 mismatch |
| EXPLAIN (FORCE INDEX) | ✅ `Backward index scan; Using index` — **không filesort** |

Con số latency thật (63s → sub-second) sẽ xác nhận trên **prod** qua `[PerfTrace] candidateRetrieval` sau khi deploy (DB local không có listing ở trạng thái visible nên không đo end-to-end được).

## Lưu ý deploy

Flyway tự chạy V97 khi boot (thêm cột + backfill + index + ANALYZE). Rollout an toàn: migration + code cùng lúc, code cũ bỏ qua cột mới.

## Deferred (tùy chọn, PR sau)

Tách query OR-province ở channel *giá* thành 2 biến thể new/legacy + branch trong Java để khử luôn filesort nhỏ còn sót ở channel giá.

Spec chi tiết: `smart-rent/docs/superpowers/specs/2026-07-06-recommendation-candidate-retrieval-optimization-design.md`.
