### PR TITLE
fix(map-bounds): include per-listing lat/lng so map pins render

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/dto/response/ListingCardResponse.java
+++ b/smart-rent/src/main/java/com/smartrent/dto/response/ListingCardResponse.java
@@ -53,6 +53,11 @@ public class ListingCardResponse {
     public static class AddressCard {
         String fullNewAddress;
         String fullAddress;
+        // Coordinates the /map-bounds map view needs to place each pin. The FE
+        // reads listing.address.latitude/longitude and filters out any listing
+        // without them, so omitting these renders an empty map even on a 200.
+        BigDecimal latitude;
+        BigDecimal longitude;
     }
 
     @Getter

--- a/smart-rent/src/main/java/com/smartrent/mapper/impl/ListingMapperImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/mapper/impl/ListingMapperImpl.java
@@ -186,6 +186,8 @@ public class ListingMapperImpl implements ListingMapper {
             addressCard = ListingCardResponse.AddressCard.builder()
                     .fullNewAddress(address.getFullNewAddress())
                     .fullAddress(address.getFullAddress())
+                    .latitude(address.getLatitude())
+                    .longitude(address.getLongitude())
                     .build();
         }
 

--- a/smart-rent/src/test/java/com/smartrent/mapper/impl/ListingMapperImplCardResponseTest.java
+++ b/smart-rent/src/test/java/com/smartrent/mapper/impl/ListingMapperImplCardResponseTest.java
@@ -1,0 +1,45 @@
+package com.smartrent.mapper.impl;
+
+import com.smartrent.dto.response.AddressResponse;
+import com.smartrent.dto.response.ListingCardResponse;
+import com.smartrent.infra.repository.entity.Listing;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * The /map-bounds map view places every pin from listing.address.latitude /
+ * listing.address.longitude and filters out any listing missing them. So
+ * toCardResponse MUST copy the coordinates from the source AddressResponse onto
+ * the card's AddressCard -- dropping them renders an empty map (0 pins, "0 bất
+ * động sản") even on a successful HTTP 200. This locks that in.
+ *
+ * toCardResponse maps plain fields only (no injected collaborators are touched
+ * on this path), so the mapper is constructed with null dependencies.
+ */
+class ListingMapperImplCardResponseTest {
+
+    private final ListingMapperImpl mapper = new ListingMapperImpl(null, null, null);
+
+    @Test
+    void toCardResponseCopiesAddressCoordinates() {
+        Listing listing = Listing.builder().listingId(1L).build();
+        AddressResponse address = AddressResponse.builder()
+                .fullNewAddress("123 Nguyễn Trãi, Thành Phố Hồ Chí Minh")
+                .fullAddress("123 Nguyễn Trãi, Phường 5, Quận 5, TP.HCM")
+                .latitude(new BigDecimal("10.75450000"))
+                .longitude(new BigDecimal("106.66790000"))
+                .build();
+
+        ListingCardResponse card = mapper.toCardResponse(listing, null, address);
+
+        assertNotNull(card.getAddress(), "map card must carry an address object");
+        assertEquals(new BigDecimal("10.75450000"), card.getAddress().getLatitude(),
+                "latitude must reach the map card so the FE can place the pin");
+        assertEquals(new BigDecimal("106.66790000"), card.getAddress().getLongitude(),
+                "longitude must reach the map card so the FE can place the pin");
+    }
+}


### PR DESCRIPTION
## Problem

`POST /v1/listings/map-bounds` returns HTTP 200 with listings, but the web `/maps` view renders **zero pins** and an empty sidebar ("0 bất động sản / Không tìm thấy bất động sản trong khu vực này") while the header still shows the real `totalCount` (e.g. 2843).

## Root cause

The map-card response carries **no per-listing coordinates**. `ListingCardResponse.AddressCard` only had `fullNewAddress` / `fullAddress`, and `ListingMapperImpl.toCardResponse` never copied `latitude` / `longitude` from the source `AddressResponse` (which does expose them).

The frontend places each pin from `listing.address.latitude/longitude` and filters out any listing missing them (`listingInViewport`). With the coordinates `undefined`, every listing is filtered out → 0 pins **and** an empty sidebar, even though `totalCount` (read from a separate field) shows the real count. This was true on `main` — the map path never emitted coordinates, so the perf branch (V98/denormalize) does not fix it either.

## Fix

- Add `latitude` / `longitude` (`BigDecimal`) to `ListingCardResponse.AddressCard`.
- Populate them in `ListingMapperImpl.toCardResponse` from `AddressResponse.getLatitude()/getLongitude()`.

`BigDecimal` serialises to a JSON number, matching the FE's declared `address.latitude: number`. Two extra numbers per card — negligible payload (the map path already nulls `description`).

## Test

Adds `ListingMapperImplCardResponseTest`, which exercises the real mapper and asserts the coordinates reach the card (the existing map-bounds service test mocks the mapper, so it could not catch this).

`./gradlew test --tests "*ListingMapperImplCardResponseTest" --tests "*ListingServiceImplMapBoundsTest"` → **BUILD SUCCESSFUL**.

## Notes

- **Independent of the map perf work** (`perf/map-bounds-denormalize` / V98). This is a correctness fix; deploying it is what makes pins appear. Query latency (~9.6s) is a separate track.
- The FE already has the matching `mapId` fix merged on `main` (PR #390, `DEMO_MAP_ID` fallback), so no FE change is needed for pins to draw once this deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
