### PR TITLE
perf(map-bounds): fix N+1 on address and trim map payload

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/infra/repository/ListingRepository.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/ListingRepository.java
@@ -143,6 +143,17 @@ public interface ListingRepository extends JpaRepository<Listing, Long>, JpaSpec
     List<Listing> findByIdsWithMedia(@Param("ids") Collection<Long> ids);
 
     /**
+     * Map-card hydration: media AND address in a single query, without the
+     * amenities join (cards never render amenities). The map-bounds query joins
+     * addresses only for its WHERE/sort, so the address association is left lazy
+     * on the returned entities — mapping each card would then lazy-load address
+     * one listing at a time (an N+1 of up to 200 queries that dominated the
+     * map-bounds latency). Fetching it here collapses that into one query.
+     */
+    @Query("SELECT DISTINCT l FROM listings l LEFT JOIN FETCH l.media LEFT JOIN FETCH l.address WHERE l.listingId IN :ids")
+    List<Listing> findByIdsWithMediaAndAddress(@Param("ids") Collection<Long> ids);
+
+    /**
      * Homepage VIP-tier carousel: the latest {@code N} verified, non-draft,
      * non-shadow listings of one tier. Returns a plain {@code List} (not a
      * {@code Page}) so Spring Data does NOT run a COUNT(*) — the carousel only

--- a/smart-rent/src/main/java/com/smartrent/service/listing/impl/ListingServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/listing/impl/ListingServiceImpl.java
@@ -985,8 +985,12 @@ public class ListingServiceImpl implements ListingService {
                 : userRepository.findAllById(userIds).stream()
                         .collect(Collectors.toMap(User::getUserId, Function.identity()));
 
-        // 1 query: batch-load media (no amenities needed for cards)
-        listingRepository.findByIdsWithMedia(listingIds);
+        // 1 query: batch-load media AND address (no amenities needed for cards).
+        // Address must be hydrated here: the map-bounds query joins addresses only
+        // for its WHERE/sort, so listing.getAddress() below would otherwise
+        // lazy-load once per listing -- an N+1 of up to 200 queries that dominated
+        // the map-bounds response time (1-23s in production traces).
+        listingRepository.findByIdsWithMediaAndAddress(listingIds);
 
         return listings.stream()
                 .map(listing -> {
@@ -3196,6 +3200,12 @@ public class ListingServiceImpl implements ListingService {
         // skips that join entirely, which is the dominant cost at high zoom-out
         // levels where the query returns close to the 500-listing cap.
         List<ListingCardResponse> listings = batchMapCardListings(page.getContent());
+
+        // The map renders pins and compact cards only — it never shows the
+        // description body. Drop it on this path (up to 500 listings per call)
+        // so full descriptions don't inflate the payload; the other
+        // batchMapCardListings callers keep theirs untouched.
+        listings.forEach(card -> card.setDescription(null));
 
         // Build bounds info
         com.smartrent.dto.response.MapListingsResponse.MapBoundsInfo boundsInfo =

--- a/smart-rent/src/test/java/com/smartrent/service/listing/impl/ListingServiceImplMapBoundsTest.java
+++ b/smart-rent/src/test/java/com/smartrent/service/listing/impl/ListingServiceImplMapBoundsTest.java
@@ -34,6 +34,12 @@ import static org.mockito.Mockito.when;
  * result set by amenity count per listing for data the map never displays.
  * Locks in the fix: the endpoint must use the card path and must never
  * touch the amenities batch-load.
+ *
+ * Also locks in the N+1 fix: the card path must hydrate media AND address in a
+ * single query (findByIdsWithMediaAndAddress). The map-bounds query joins
+ * addresses only for its WHERE/sort, so without this the per-card
+ * getAddress() would lazy-load one row at a time -- an N+1 of up to 200
+ * queries. The media-only findByIdsWithMedia must no longer be used here.
  */
 @ExtendWith(MockitoExtension.class)
 class ListingServiceImplMapBoundsTest {
@@ -62,7 +68,7 @@ class ListingServiceImplMapBoundsTest {
         when(listingQueryService.queryByMapBounds(
                 any(), any(), any(), any(), any(), any(), any(), any()))
                 .thenReturn(new PageImpl<>(List.of(listing), Pageable.unpaged(), 1));
-        when(listingRepository.findByIdsWithMedia(anyCollection()))
+        when(listingRepository.findByIdsWithMediaAndAddress(anyCollection()))
                 .thenReturn(List.of(listing));
         when(listingMapper.toCardResponse(any(), any(), any()))
                 .thenReturn(ListingCardResponse.builder().listingId(1L).build());
@@ -81,5 +87,9 @@ class ListingServiceImplMapBoundsTest {
         assertEquals(1, response.getListings().size());
         assertEquals(1L, response.getListings().get(0).getListingId());
         verify(listingRepository, never()).findByIdsWithAmenities(anyCollection());
+        // Media + address hydrated together; the media-only path (which left
+        // address lazy and caused the N+1) must not be used on the map path.
+        verify(listingRepository).findByIdsWithMediaAndAddress(anyCollection());
+        verify(listingRepository, never()).findByIdsWithMedia(anyCollection());
     }
 }


### PR DESCRIPTION
## Bối cảnh

`/v1/listings/map-bounds` chậm nghiêm trọng trên production: Network cho thấy mỗi request mất **1–23 giây** với payload **500–600 kB**. Root cause chính là một **N+1 query** ẩn.

## Root cause

Đường map dùng `batchMapCardListings`, chỉ hydrate media (`findByIdsWithMedia`). Truy vấn map-bounds chỉ `JOIN` bảng `addresses` để lọc/sắp xếp (WHERE/ORDER BY), **không** fetch association `address`. `Listing.address` là `@ManyToOne(fetch = LAZY)`, nên khi map từng card gọi `listing.getAddress()` sẽ **lazy-load một câu SELECT address cho mỗi listing** — tối đa ~200 câu query rời rạc mỗi request. Dưới tải nhiều request chồng nhau + DB ~100k dòng, đây là thứ đẩy thời gian lên 1–23s.

## Thay đổi

- Thêm `findByIdsWithMediaAndAddress` (`LEFT JOIN FETCH l.media LEFT JOIN FETCH l.address`) và cho đường map dùng nó — gộp media + address vào **một** query, vẫn không kéo theo amenities.
- Bỏ trường `description` **chỉ trên đường map** (bản đồ không bao giờ hiển thị nó) để giảm payload; 5 endpoint card khác giữ nguyên.
- Cập nhật `ListingServiceImplMapBoundsTest` để khoá cả hai: đường map dùng `findByIdsWithMediaAndAddress`, và **không** dùng `findByIdsWithMedia` (media-only) lẫn `findByIdsWithAmenities`.

## Kiểm chứng

- `./gradlew compileJava`: pass
- `./gradlew test --tests *ListingServiceImplMapBoundsTest*`: pass

## Cách xác nhận sau khi merge/deploy

1. Bật `logging.level.org.hibernate.SQL: DEBUG` — số câu query mỗi lần gọi map-bounds phải tụt từ ~200 xuống ~3–4 (không còn loạt `select ... from addresses where address_id=?` lặp lại).
2. Đo lại cột Time của `map-bounds` trên môi trường có dữ liệu thật.
3. Nếu vẫn chậm, kiểm tra index geo (`SHOW INDEX FROM addresses WHERE Key_name='idx_addresses_geo'`) và `EXPLAIN` truy vấn ở zoom rộng.