### PR TITLE
feat(security): optional-auth for POST /v1/ai/chat/stream (guest chat)

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/config/security/SecurityConfig.java
+++ b/smart-rent/src/main/java/com/smartrent/config/security/SecurityConfig.java
@@ -167,12 +167,27 @@ public class SecurityConfig {
       "/v1/users/*/following",
   };
 
+  // POST endpoints public to anonymous callers that must still process a Bearer
+  // token when one is supplied. AI chat streaming: guests may use it (the
+  // controller rate-limits them by IP), while logged-in users keep their
+  // user_id + per-user rate limiting instead of being treated as anonymous.
+  private static final String[] OPTIONAL_AUTH_POST_PATTERNS = {
+      "/v1/ai/chat/stream",
+  };
+
   private boolean isOptionalAuthPath(String method, String path) {
-    if (!"GET".equalsIgnoreCase(method)) return false;
-    for (String pattern : OPTIONAL_AUTH_GET_PATTERNS) {
+    String[] patterns = optionalAuthPatternsForMethod(method);
+    if (patterns == null) return false;
+    for (String pattern : patterns) {
       if (pathMatches(path, pattern)) return true;
     }
     return false;
+  }
+
+  private String[] optionalAuthPatternsForMethod(String method) {
+    if ("GET".equalsIgnoreCase(method)) return OPTIONAL_AUTH_GET_PATTERNS;
+    if ("POST".equalsIgnoreCase(method)) return OPTIONAL_AUTH_POST_PATTERNS;
+    return null;
   }
 
   @Bean

--- a/smart-rent/src/main/resources/application.yml
+++ b/smart-rent/src/main/resources/application.yml
@@ -241,6 +241,10 @@ application:
         - "/v1/listings/map-bounds"
         - "/v1/listings/search-suggestions/click"
         - "/v1/views"
+        # AI chat streaming is optional-auth (see OPTIONAL_AUTH_POST_PATTERNS):
+        # guests may use it (IP rate-limited in ChatController) while logged-in
+        # users still get their JWT processed for personalisation.
+        - "/v1/ai/chat/stream"
   authentication:
     jwt:
       access-signer-key: "${ACCESS_SIGNER_KEY}"


### PR DESCRIPTION
## Mục tiêu
Cho guest (chưa đăng nhập) chạm được AI chat stream để dùng thử chatbot, **mà không** biến user đã đăng nhập thành anonymous.

Đi kèm PR frontend `smartrent-fe#398` (guest gửi 5 tin trước khi bắt buộc đăng nhập).

## Vấn đề
Controller `chatStream` đã xử lý anon (identity fallback về IP, rate-limit theo IP, chỉ inject `user_id`/token khi có auth). Nhưng endpoint chỉ public trong `application-local.yaml` → dev/prod anon bị **401**.

**Không thể** chỉ thêm vào allowlist POST công khai: `bearerTokenResolver` bỏ qua JWT hoàn toàn với public POST → **user đăng nhập bị coi là anonymous** (mất personalization + rate-limit theo user).

## Cách sửa — optional-auth cho POST (mirror cơ chế GET sẵn có)
- **`application.yml`**: thêm `/v1/ai/chat/stream` vào allowlist POST (**hẹp**, không mở `/v1/ai/**`).
- **`SecurityConfig`**: `OPTIONAL_AUTH_POST_PATTERNS` + `isOptionalAuthPath` nhận cả POST → có Bearer thì vẫn xử lý JWT, không có thì anon đi qua.

**Kết quả:** anon → cho qua, không token, rate-limit theo IP; authed → xử lý JWT, inject `user_id`, rate-limit theo user. Các endpoint AI khác (price-suggestion, verify, non-stream chat) vẫn authenticated-only ở prod.

## Verify
- `./gradlew compileJava` ✅ (offline, exit 0).
- Repo chưa có test MockMvc/security nào (kể cả GET optional-auth hiện tại) → runtime verify là **smoke-test khi deploy**: anon `POST /v1/ai/chat/stream` trả 200; authed vẫn inject `user_id`.