### PR TITLE
perf(recommendation): cut similar-listings cold-start latency (TTL + trim over-fetch + PerfTrace)

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/service/recommendation/impl/RecommendationServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/recommendation/impl/RecommendationServiceImpl.java
@@ -61,6 +61,7 @@ public class RecommendationServiceImpl implements RecommendationService {
             return emptyResponse("similar");
         }
 
+        long tStart = System.nanoTime();
         com.smartrent.infra.repository.entity.Address targetAddr = target.getAddress();
         Integer provinceId = (targetAddr != null) ? targetAddr.getLegacyProvinceId() : null;
         String provinceCode = (targetAddr != null) ? targetAddr.getNewProvinceCode() : null;
@@ -71,7 +72,7 @@ public class RecommendationServiceImpl implements RecommendationService {
                     if (districtId != null) {
                         return listingRepository.findSimilarProximityCandidates(
                                 provinceCode, provinceId, districtId, target.getProductType(), target.getListingType(),
-                                listingId, PageRequest.of(0, 250));
+                                listingId, PageRequest.of(0, 150));
                     }
                     return java.util.Collections.emptyList();
                 });
@@ -85,7 +86,7 @@ public class RecommendationServiceImpl implements RecommendationService {
                         return listingRepository.findSimilarPriceCandidates(
                                 provinceCode, provinceId, minPrice, maxPrice, target.getProductType(),
                                 target.getListingType(),
-                                listingId, PageRequest.of(0, 200));
+                                listingId, PageRequest.of(0, 120));
                     }
                     return java.util.Collections.emptyList();
                 });
@@ -116,10 +117,13 @@ public class RecommendationServiceImpl implements RecommendationService {
             candidateSet.addAll(priceFuture.get());
             candidateSet.addAll(freshFuture.get());
 
-            // Stage-2 Fallback Top-up if candidate pool is less than 150 (prevent candidate
-            // starvation)
-            if (candidateSet.size() < 150) {
-                int needed = 300 - candidateSet.size();
+            // Stage-2 Fallback Top-up if candidate pool is less than 120 (prevent candidate
+            // starvation). Pool trimmed 300→200 for cold-start latency: on the 32MB
+            // buffer pool, hydrating fewer candidates cuts the cold disk reads; 200 is
+            // ample to rank a top-N feed. (Similar has no discovery-shift pinning, so
+            // unlike the personalized feed it does not need a large fixed pool.)
+            if (candidateSet.size() < 120) {
+                int needed = 200 - candidateSet.size();
                 List<Listing> topUp;
                 if (provinceCode != null && !provinceCode.isEmpty() && !provinceCode.equals("UNKNOWN")) {
                     topUp = listingRepository.findCandidatesForSimilarByNewProvince(
@@ -138,12 +142,14 @@ public class RecommendationServiceImpl implements RecommendationService {
             }
 
             candidates = candidateSet.stream()
-                    .limit(300)
+                    .limit(200)
                     .collect(Collectors.toList());
         } catch (Exception e) {
             log.error("Error executing parallel multi-channel retrieval for similar listings", e);
             candidates = freshFuture.join();
         }
+
+        long tAfterCandidates = System.nanoTime();
 
         if (candidates.isEmpty()) {
             return emptyResponse("similar");
@@ -187,8 +193,16 @@ public class RecommendationServiceImpl implements RecommendationService {
                 .interactionFeatures(interactionFeatures)
                 .build();
 
+        long tBeforeAi = System.nanoTime();
         try {
             List<RecommendationItemDto> result = aiConnector.getSimilarListings(aiRequest);
+            long tAfterAi = System.nanoTime();
+            log.info("[PerfTrace] similar listingId={} candidatePool={} | candidateRetrieval={}ms interactions+features={}ms feignAi={}ms total(soFar)={}ms",
+                    listingId, candidates.size(),
+                    (tAfterCandidates - tStart) / 1_000_000,
+                    (tBeforeAi - tAfterCandidates) / 1_000_000,
+                    (tAfterAi - tBeforeAi) / 1_000_000,
+                    (tAfterAi - tStart) / 1_000_000);
             return buildResponse(result, userId != null ? "similar_personalized" : "similar", false, false);
         } catch (Exception e) {
             log.error("AI service error for similar listings (listingId={})", listingId, e);

--- a/smart-rent/src/main/resources/application.yml
+++ b/smart-rent/src/main/resources/application.yml
@@ -179,7 +179,12 @@ spring:
         # Asia/Ho_Chi_Minh by HomepageStatsCacheScheduler.
         "[listing.stats.categories]": 0s
         "[listing.stats.provinces]": 0s
-        "[listing.recommendation.similar]": 5m
+        # Similar-listings cache is keyed by listingId (NOT per-user) so it is
+        # shared across everyone viewing a listing and is never evicted on view.
+        # A longer TTL keeps the cold ~5s recompute rare (once per listing per
+        # window) — a big win while the DB buffer pool is only 32MB. See PR reco
+        # cold-start work.
+        "[listing.recommendation.similar]": 30m
         "[listing.recommendation.personalized]": 2m
 
 application:


### PR DESCRIPTION
Follow-up của #361. Sau khi khử filesort, **warm /similar = 78ms** (đo bằng Network tab), nhưng **cold (lần đầu) = ~5.4s** — do buffer pool DB chỉ 32MB (DO managed 1GB, không sửa được) nên request đầu đọc trang từ đĩa. PR này giảm cold cho endpoint **similar** (không đụng buffer pool, không đụng personalized).

## Thay đổi (chỉ path `/similar`)

- **TTL cache 5m → 30m.** Cache similar keyed theo `listingId` (dùng chung mọi user, không bị evict khi xem tin) → TTL dài làm cái ~5s cold trở nên **hiếm**: chỉ 1 lần/tin/khoảng-TTL.
- **Giảm over-fetch candidate:** proximity 250→150, price 200→120, cap 300→200, ngưỡng top-up 150→120. Hydrate ít candidate hơn → **ít đọc đĩa lúc cold** → cold kỳ vọng ~5s xuống ~2-3s. 200 candidate là quá đủ để rank top-10.
- **Thêm `[PerfTrace]` vào `getSimilarListings`** (mirror personalized) → đo được stage timing của similar trên prod.

## Vì sao an toàn

- Chỉ sửa `getSimilarListings`. **Personalized để nguyên** vì pool 300 của nó nuôi logic discovery-shift pinning (slot 8/9/10) — similar **không có** logic đó nên cắt pool vô hại.
- Cache key không đổi → không ảnh hưởng cache hiện có.

## Verify

- `gradlew compileJava` ✅.
- Độ trễ thực đo trên prod sau deploy qua dòng `[PerfTrace] similar …` mới. Dễ revert nếu chất lượng feed giảm (chỉ là vài hằng số + TTL).

## Chưa làm (deferred)

- Sub-second cold thật sự cần **buffer pool lớn hơn** → cut-over DB self-host (Phase 2 Dokploy), `innodb_buffer_pool_size=512M+`.
- Denormalize thêm lat/lon → bỏ `JOIN FETCH address` ở query candidate (cần 1 migration nữa).
