### PR TITLE
perf(map-bounds): denormalize lat/lng onto listings, drop the addresses join

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/infra/repository/entity/Listing.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/entity/Listing.java
@@ -58,7 +58,13 @@ import java.util.List;
                 @Index(name = "idx_listings_reco_legacy_dist", columnList = "legacy_district_id, is_draft, is_shadow, verified, expired, pushed_at, post_date"),
                 @Index(name = "idx_listings_reco_legacy_ward", columnList = "legacy_ward_id, is_draft, is_shadow, verified, expired, pushed_at, post_date"),
                 @Index(name = "idx_listings_reco_legacy_prov", columnList = "legacy_province_id, is_draft, is_shadow, verified, expired, pushed_at, post_date"),
-                @Index(name = "idx_listings_reco_fresh", columnList = "is_draft, is_shadow, verified, expired, pushed_at, post_date")
+                @Index(name = "idx_listings_reco_fresh", columnList = "is_draft, is_shadow, verified, expired, pushed_at, post_date"),
+                // Public /map-bounds bounding-box query — see V98. lat/lng are denormalized
+                // from addresses so the visibility filter, the bbox and the vip/updated_at
+                // sort all live on listings ⇒ a single-table range scan replaces the
+                // addresses join. Equality prefix (is_draft, verified, expired) + latitude
+                // range + covering suffix (longitude, expiry_date + sort keys).
+                @Index(name = "idx_listings_map_bounds", columnList = "is_draft, verified, expired, latitude, longitude, expiry_date, vip_type_sort_order, updated_at, listing_id")
         })
 @Getter
 @Setter
@@ -210,6 +216,19 @@ public class Listing {
 
     @Column(name = "legacy_ward_id")
     Integer legacyWardId;
+
+    // Denormalized coordinates copied from the referenced Address, same rationale
+    // as the location keys above: /map-bounds filters by a lat/lng bounding box
+    // AND sorts by vip_type_sort_order/updated_at. Keeping lat/lng on listings
+    // turns that cross-table filter+sort (a ~20s nested-loop join on the
+    // small-buffer-pool prod DB) into a single-table index range scan
+    // (idx_listings_map_bounds). Populated by updateSearchFields() and backfilled
+    // in V98. Read the Address entity for canonical values; never write directly.
+    @Column(name = "latitude", precision = 10, scale = 8)
+    BigDecimal latitude;
+
+    @Column(name = "longitude", precision = 11, scale = 8)
+    BigDecimal longitude;
 
     // Property Specifications
     @Column(name = "area")
@@ -405,6 +424,8 @@ public class Listing {
             legacyProvinceId = address.getLegacyProvinceId();
             legacyDistrictId = address.getLegacyDistrictId();
             legacyWardId = address.getLegacyWardId();
+            latitude = address.getLatitude();
+            longitude = address.getLongitude();
         }
 
         String addressText = address != null ? address.getDisplayAddress() : null;

--- a/smart-rent/src/main/java/com/smartrent/infra/repository/specification/ListingSpecification.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/specification/ListingSpecification.java
@@ -970,20 +970,21 @@ public class ListingSpecification {
         return (root, query, criteriaBuilder) -> {
             List<Predicate> predicates = new ArrayList<>();
 
-            // Join with Address table to access latitude and longitude
-            Join<Listing, Address> addressJoin = root.join("address", JoinType.INNER);
-
-            // Bounding box filter: latitude and longitude must be within bounds
-            // Latitude: swLat <= latitude <= neLat
-            // Longitude: swLng <= longitude <= neLng
+            // Bounding-box filter on the coordinates denormalized onto listings
+            // (V98). Filtering here instead of joining addresses keeps the query
+            // single-table, so the visibility filter, the bbox and the
+            // vip_type_sort_order/updated_at sort are all served by
+            // idx_listings_map_bounds -- no nested-loop join to addresses, which
+            // was the ~20s cost at wide zoom on the small-buffer-pool prod DB.
+            // Latitude: swLat <= latitude <= neLat; Longitude: swLng <= longitude <= neLng
             predicates.add(criteriaBuilder.between(
-                addressJoin.get("latitude"),
+                root.get("latitude"),
                 swLat.doubleValue(),
                 neLat.doubleValue()
             ));
 
             predicates.add(criteriaBuilder.between(
-                addressJoin.get("longitude"),
+                root.get("longitude"),
                 swLng.doubleValue(),
                 neLng.doubleValue()
             ));

--- a/smart-rent/src/main/resources/db/migration/V98__Denormalize_latlng_onto_listings_for_map_bounds.sql
+++ b/smart-rent/src/main/resources/db/migration/V98__Denormalize_latlng_onto_listings_for_map_bounds.sql
@@ -1,0 +1,82 @@
+-- Migration V98: Denormalize lat/lng onto listings + covering index for
+-- /map-bounds, so the bounding-box query drops the addresses join entirely.
+-- ============================================================================
+-- WHY. EXPLAIN ANALYZE of the map-bounds query (zoom 11, ~9k matches) on the
+-- 32MB-buffer-pool prod DB:
+--
+--   Sort (vip_type_sort_order, updated_at)            actual 20752ms
+--     Nested loop inner join                          actual 20602ms   <-- cost
+--       range scan addresses using idx_addresses_geo  actual   50ms (4156 rows)
+--       Index lookup on listings using idx_address    actual  ~8ms x loops=2515
+--
+-- The geo index is fine (50ms) and the sort is cheap (~150ms). The 20s is the
+-- JOIN: for each in-box address it looks up listings by address_id then fetches
+-- the WIDE clustered row (LONGTEXT description) to read the visibility flags +
+-- sort keys -- ~24k random disk reads on the tiny buffer pool.
+--
+-- FIX. latitude/longitude are fixed reference data on the address; copy them
+-- onto listings (exactly like V97 did for the province/ward keys) so the map
+-- filter (bbox + visibility) AND the sort all live on listings. The query then
+-- becomes a single-table index range scan on idx_listings_map_bounds -- no join
+-- to addresses at all. Equality prefix (is_draft, verified, expired) + primary
+-- range (latitude) + covering suffix (longitude, expiry_date + the sort keys)
+-- so the scan is index-only; only the final LIMIT 200 rows fetch full rows.
+--
+-- Order: add columns -> backfill -> then index (index the populated columns once
+-- rather than maintain it during the bulk UPDATE). Idempotent via
+-- information_schema checks, matching V97 style. The @PrePersist/@PreUpdate hook
+-- (Listing.updateSearchFields) keeps the copies in sync on create/update.
+-- ============================================================================
+
+-- ---------------------------------------------------------------------------
+-- 1. Add the two denormalized coordinate columns (nullable -- a listing whose
+--    address has no coordinates simply won't appear on the map).
+--    Types mirror addresses.latitude DECIMAL(10,8) / longitude DECIMAL(11,8).
+-- ---------------------------------------------------------------------------
+SET @col_exists = (SELECT COUNT(*) FROM information_schema.columns
+                   WHERE table_schema = DATABASE()
+                     AND table_name = 'listings'
+                     AND column_name = 'latitude');
+SET @sql = IF(@col_exists = 0,
+    'ALTER TABLE listings ADD COLUMN latitude DECIMAL(10,8) NULL',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @col_exists = (SELECT COUNT(*) FROM information_schema.columns
+                   WHERE table_schema = DATABASE()
+                     AND table_name = 'listings'
+                     AND column_name = 'longitude');
+SET @sql = IF(@col_exists = 0,
+    'ALTER TABLE listings ADD COLUMN longitude DECIMAL(11,8) NULL',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- ---------------------------------------------------------------------------
+-- 2. Backfill from addresses (one-time; addresses are fixed reference data).
+--    PK-join on listings.address_id, runs before the index exists.
+-- ---------------------------------------------------------------------------
+UPDATE listings l
+JOIN addresses a ON l.address_id = a.address_id
+SET l.latitude  = a.latitude,
+    l.longitude = a.longitude;
+
+-- ---------------------------------------------------------------------------
+-- 3. Covering index for ListingSpecification.withinMapBounds. Equality prefix
+--    (is_draft, verified, expired) + latitude range + covering suffix
+--    (longitude, expiry_date, vip_type_sort_order, updated_at, listing_id) so
+--    the whole filter + sort-key read is index-only, no clustered-row fetch.
+-- ---------------------------------------------------------------------------
+SET @idx_exists = (SELECT COUNT(*) FROM information_schema.statistics
+                   WHERE table_schema = DATABASE()
+                     AND table_name = 'listings'
+                     AND index_name = 'idx_listings_map_bounds');
+SET @sql = IF(@idx_exists = 0,
+    'CREATE INDEX idx_listings_map_bounds ON listings (is_draft, verified, expired, latitude, longitude, expiry_date, vip_type_sort_order, updated_at, listing_id)',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- ---------------------------------------------------------------------------
+-- 4. Refresh optimizer statistics so the planner adopts the new index/columns
+--    immediately. Fast on the ~100k-row table.
+-- ---------------------------------------------------------------------------
+ANALYZE TABLE listings;


### PR DESCRIPTION
Follow-up to #366 (N+1 on address). That fix is merged, but production `EXPLAIN ANALYZE` shows the map-bounds query is still ~20s single-threaded / up to 42s under concurrent panning — and it is **not** an index problem.

## Root cause (confirmed by EXPLAIN ANALYZE, zoom 11, ~9k matches)

```
Sort (vip_type_sort_order, updated_at)            actual 20752ms
  Nested loop inner join                          actual 20602ms   <-- the cost
    range scan addresses using idx_addresses_geo  actual   50ms (4156 rows)
    Index lookup on listings using idx_address    actual  ~8ms x loops=2515
```

The geo index is fine (50ms) and the sort is cheap (~150ms). The 20s is the **join**: for each in-box address it looks up listings by `address_id` (`idx_address` is address_id only), then fetches the wide clustered row (listings has a `LONGTEXT description`) to read the visibility flags + sort keys — ~24k random disk reads on the DB's tiny (32MB) InnoDB buffer pool.

## Fix

`latitude`/`longitude` are fixed reference data on the address. Copy them onto `listings` (exactly like V97 did for the province/ward keys) so the map filter (bbox + visibility) **and** the sort all live on `listings`. The query becomes a single-table index range scan on `idx_listings_map_bounds` — **no join to addresses at all**.

- **V98**: add `listings.latitude/longitude`, backfill from `addresses`, create `idx_listings_map_bounds (is_draft, verified, expired, latitude, longitude, expiry_date, vip_type_sort_order, updated_at, listing_id)`, `ANALYZE TABLE`.
- **Listing**: add the two columns + the covering index. The existing `@PrePersist/@PreUpdate updateSearchFields()` hook now also copies `lat/lng` from the address, so the denormalized copies stay in sync on create/update (no separate sync code).
- **ListingSpecification.withinMapBounds**: filter `root.latitude/longitude` instead of joining `addresses`.

No API contract change — the frontend is unaffected.

## Verification

- `./gradlew compileJava test --tests *ListingServiceImplMapBoundsTest*`: pass.
- Suggested prod check after deploy — re-run the same `EXPLAIN ANALYZE` (now single-table): expect an index range scan on `idx_listings_map_bounds`, no `Nested loop`, ~20s → sub-second.

Note: the 32MB buffer pool is a systemic under-provisioning (it also caused the 63–81s recommendation queries fixed by V97). Bumping the DB plan is still recommended, but this change removes the map's dependence on it.