### PR TITLE
fix(payment): reject SePay on public callback path — closes payment-bypass (audit Critical #4)

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/controller/PaymentController.java
+++ b/smart-rent/src/main/java/com/smartrent/controller/PaymentController.java
@@ -162,6 +162,20 @@ public class PaymentController {
 
         log.info("Processing payment callback for provider: {} with params: {}", provider, params.keySet());
 
+        // SePay is webhook-only (bank-transfer QR — no browser redirect). Its sole
+        // authentic entry point is POST /webhook/sepay, which verifies X-Secret-Key.
+        // Reject SEPAY on this PUBLIC browser-callback path: otherwise a forged
+        // GET /v1/payments/callback/SEPAY?...&transaction_status=APPROVED reaches the
+        // same processIPN and can mark a PENDING transaction COMPLETED — granting paid
+        // listings/memberships without the secret key. (Audit: SePay callback bypass.)
+        if (provider == PaymentProvider.SEPAY) {
+            log.warn("Rejected SePay on the browser-callback path; SePay must use the authenticated /webhook/sepay endpoint");
+            return ApiResponse.<PaymentCallbackResponse>builder()
+                    .code("400002")
+                    .message("SePay is not supported on the callback path")
+                    .build();
+        }
+
         try {
             PaymentCallbackRequest callbackRequest = PaymentCallbackRequest.builder()
                     .provider(provider)


### PR DESCRIPTION
Vá lỗ hổng **payment bypass** (CROSS_REPO_AUDIT Critical #4), đã re-verify còn OPEN trên code hiện tại.

## Lỗ hổng

SePay là **webhook-only** (QR chuyển khoản, không có redirect trình duyệt). Lối hợp lệ duy nhất là `POST /webhook/sepay` — có verify `X-Secret-Key`. Nhưng endpoint công khai `GET /v1/payments/callback/{provider}` lại route `SEPAY` vào **cùng** `PaymentService.processIPN` mà **không check secret**. Kẻ tấn công có thể giả:

```
GET /v1/payments/callback/SEPAY?order_invoice_number=<ref>
    &notification_type=ORDER_PAID&transaction_status=APPROVED
    &transaction_amount=<>= số tiền order>
```

→ flip transaction PENDING → COMPLETED → trigger hoàn tất listing/membership/push → **nhận đồ trả phí miễn phí, không cần secret**.

## Fix

Từ chối `provider=SEPAY` ngay ở handler callback (trả `400002`) → webhook có secret là đường **duy nhất** hoàn tất thanh toán SePay. VNPay/ZaloPay (có redirect trình duyệt thật) không bị ảnh hưởng.

Chỉ 1 file, +14 dòng, `PaymentController.handlePaymentCallback`.

## Verify

- `gradlew compileJava` ✅.
- Follow-up nên thêm: MockMvc test khẳng định `GET /v1/payments/callback/SEPAY` trả `400002` và không hoàn tất transaction.

## Ghi chú

Đây là 1 trong 4 Critical còn OPEN sau re-audit (2026-07-07). Còn lại đáng làm: **#3 ZaloPay callback** (cần MAC key2 + so amount), **#5 WebSocket notification IDOR**, **#6 scraper address_id NULL**. #1/#2/#7/#8/#9 đã được vá trước đó.
