### PR TITLE
perf(listings): count category stats in one grouped query

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/infra/repository/CategoryListingCount.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/CategoryListingCount.java
@@ -1,0 +1,10 @@
+package com.smartrent.infra.repository;
+
+/**
+ * Row projection for
+ * {@link ListingRepository#countPublicListingsByCategory}: a category id paired
+ * with the number of publicly-visible listings it contains, produced by the
+ * grouped homepage "by category" count query.
+ */
+public record CategoryListingCount(Long categoryId, Long total) {
+}

--- a/smart-rent/src/main/java/com/smartrent/infra/repository/ListingRepository.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/ListingRepository.java
@@ -36,6 +36,36 @@ public interface ListingRepository extends JpaRepository<Listing, Long>, JpaSpec
     """)
     List<Listing> findDisplayingByListingIdIn(@Param("listingIds") Collection<Long> listingIds);
 
+    /**
+     * Homepage "by category" counts in ONE grouped query. Replaces the previous
+     * per-category {@code count(ListingSpecification)} loop (one COUNT per
+     * category → N sequential round-trips; ~20s for 5 categories on a cold
+     * cache). The WHERE clause MUST mirror the public-visibility predicates that
+     * {@link com.smartrent.infra.repository.specification.ListingSpecification#fromFilterRequest}
+     * applies for a category card filter (categoryId + excludeExpired, no auth):
+     * isDraft=false, isShadow=false, moderationStatus=APPROVED, and not-expired
+     * (expired=false AND (expiryDate IS NULL OR expiryDate &gt; now)) — so the
+     * homepage number equals the /properties total for that card. Categories
+     * with no matching listing are absent from the result (caller defaults them
+     * to 0). Served by idx_listings_public_cursor_category (leads with
+     * category_id).
+     */
+    @Query("""
+        SELECT new com.smartrent.infra.repository.CategoryListingCount(l.categoryId, COUNT(l))
+        FROM listings l
+        WHERE l.categoryId IN :categoryIds
+          AND l.isDraft = false
+          AND l.isShadow = false
+          AND l.moderationStatus = :approved
+          AND l.expired = false
+          AND (l.expiryDate IS NULL OR l.expiryDate > :now)
+        GROUP BY l.categoryId
+    """)
+    List<CategoryListingCount> countPublicListingsByCategory(
+            @Param("categoryIds") Collection<Long> categoryIds,
+            @Param("approved") com.smartrent.enums.ModerationStatus approved,
+            @Param("now") LocalDateTime now);
+
     List<Listing> findByUserId(String userId);
 
     Optional<Listing> findByParentListingId(Long parentListingId);

--- a/smart-rent/src/main/java/com/smartrent/service/listing/impl/ListingServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/listing/impl/ListingServiceImpl.java
@@ -35,6 +35,7 @@ import com.smartrent.infra.repository.AddressRepository;
 // AddressMetadataRepository removed — queries now use addresses table directly
 import com.smartrent.infra.repository.AdminRepository;
 import com.smartrent.infra.repository.AmenityRepository;
+import com.smartrent.infra.repository.CategoryListingCount;
 import com.smartrent.infra.repository.CategoryRepository;
 import com.smartrent.infra.repository.LegacyProvinceRepository;
 import com.smartrent.infra.repository.LegacyDistrictRepository;
@@ -1913,10 +1914,23 @@ public class ListingServiceImpl implements ListingService {
         Map<Long, Category> categoryMap = categoryRepository.findAllById(request.getCategoryIds())
                 .stream().collect(Collectors.toMap(Category::getCategoryId, Function.identity()));
 
-        // SINGLE SOURCE OF TRUTH: count each category with the EXACT same
-        // ListingSpecification the public /properties listing page uses, with
-        // the same param the FE card navigates with (categoryId). Guarantees
-        // the homepage number equals the listing-page total for that card.
+        // SINGLE SOURCE OF TRUTH: count every requested category in ONE grouped
+        // query whose WHERE mirrors the public /properties card filter
+        // (categoryId + excludeExpired). This replaced a per-category
+        // count(ListingSpecification) loop — N sequential COUNTs, ~20s for 5
+        // categories on a cold cache. Categories with no listing are absent from
+        // the map and default to 0 below. Keep the query's WHERE in sync with
+        // ListingSpecification.fromFilterRequest so the homepage number equals
+        // the listing-page total for that card.
+        Map<Long, Long> countByCategory = listingRepository
+                .countPublicListingsByCategory(
+                        request.getCategoryIds(),
+                        ModerationStatus.APPROVED,
+                        java.time.LocalDateTime.now())
+                .stream()
+                .collect(Collectors.toMap(
+                        CategoryListingCount::categoryId, CategoryListingCount::total));
+
         boolean verifiedOnly = Boolean.TRUE.equals(request.getVerifiedOnly());
         for (Long categoryId : request.getCategoryIds()) {
             Category category = categoryMap.get(categoryId);
@@ -1925,11 +1939,7 @@ public class ListingServiceImpl implements ListingService {
                 continue;
             }
 
-            ListingFilterRequest cardFilter = ListingFilterRequest.builder()
-                    .categoryId(categoryId)
-                    .excludeExpired(true)
-                    .build();
-            long count = countPublicListings(cardFilter);
+            long count = countByCategory.getOrDefault(categoryId, 0L);
 
             if (verifiedOnly && count == 0) {
                 continue;

--- a/smart-rent/src/test/java/com/smartrent/service/listing/impl/ListingServiceImplCategoryStatsTest.java
+++ b/smart-rent/src/test/java/com/smartrent/service/listing/impl/ListingServiceImplCategoryStatsTest.java
@@ -1,0 +1,113 @@
+package com.smartrent.service.listing.impl;
+
+import com.smartrent.dto.request.CategoryStatsRequest;
+import com.smartrent.dto.response.CategoryListingStatsResponse;
+import com.smartrent.infra.repository.CategoryListingCount;
+import com.smartrent.infra.repository.CategoryRepository;
+import com.smartrent.infra.repository.ListingRepository;
+import com.smartrent.infra.repository.entity.Category;
+import com.smartrent.infra.repository.entity.Listing;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.jpa.domain.Specification;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * POST /v1/listings/stats/categories used to run one
+ * {@code count(ListingSpecification)} per category — N sequential COUNT
+ * queries that made the endpoint ~20s on a cold cache. Locks in the fix: it
+ * must count every category in a SINGLE grouped query
+ * ({@link ListingRepository#countPublicListingsByCategory}) and never fall back
+ * to the per-category {@code listingRepository.count(spec)} path.
+ */
+@ExtendWith(MockitoExtension.class)
+class ListingServiceImplCategoryStatsTest {
+
+    @Mock
+    ListingRepository listingRepository;
+
+    @Mock
+    CategoryRepository categoryRepository;
+
+    @InjectMocks
+    ListingServiceImpl service;
+
+    private Category category(long id) {
+        return Category.builder()
+                .categoryId(id)
+                .name("Cat " + id)
+                .slug("cat-" + id)
+                .icon("icon-" + id)
+                .build();
+    }
+
+    @Test
+    void countsAllCategoriesInOneGroupedQueryAndDefaultsMissingToZero() {
+        when(categoryRepository.findAllById(anyCollection()))
+                .thenReturn(List.of(category(1), category(2), category(3)));
+        // Grouped query only returns rows for categories that have listings;
+        // category 3 is absent → the service must default it to 0.
+        when(listingRepository.countPublicListingsByCategory(
+                anyCollection(), any(), any(LocalDateTime.class)))
+                .thenReturn(List.of(
+                        new CategoryListingCount(1L, 10L),
+                        new CategoryListingCount(2L, 4L)));
+
+        CategoryStatsRequest request = CategoryStatsRequest.builder()
+                .categoryIds(List.of(1L, 2L, 3L))
+                .verifiedOnly(false)
+                .build();
+
+        List<CategoryListingStatsResponse> result = service.getCategoryStats(request);
+
+        Map<Long, Long> totalById = result.stream()
+                .collect(Collectors.toMap(
+                        CategoryListingStatsResponse::getCategoryId,
+                        CategoryListingStatsResponse::getTotalListings));
+
+        assertEquals(3, result.size());
+        assertEquals(10L, totalById.get(1L));
+        assertEquals(4L, totalById.get(2L));
+        assertEquals(0L, totalById.get(3L));
+
+        // The fix: a single grouped query, never a per-category specification COUNT.
+        verify(listingRepository).countPublicListingsByCategory(
+                anyCollection(), any(), any(LocalDateTime.class));
+        verify(listingRepository, never()).count(ArgumentMatchers.<Specification<Listing>>any());
+    }
+
+    @Test
+    void verifiedOnlySkipsZeroCountCategories() {
+        when(categoryRepository.findAllById(anyCollection()))
+                .thenReturn(List.of(category(1), category(2)));
+        when(listingRepository.countPublicListingsByCategory(
+                anyCollection(), any(), any(LocalDateTime.class)))
+                .thenReturn(List.of(new CategoryListingCount(1L, 7L)));
+
+        CategoryStatsRequest request = CategoryStatsRequest.builder()
+                .categoryIds(List.of(1L, 2L))
+                .verifiedOnly(true)
+                .build();
+
+        List<CategoryListingStatsResponse> result = service.getCategoryStats(request);
+
+        assertEquals(1, result.size());
+        assertEquals(1L, result.get(0).getCategoryId());
+        assertEquals(7L, result.get(0).getTotalListings());
+    }
+}


### PR DESCRIPTION
## Vấn đề

`POST /v1/listings/stats/categories` (section homepage "Bất động sản theo danh mục") mất **~20s** khi cache nguội. Nguyên nhân: `computeCategoryStats` chạy **một `count(ListingSpecification)` cho mỗi category** → 5 câu COUNT tuần tự.

Endpoint được che bởi Redis cache (permanent, warm bởi `HomepageStatsCacheScheduler`), nhưng khi cache nguội/không phục vụ (vd Redis chưa sẵn sau khi chuyển Dokploy — `RedisCacheErrorHandler` nuốt lỗi rồi recompute), mọi request chịu trọn 20s.

## Thay đổi

- **`ListingRepository.countPublicListingsByCategory(...)`** — 1 câu JPQL `GROUP BY category_id` đếm tất cả category cùng lúc. WHERE **mirror đúng** card filter public của `ListingSpecification.fromFilterRequest` (`isDraft=false, isShadow=false, moderationStatus=APPROVED, expired=false, (expiryDate IS NULL OR > now)`) → số homepage = số trang /properties. Được index `idx_listings_public_cursor_category` (dẫn đầu `category_id`) đỡ.
- **`computeCategoryStats`** — gọi 1 query thay loop 5×; category không có listing → default 0; giữ nguyên skip `verifiedOnly && count==0`.
- **`CategoryListingCount`** — record projection `(categoryId, total)`.
- Lợi ích phụ: đường **cache-miss** giờ cũng rẻ (1 query thay 5) → endpoint bền với cache nguội.

## Kiểm thử

- ✅ `./gradlew test --tests …ListingServiceImplCategoryStatsTest` — 2 test pass (đếm 1 query + default 0; verifiedOnly skip; lock không còn per-category `count(spec)`)
- ✅ `./gradlew test --tests "…listing.impl.*"` — không regression (gồm MapBounds test)
- ✅ Compile sạch (Java 17)

## Chưa verify trong PR này

- JPQL chạy thật trên MySQL (unit test mock repository). Spring Data validate `@Query` lúc app khởi động — nên chạy staging/local 1 lần để chắc parse OK + đo thời gian thực.
- Nếu prod vẫn 20s **mọi lần** sau khi merge → gốc là Redis không phục vụ (hạ tầng), không phải query.