### PR TITLE
fix(ws): authenticate STOMP CONNECT + per-user notification routing — closes IDOR (audit Critical #5)

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/config/WebSocketAuthChannelInterceptor.java
+++ b/smart-rent/src/main/java/com/smartrent/config/WebSocketAuthChannelInterceptor.java
@@ -1,0 +1,91 @@
+package com.smartrent.config;
+
+import com.smartrent.config.security.CustomJwtDecoder;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessagingException;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.stereotype.Component;
+
+import java.security.Principal;
+
+/**
+ * Authenticates the STOMP CONNECT frame and pins a {@link Principal} (the
+ * recipientId — admin_id / user_id, matching NotificationController.resolveRecipientId)
+ * to the WebSocket session. Notifications are then routed with
+ * {@code convertAndSendToUser(recipientId, "/queue/notifications", ...)} to that
+ * one session's private user-destination.
+ *
+ * <p>This closes the notification IDOR: previously the server broadcast to a
+ * guessable public topic {@code /topic/notifications/{userId}} and the STOMP
+ * layer skipped auth entirely, so any anonymous client could subscribe to any
+ * user's realtime notifications. The bearer token is read from the CONNECT
+ * frame's native {@code Authorization} header (the SockJS/STOMP client already
+ * sends it) and validated with the same {@link CustomJwtDecoder} used by the
+ * REST layer, so signature + invalidated-token checks stay consistent. A missing
+ * or invalid token rejects the CONNECT.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class WebSocketAuthChannelInterceptor implements ChannelInterceptor {
+
+    private final CustomJwtDecoder jwtDecoder;
+
+    @Override
+    public Message<?> preSend(Message<?> message, MessageChannel channel) {
+        StompHeaderAccessor accessor =
+                MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+
+        if (accessor == null || !StompCommand.CONNECT.equals(accessor.getCommand())) {
+            return message;
+        }
+
+        String authHeader = accessor.getFirstNativeHeader("Authorization");
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            log.warn("Rejected STOMP CONNECT: missing bearer token");
+            throw new MessagingException("Missing bearer token on STOMP CONNECT");
+        }
+
+        try {
+            Jwt jwt = jwtDecoder.decode(authHeader.substring(7));
+            String recipientId = resolveRecipientId(jwt);
+            accessor.setUser(new StompPrincipal(recipientId));
+            log.debug("STOMP CONNECT authenticated for principal {}", recipientId);
+        } catch (MessagingException e) {
+            throw e;
+        } catch (Exception e) {
+            log.warn("Rejected STOMP CONNECT: invalid token ({})", e.getMessage());
+            throw new MessagingException("Invalid token on STOMP CONNECT", e);
+        }
+
+        return message;
+    }
+
+    /** Mirrors NotificationController.resolveRecipientId so the Principal name
+     *  equals the recipientId notifications are addressed to. */
+    private String resolveRecipientId(Jwt jwt) {
+        String adminId = jwt.getClaimAsString("admin_id");
+        if (adminId != null) {
+            return adminId;
+        }
+        String userId = jwt.getClaimAsString("user_id");
+        if (userId != null) {
+            return userId;
+        }
+        return jwt.getSubject();
+    }
+
+    private record StompPrincipal(String name) implements Principal {
+        @Override
+        public String getName() {
+            return name;
+        }
+    }
+}

--- a/smart-rent/src/main/java/com/smartrent/config/WebSocketConfig.java
+++ b/smart-rent/src/main/java/com/smartrent/config/WebSocketConfig.java
@@ -1,6 +1,8 @@
 package com.smartrent.config;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
@@ -8,21 +10,39 @@ import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerCo
 
 @Configuration
 @EnableWebSocketMessageBroker
+@RequiredArgsConstructor
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    private final WebSocketAuthChannelInterceptor authChannelInterceptor;
 
     @Override
     public void configureMessageBroker(MessageBrokerRegistry config) {
-        // Enable a simple in-memory message broker for /topic destinations
-        config.enableSimpleBroker("/topic");
+        // In-memory broker. "/queue" is required so per-user destinations
+        // (convertAndSendToUser → /user/{session}/queue/...) can be delivered;
+        // "/topic" is kept for any pub/sub broadcast use.
+        config.enableSimpleBroker("/topic", "/queue");
         // Prefix for messages bound from client to server
         config.setApplicationDestinationPrefixes("/app");
+        // Per-user destination prefix — clients subscribe to /user/queue/... and
+        // the framework routes to the session whose authenticated Principal matches.
+        config.setUserDestinationPrefix("/user");
     }
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
-        // WebSocket endpoint with SockJS fallback
+        // WebSocket endpoint with SockJS fallback. The HTTP handshake stays open
+        // (permitAll in SecurityConfig); authentication happens at the STOMP layer
+        // via authChannelInterceptor on the CONNECT frame.
         registry.addEndpoint("/ws")
                 .setAllowedOriginPatterns("*")
                 .withSockJS();
+    }
+
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        // Authenticate the STOMP CONNECT and pin the user's Principal to the session
+        // so notifications route only to their own /user destination (closes the
+        // notification IDOR).
+        registration.interceptors(authChannelInterceptor);
     }
 }

--- a/smart-rent/src/main/java/com/smartrent/service/notification/impl/NotificationServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/notification/impl/NotificationServiceImpl.java
@@ -54,18 +54,24 @@ public class NotificationServiceImpl implements NotificationService {
             // Send WebSocket AFTER transaction commits to avoid race condition
             // where frontend queries DB before TX is visible.
             NotificationResponse response = mapToResponse(saved);
-            String destination = "/topic/notifications/" + recipientId;
+            // Route to the recipient's PRIVATE user-destination. The STOMP session's
+            // authenticated Principal (set by WebSocketAuthChannelInterceptor) equals
+            // recipientId, and the FE subscribes to /user/queue/notifications, so only
+            // that user receives it. Replaces the old guessable public
+            // /topic/notifications/{recipientId} broadcast that any anonymous client
+            // could subscribe to (notification IDOR).
+            String userDestination = "/queue/notifications";
             if (TransactionSynchronizationManager.isActualTransactionActive()) {
                 TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
                     @Override
                     public void afterCommit() {
-                        messagingTemplate.convertAndSend(destination, response);
-                        log.debug("WebSocket notification sent after commit to {}", destination);
+                        messagingTemplate.convertAndSendToUser(recipientId, userDestination, response);
+                        log.debug("WebSocket notification sent after commit to user {}", recipientId);
                     }
                 });
             } else {
-                messagingTemplate.convertAndSend(destination, response);
-                log.debug("WebSocket notification sent to {}", destination);
+                messagingTemplate.convertAndSendToUser(recipientId, userDestination, response);
+                log.debug("WebSocket notification sent to user {}", recipientId);
             }
         } catch (Exception e) {
             log.error("Failed to send notification: type={}, recipient={}:{}, error={}",


### PR DESCRIPTION
Vá **notification IDOR** (CROSS_REPO_AUDIT Critical #5, đã re-verify còn OPEN).

## Lỗ hổng
Notification realtime bị broadcast tới topic công khai đoán được `/topic/notifications/{userId}` trên SimpleBroker không auth subscribe, và tầng STOMP bỏ qua JWT hoàn toàn → **client ẩn danh nào cũng connect `/ws` rồi subscribe `/topic/notifications/{userId nạn nhân}` đọc notification người khác**.

## Fix
- `WebSocketAuthChannelInterceptor`: validate JWT trên frame STOMP CONNECT (token FE đã gửi sẵn trong `connectHeaders`) bằng chính `CustomJwtDecoder` của REST, set Principal = recipientId (admin_id/user_id, khớp `resolveRecipientId`). Token thiếu/sai → từ chối CONNECT.
- `WebSocketConfig`: đăng ký interceptor + bật broker `/queue` + user-destination `/user`.
- `NotificationServiceImpl`: gửi bằng `convertAndSendToUser(recipientId, "/queue/notifications", ...)` → chỉ session có Principal khớp mới nhận. Hết topic công khai.

HTTP `/ws` handshake vẫn permitAll (SockJS); auth chuyển sang tầng STOMP.

## ⚠️ Deploy cùng FE
Cần PR frontend đi kèm (subscribe `/user/queue/notifications`) — **BE + FE phải deploy cùng lúc**, không thì notification ngừng chạy.

## Verify
`gradlew compileJava` ✅. (Follow-up: MockMvc/STOMP test cho CONNECT không token bị từ chối + user chỉ nhận của mình.)