### PR TITLE
perf(map-bounds): force idx_listings_map_bounds so the map query stays ~70ms

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/infra/repository/ListingRepository.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/ListingRepository.java
@@ -154,6 +154,65 @@ public interface ListingRepository extends JpaRepository<Listing, Long>, JpaSpec
     List<Listing> findByIdsWithMediaAndAddress(@Param("ids") Collection<Long> ids);
 
     /**
+     * Map-bounds pin IDs — ordered (VIP-first, then newest, then id) and capped,
+     * with the geo index FORCED. The bbox + visibility filter mirrors
+     * {@link com.smartrent.infra.repository.specification.ListingSpecification#withinMapBounds}
+     * exactly (is_draft/is_shadow/verified/moderation_status/expired + bbox + expiry
+     * + optional category).
+     *
+     * <p>FORCE INDEX is load-bearing: with this ORDER BY + LIMIT shape the optimizer
+     * otherwise prefers idx_listings_sort_order and filters row-by-row (measured
+     * ~1.5s at city zoom on the small-buffer-pool prod DB, and far worse when zoomed
+     * into a sparse area where it scans most of the sort index before hitting the
+     * cap). idx_listings_map_bounds is a covering, geo-bounded range scan (~70ms,
+     * consistent). A histogram on latitude/longitude does NOT flip the planner — the
+     * ORDER BY+LIMIT bias wins — so the hint is required. Returns IDs only; the
+     * caller hydrates the managed entities (media+address) by id.
+     */
+    @Query(value = """
+            SELECT l.listing_id
+            FROM listings l FORCE INDEX (idx_listings_map_bounds)
+            WHERE l.is_draft = 0
+              AND l.is_shadow = 0
+              AND l.verified = 1
+              AND l.moderation_status = 'APPROVED'
+              AND l.expired = 0
+              AND l.latitude BETWEEN :swLat AND :neLat
+              AND l.longitude BETWEEN :swLng AND :neLng
+              AND (l.expiry_date IS NULL OR l.expiry_date > NOW())
+              AND (:categoryId IS NULL OR l.category_id = :categoryId)
+            ORDER BY l.vip_type_sort_order ASC, l.updated_at DESC, l.listing_id ASC
+            LIMIT :limit
+            """, nativeQuery = true)
+    List<Long> findMapBoundsListingIds(
+            @Param("swLat") BigDecimal swLat, @Param("neLat") BigDecimal neLat,
+            @Param("swLng") BigDecimal swLng, @Param("neLng") BigDecimal neLng,
+            @Param("categoryId") Long categoryId, @Param("limit") int limit);
+
+    /**
+     * Total matching pins in the bounds (drives the FE "X tổng, phóng to" hint).
+     * Same filter + forced geo index as {@link #findMapBoundsListingIds}; no ORDER BY
+     * so it's a plain covering range-count.
+     */
+    @Query(value = """
+            SELECT COUNT(*)
+            FROM listings l FORCE INDEX (idx_listings_map_bounds)
+            WHERE l.is_draft = 0
+              AND l.is_shadow = 0
+              AND l.verified = 1
+              AND l.moderation_status = 'APPROVED'
+              AND l.expired = 0
+              AND l.latitude BETWEEN :swLat AND :neLat
+              AND l.longitude BETWEEN :swLng AND :neLng
+              AND (l.expiry_date IS NULL OR l.expiry_date > NOW())
+              AND (:categoryId IS NULL OR l.category_id = :categoryId)
+            """, nativeQuery = true)
+    long countMapBoundsListings(
+            @Param("swLat") BigDecimal swLat, @Param("neLat") BigDecimal neLat,
+            @Param("swLng") BigDecimal swLng, @Param("neLng") BigDecimal neLng,
+            @Param("categoryId") Long categoryId);
+
+    /**
      * Homepage VIP-tier carousel: the latest {@code N} verified, non-draft,
      * non-shadow listings of one tier. Returns a plain {@code List} (not a
      * {@code Page}) so Spring Data does NOT run a COUNT(*) — the carousel only

--- a/smart-rent/src/main/java/com/smartrent/service/listing/ListingQueryService.java
+++ b/smart-rent/src/main/java/com/smartrent/service/listing/ListingQueryService.java
@@ -4,11 +4,18 @@ import com.smartrent.dto.request.ListingFilterRequest;
 import com.smartrent.infra.repository.ListingRepository;
 import com.smartrent.infra.repository.entity.Listing;
 import com.smartrent.infra.repository.specification.ListingSpecification;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -165,30 +172,43 @@ public class ListingQueryService {
         log.debug("Querying listings by map bounds - NE: ({}, {}), SW: ({}, {}), limit: {}",
                 neLat, neLng, swLat, swLng, limit);
 
-        // Build specification for map bounds query
-        Specification<Listing> spec = ListingSpecification.withinMapBounds(
-                neLat, neLng, swLat, swLng, verifiedOnly, categoryId, vipType);
-
         // Deterministic ordering is REQUIRED for the map: the query is capped by
         // `limit`, so without a stable ORDER BY the database is free to return a
-        // different subset (and different order) for the same bounding box on each
-        // call — which is exactly the "points flicker / disappear in the same area"
-        // bug. Sort by VIP tier (DIAMOND first) so the most relevant pins always
-        // win the cap, then newest first, then listingId as a final tie-breaker so
-        // the result set is fully reproducible.
-        Sort sort = Sort.by(Sort.Direction.ASC, "vipTypeSortOrder")
-                .and(Sort.by(Sort.Direction.DESC, "updatedAt"))
-                .and(Sort.by(Sort.Direction.ASC, "listingId"));
-
-        // Create pageable with limit and the deterministic sort
+        // different subset for the same bounding box on each call — the "points
+        // flicker / disappear in the same area" bug. VIP tier first (DIAMOND wins
+        // the cap), then newest, then listingId as a final tie-breaker. That order
+        // is baked into findMapBoundsListingIds' native ORDER BY.
         int safeLimit = Math.min(Math.max(limit, 1), 500); // Max 500 for map queries
-        Pageable pageable = PageRequest.of(0, safeLimit, sort);
 
-        // Execute query
-        Page<Listing> results = listingRepository.findAll(spec, pageable);
+        // Force idx_listings_map_bounds. This bbox + ORDER BY + LIMIT shape makes
+        // the optimizer prefer idx_listings_sort_order and filter row-by-row
+        // (~1.5s at city zoom, worse when zoomed into a sparse area); the forced
+        // geo index is a covering range scan (~70ms, consistent). The native query
+        // reproduces ListingSpecification.withinMapBounds' filter exactly — the map
+        // is always verified-only, so verifiedOnly/vipType aren't applied separately
+        // (matching the previous behaviour, where vipType was disabled and
+        // verifiedOnly resolved to verified=true either way).
+        List<Long> ids = listingRepository.findMapBoundsListingIds(
+                swLat, neLat, swLng, neLng, categoryId, safeLimit);
+        long total = listingRepository.countMapBoundsListings(
+                swLat, neLat, swLng, neLng, categoryId);
 
-        log.debug("Map bounds query returned {} results", results.getNumberOfElements());
+        // Hydrate the managed entities and restore the native order (IN loses it).
+        // Left lazy on media/address here on purpose: the caller's
+        // batchMapCardListings batch-fetches those in a single query.
+        List<Listing> ordered;
+        if (ids.isEmpty()) {
+            ordered = Collections.emptyList();
+        } else {
+            Map<Long, Listing> byId = listingRepository.findAllById(ids).stream()
+                    .collect(Collectors.toMap(Listing::getListingId, Function.identity(), (a, b) -> a));
+            ordered = ids.stream()
+                    .map(byId::get)
+                    .filter(Objects::nonNull)
+                    .collect(Collectors.toList());
+        }
 
-        return results;
+        log.debug("Map bounds query returned {} of {} listings", ordered.size(), total);
+        return new PageImpl<>(ordered, PageRequest.of(0, safeLimit), total);
     }
 }

--- a/smart-rent/src/test/java/com/smartrent/service/listing/ListingQueryServiceMapBoundsTest.java
+++ b/smart-rent/src/test/java/com/smartrent/service/listing/ListingQueryServiceMapBoundsTest.java
@@ -1,0 +1,95 @@
+package com.smartrent.service.listing;
+
+import com.smartrent.infra.repository.ListingRepository;
+import com.smartrent.infra.repository.entity.Listing;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * queryByMapBounds must go through the FORCE INDEX path (findMapBoundsListingIds +
+ * countMapBoundsListings), NOT findAll(spec, pageable). With the map query's bbox
+ * + ORDER BY + LIMIT shape the optimizer picks idx_listings_sort_order and filters
+ * row-by-row (~1.5s at city zoom, worse when zoomed into a sparse area) instead of
+ * the covering geo index idx_listings_map_bounds (~70ms). The wiring must also
+ * preserve the native VIP-first order after hydration (IN loses it) and cap the
+ * limit at 500.
+ *
+ * The native SQL itself can't run on the H2 test DB (FORCE INDEX / MySQL-only), so
+ * the repository is mocked here; the SQL was verified against prod via EXPLAIN
+ * ANALYZE (covering range scan on idx_listings_map_bounds, ~70ms).
+ */
+@ExtendWith(MockitoExtension.class)
+class ListingQueryServiceMapBoundsTest {
+
+    @Mock
+    ListingRepository listingRepository;
+
+    @InjectMocks
+    ListingQueryService service;
+
+    private static BigDecimal bd(double v) {
+        return BigDecimal.valueOf(v);
+    }
+
+    @Test
+    void queryByMapBounds_usesForcedIndex_preservesOrder_andTotal() {
+        when(listingRepository.findMapBoundsListingIds(any(), any(), any(), any(), any(), anyInt()))
+                .thenReturn(List.of(30L, 10L, 20L)); // VIP-first native order
+        when(listingRepository.countMapBoundsListings(any(), any(), any(), any(), any()))
+                .thenReturn(57L);
+        when(listingRepository.findAllById(any())) // IN returns them out of order
+                .thenReturn(List.of(
+                        Listing.builder().listingId(10L).build(),
+                        Listing.builder().listingId(30L).build(),
+                        Listing.builder().listingId(20L).build()));
+
+        // limit (=3) <= total (=57): the 3 pins are the capped page, and totalCount
+        // still reports the full 57 (the FE "X tổng, phóng to" hint). Keeping limit
+        // <= total avoids PageImpl re-deriving total as a "last page" — which in
+        // production never triggers, since the id query returns min(total, limit).
+        Page<Listing> page = service.queryByMapBounds(
+                bd(10.823), bd(106.701), bd(10.705), bd(106.590),
+                3, false, null, null);
+
+        assertEquals(57L, page.getTotalElements(), "totalCount comes from the count query");
+        assertEquals(List.of(30L, 10L, 20L),
+                page.getContent().stream().map(Listing::getListingId).toList(),
+                "native VIP-first order must survive hydration");
+        // The Criteria path (which the optimizer mis-plans) must not be used.
+        verify(listingRepository, never())
+                .findAll(org.mockito.ArgumentMatchers.<Specification<Listing>>any(), any(Pageable.class));
+    }
+
+    @Test
+    void queryByMapBounds_capsLimitAt500() {
+        when(listingRepository.findMapBoundsListingIds(any(), any(), any(), any(), any(), anyInt()))
+                .thenReturn(List.of());
+        when(listingRepository.countMapBoundsListings(any(), any(), any(), any(), any()))
+                .thenReturn(0L);
+
+        service.queryByMapBounds(bd(10.9), bd(106.8), bd(10.7), bd(106.5),
+                9999, false, null, null);
+
+        ArgumentCaptor<Integer> limitCaptor = ArgumentCaptor.forClass(Integer.class);
+        verify(listingRepository).findMapBoundsListingIds(
+                any(), any(), any(), any(), any(), limitCaptor.capture());
+        assertEquals(500, limitCaptor.getValue(), "map limit is capped at 500");
+    }
+}


### PR DESCRIPTION
## Problem

After V98/V99 (denormalized lat/lng + `idx_listings_map_bounds`), the `/v1/listings/map-bounds` query dropped the addresses join, but it still isn't fast: the optimizer **won't use the geo index**. With the map's `bbox + ORDER BY (vip_type_sort_order, updated_at) + LIMIT` shape it prefers `idx_listings_sort_order` (scan in sort order, filter row-by-row) because that avoids a filesort and it *thinks* it'll hit the LIMIT quickly.

Measured on prod (`EXPLAIN ANALYZE`, city-wide bbox):

**Optimizer's choice — `idx_listings_sort_order`, ~1.5 s:**
```
-> Limit: 200  (actual time=12.5..1523 rows=200)
   -> Filter: (bbox + visibility)  (actual time=12.5..1522 rows=200)
      -> Index scan on l using idx_listings_sort_order  (actual time=12.5..1517 rows=2147)
```
It scanned 2147 rows doing clustered-row lookups to check lat/lng. Worse: this scales with density — **zoom into a sparse area and it scans most of the sort index** before reaching the cap.

**Forced geo index — `idx_listings_map_bounds`, ~71 ms:**
```
-> Limit: 200  (actual time=71.3..71.4 rows=200)
   -> Sort: vip_type_sort_order, updated_at DESC, listing_id  (actual time=71.3..71.4 rows=200)
      -> Filter: (bbox + visibility)  (actual time=0.184..64.6 rows=8916)
         -> Covering index range scan on l using idx_listings_map_bounds  (actual time=0.164..45.2 rows=9878)
```
Index-only, geo-bounded, ~**22× faster** and flat regardless of zoom/density. A histogram on `latitude`/`longitude` did **not** flip the planner — the `ORDER BY`+`LIMIT` bias wins — so the hint must be explicit.

## Why a code change

`queryByMapBounds` used `findAll(spec, pageable)` (JPA Criteria), and Criteria can't emit `FORCE INDEX`. So the fix replaces the Criteria path with native queries.

## Change

- **`ListingRepository`** — two native queries that `FORCE INDEX (idx_listings_map_bounds)` and reproduce `ListingSpecification.withinMapBounds`' filter **exactly** (`is_draft=0, is_shadow=0, verified=1, moderation_status='APPROVED', expired=0` + bbox + expiry + optional category):
  - `findMapBoundsListingIds(...)` — ordered (VIP-first, newest, id) + `LIMIT`, returns ids only.
  - `countMapBoundsListings(...)` — the `totalCount` for the FE "X tổng, phóng to" hint.
- **`ListingQueryService.queryByMapBounds`** — calls those, hydrates managed entities via `findAllById`, and **restores the native order** (`IN` loses it). `batchMapCardListings` still batch-loads media+address downstream. Response contract, VIP-first ordering, and the 500 cap are unchanged.

## Tests

`ListingQueryServiceMapBoundsTest` covers the wiring: forced-index path is used (never `findAll(spec, pageable)`), native order survives hydration, limit capped at 500. The native SQL is MySQL-only (`FORCE INDEX`) so it can't run on the H2 test DB — it was verified on prod via the EXPLAIN above. `./gradlew test` green (this + the existing `ListingServiceImplMapBoundsTest`).

## Notes

- `ListingSpecification.withinMapBounds` is now unreferenced (kept as the documented filter source; can be removed in a follow-up).
- Depends on `idx_listings_map_bounds` existing (V98/V99). Deploy after those are applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
