### PR TITLE
fix(map-bounds): restore pin coordinates and gate pins on admin approval

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/dto/response/ListingCardResponse.java
+++ b/smart-rent/src/main/java/com/smartrent/dto/response/ListingCardResponse.java
@@ -53,6 +53,8 @@ public class ListingCardResponse {
     public static class AddressCard {
         String fullNewAddress;
         String fullAddress;
+        BigDecimal latitude;
+        BigDecimal longitude;
     }
 
     @Getter

--- a/smart-rent/src/main/java/com/smartrent/infra/repository/entity/Listing.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/entity/Listing.java
@@ -59,12 +59,14 @@ import java.util.List;
                 @Index(name = "idx_listings_reco_legacy_ward", columnList = "legacy_ward_id, is_draft, is_shadow, verified, expired, pushed_at, post_date"),
                 @Index(name = "idx_listings_reco_legacy_prov", columnList = "legacy_province_id, is_draft, is_shadow, verified, expired, pushed_at, post_date"),
                 @Index(name = "idx_listings_reco_fresh", columnList = "is_draft, is_shadow, verified, expired, pushed_at, post_date"),
-                // Public /map-bounds bounding-box query — see V98. lat/lng are denormalized
-                // from addresses so the visibility filter, the bbox and the vip/updated_at
-                // sort all live on listings ⇒ a single-table range scan replaces the
-                // addresses join. Equality prefix (is_draft, verified, expired) + latitude
-                // range + covering suffix (longitude, expiry_date + sort keys).
-                @Index(name = "idx_listings_map_bounds", columnList = "is_draft, verified, expired, latitude, longitude, expiry_date, vip_type_sort_order, updated_at, listing_id")
+                // Public /map-bounds bounding-box query — see V98/V99. lat/lng are
+                // denormalized from addresses so the visibility filter, the bbox and the
+                // vip/updated_at sort all live on listings ⇒ a single-table range scan
+                // replaces the addresses join. Equality prefix (is_draft, is_shadow,
+                // verified, moderation_status, expired) + latitude range + covering
+                // suffix (longitude, expiry_date + sort keys). moderation_status/is_shadow
+                // added in V99 to match withinMapBounds()'s admin-approval + shadow-ban gate.
+                @Index(name = "idx_listings_map_bounds", columnList = "is_draft, is_shadow, verified, moderation_status, expired, latitude, longitude, expiry_date, vip_type_sort_order, updated_at, listing_id")
         })
 @Getter
 @Setter

--- a/smart-rent/src/main/java/com/smartrent/infra/repository/specification/ListingSpecification.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/specification/ListingSpecification.java
@@ -992,6 +992,11 @@ public class ListingSpecification {
             // Exclude drafts - only show published listings on map
             predicates.add(criteriaBuilder.equal(root.get("isDraft"), false));
 
+            // Exclude shadow-banned listings. Every other public-visibility path
+            // (fromFilterRequest, findHomepageTier) applies this unconditionally;
+            // withinMapBounds had drifted from that and was missing it.
+            predicates.add(criteriaBuilder.equal(root.get("isShadow"), false));
+
             // Verified filter
             if (Boolean.TRUE.equals(verifiedOnly)) {
                 predicates.add(criteriaBuilder.equal(root.get("verified"), true));
@@ -999,6 +1004,20 @@ public class ListingSpecification {
                 // By default, only show verified listings on public map
                 predicates.add(criteriaBuilder.equal(root.get("verified"), true));
             }
+
+            // Admin-approval gate. `verified` alone is not authoritative -- it's a
+            // badge flag that can drift from the actual moderation outcome (see
+            // ListingModerationServiceImpl, which sets both together on approve but
+            // can flip verified back to false on revision/resubmission while
+            // moderationStatus moves independently). moderationStatus=APPROVED is
+            // what admin approval actually gates on, and is required by the same
+            // "Đang hiển thị" (DISPLAYING) rule /seller/listings uses -- see
+            // ListingSpecification.buildStatusPredicate(DISPLAYING) plus the
+            // moderationStatus=APPROVED predicate the seller page always sends
+            // alongside it.
+            predicates.add(criteriaBuilder.equal(
+                root.get("moderationStatus"),
+                com.smartrent.enums.ModerationStatus.APPROVED));
 
             // Exclude expired listings (flag AND date check)
             LocalDateTime mapNow = LocalDateTime.now();

--- a/smart-rent/src/main/java/com/smartrent/mapper/impl/ListingMapperImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/mapper/impl/ListingMapperImpl.java
@@ -186,6 +186,8 @@ public class ListingMapperImpl implements ListingMapper {
             addressCard = ListingCardResponse.AddressCard.builder()
                     .fullNewAddress(address.getFullNewAddress())
                     .fullAddress(address.getFullAddress())
+                    .latitude(address.getLatitude())
+                    .longitude(address.getLongitude())
                     .build();
         }
 

--- a/smart-rent/src/main/resources/db/migration/V99__Add_moderation_shadow_gate_to_map_bounds_index.sql
+++ b/smart-rent/src/main/resources/db/migration/V99__Add_moderation_shadow_gate_to_map_bounds_index.sql
@@ -1,0 +1,50 @@
+-- Migration V99: withinMapBounds() was missing the moderation_status=APPROVED
+-- and is_shadow=false gates that every other public-visibility query
+-- (fromFilterRequest, findHomepageTier) already applies -- listings that were
+-- shadow-banned or never admin-approved could still show as pins on the
+-- public map even though verified=true alone doesn't guarantee that (see
+-- ListingModerationServiceImpl, which can flip verified back to false
+-- independently of moderation_status on revision/resubmission).
+--
+-- ListingSpecification.withinMapBounds now filters on
+-- (is_draft, is_shadow, verified, moderation_status, expired, latitude,
+-- longitude, expiry_date) -- rebuild idx_listings_map_bounds so the new
+-- equality predicates (is_shadow, moderation_status) stay in the index
+-- prefix ahead of the latitude range scan, instead of falling back to a
+-- row-by-row filter after the index lookup.
+--
+-- Idempotent via information_schema checks, matching V97/V98 style.
+-- ============================================================================
+
+-- ---------------------------------------------------------------------------
+-- 1. Drop the old index (equality prefix no longer matches the query).
+-- ---------------------------------------------------------------------------
+SET @idx_exists = (SELECT COUNT(*) FROM information_schema.statistics
+                   WHERE table_schema = DATABASE()
+                     AND table_name = 'listings'
+                     AND index_name = 'idx_listings_map_bounds');
+SET @sql = IF(@idx_exists > 0,
+    'DROP INDEX idx_listings_map_bounds ON listings',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- ---------------------------------------------------------------------------
+-- 2. Recreate with the full equality prefix used by withinMapBounds:
+--    is_draft, is_shadow, verified, moderation_status, expired -- then the
+--    latitude range, then the covering suffix (longitude, expiry_date +
+--    the ORDER BY keys) exactly as V98 laid out.
+-- ---------------------------------------------------------------------------
+SET @idx_exists = (SELECT COUNT(*) FROM information_schema.statistics
+                   WHERE table_schema = DATABASE()
+                     AND table_name = 'listings'
+                     AND index_name = 'idx_listings_map_bounds');
+SET @sql = IF(@idx_exists = 0,
+    'CREATE INDEX idx_listings_map_bounds ON listings (is_draft, is_shadow, verified, moderation_status, expired, latitude, longitude, expiry_date, vip_type_sort_order, updated_at, listing_id)',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- ---------------------------------------------------------------------------
+-- 3. Refresh optimizer statistics so the planner adopts the rebuilt index
+--    immediately.
+-- ---------------------------------------------------------------------------
+ANALYZE TABLE listings;

--- a/smart-rent/src/test/java/com/smartrent/mapper/impl/ListingMapperImplTest.java
+++ b/smart-rent/src/test/java/com/smartrent/mapper/impl/ListingMapperImplTest.java
@@ -1,0 +1,56 @@
+package com.smartrent.mapper.impl;
+
+import com.smartrent.dto.response.AddressResponse;
+import com.smartrent.dto.response.ListingCardResponse;
+import com.smartrent.infra.repository.entity.Listing;
+import com.smartrent.mapper.AmenityMapper;
+import com.smartrent.mapper.MediaMapper;
+import com.smartrent.infra.repository.LegacyDistrictRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * toCardResponse() feeds the /v1/listings/map-bounds response, which the map
+ * page renders pins from. AddressCard used to declare only fullAddress/
+ * fullNewAddress, so the map's latitude/longitude were silently dropped even
+ * though the AddressResponse passed in had them -- every listing matched the
+ * bounds query but rendered no pin. Locks in that address.latitude/longitude
+ * survive the entity -> card mapping.
+ */
+@ExtendWith(MockitoExtension.class)
+class ListingMapperImplTest {
+
+    @Mock
+    AmenityMapper amenityMapper;
+
+    @Mock
+    MediaMapper mediaMapper;
+
+    @Mock
+    LegacyDistrictRepository legacyDistrictRepository;
+
+    @Test
+    void toCardResponseKeepsAddressCoordinates() {
+        ListingMapperImpl mapper =
+                new ListingMapperImpl(amenityMapper, mediaMapper, legacyDistrictRepository);
+
+        Listing listing = Listing.builder().listingId(1L).build();
+        AddressResponse address = AddressResponse.builder()
+                .fullAddress("123 Le Loi")
+                .fullNewAddress("123 Le Loi, Da Nang")
+                .latitude(BigDecimal.valueOf(16.0544))
+                .longitude(BigDecimal.valueOf(108.2022))
+                .build();
+
+        ListingCardResponse card = mapper.toCardResponse(listing, null, address);
+
+        assertEquals(BigDecimal.valueOf(16.0544), card.getAddress().getLatitude());
+        assertEquals(BigDecimal.valueOf(108.2022), card.getAddress().getLongitude());
+    }
+}


### PR DESCRIPTION
- AddressCard (the DTO backing /v1/listings/map-bounds) never declared latitude/longitude, so the mapper silently dropped them even though the AddressResponse passed in had them. Every listing matched the bbox query but rendered with undefined coordinates, so the frontend's viewport filter dropped every pin and the map showed nothing despite a successful response.
- withinMapBounds() was missing moderationStatus=APPROVED and isShadow=false, unlike every other public-visibility path (fromFilterRequest, findHomepageTier). verified=true alone isn't authoritative since it can drift from the moderation outcome on revision/resubmission, so shadow-banned or not-yet-approved listings could still show as pins on the public map. Aligned with the same rule /seller/listings' "Đang hiển thị" tab uses.
- V99 rebuilds idx_listings_map_bounds with the two new equality predicates in the prefix, ahead of the latitude range scan.