### PR TITLE
fix(listing): stop client-supplied userId from bypassing the public v…

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/controller/ListingSearchController.java
+++ b/smart-rent/src/main/java/com/smartrent/controller/ListingSearchController.java
@@ -165,6 +165,7 @@ public class ListingSearchController {
 
             if (filter.getIsDraft() != null || filter.getIsVerify() != null) {
                 filter.setUserId(authentication.getName());
+                filter.setIsOwnerRequest(true);
             }
         }
 

--- a/smart-rent/src/main/java/com/smartrent/dto/request/ListingFilterRequest.java
+++ b/smart-rent/src/main/java/com/smartrent/dto/request/ListingFilterRequest.java
@@ -52,7 +52,15 @@ public class ListingFilterRequest {
     String listingStatus;
 
     @Schema(description = "Internal flag to indicate this is an admin request (set by backend, not by frontend)", hidden = true)
+    @JsonIgnore
     Boolean isAdminRequest;
+
+    @Schema(description = "Internal flag: userId was set by the backend from an authenticated principal "
+            + "(owner's own dashboard), not supplied by an anonymous caller. Only requests with this flag "
+            + "skip the isDraft=false / moderationStatus=APPROVED public-visibility gate. Set by backend, "
+            + "not by frontend.", hidden = true)
+    @JsonIgnore
+    Boolean isOwnerRequest;
 
     @Schema(description = "Filter by moderation status (admin only)",
             example = "PENDING_REVIEW",

--- a/smart-rent/src/main/java/com/smartrent/infra/repository/specification/ListingSpecification.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/specification/ListingSpecification.java
@@ -61,18 +61,24 @@ public class ListingSpecification {
             }
 
             // Draft status filter
+            // Note: gate on isOwnerRequest, not "userId == null". A userId is also set for
+            // *public* browsing of one seller's profile (GET /sellers/{userId}/{tier} and any
+            // POST /search caller passing an arbitrary userId) — that caller is anonymous and
+            // must still be denied drafts/unapproved listings. Only the owner's own dashboard
+            // (userId resolved from the JWT — see ListingServiceImpl#getMyListings and
+            // ListingSearchController#searchListings) sets isOwnerRequest=true. The field is
+            // @JsonIgnore'd so a client cannot set it directly in the request body.
             if (filter.getIsDraft() != null) {
                 predicates.add(criteriaBuilder.equal(root.get("isDraft"), filter.getIsDraft()));
-            } else if (filter.getUserId() == null && !Boolean.TRUE.equals(filter.getIsAdminRequest())) {
-                // For public search (userId null AND not admin), exclude drafts by default
-                // Admin requests can see drafts if they want to
+            } else if (!Boolean.TRUE.equals(filter.getIsOwnerRequest()) && !Boolean.TRUE.equals(filter.getIsAdminRequest())) {
+                // For public search (not the owner, not admin), exclude drafts by default
                 predicates.add(criteriaBuilder.equal(root.get("isDraft"), false));
             }
 
             // Verified filter
             if (filter.getVerified() != null) {
                 predicates.add(criteriaBuilder.equal(root.get("verified"), filter.getVerified()));
-            } else if (filter.getUserId() == null && !Boolean.TRUE.equals(filter.getIsAdminRequest())) {
+            } else if (!Boolean.TRUE.equals(filter.getIsOwnerRequest()) && !Boolean.TRUE.equals(filter.getIsAdminRequest())) {
                 // Public search gates on moderation outcome, not the admin "verified" badge.
                 // verified=true still surfaces a "Tin đã xác minh" badge on the FE, but pending
                 // listings that passed moderation (APPROVED) are visible too — matching how

--- a/smart-rent/src/main/java/com/smartrent/service/listing/impl/ListingServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/listing/impl/ListingServiceImpl.java
@@ -2108,8 +2108,12 @@ public class ListingServiceImpl implements ListingService {
         log.info("Owner {} requesting listings - Page: {}, Size: {}, Filters: verified={}, expired={}, isDraft={}",
                 userId, filter.getPage(), filter.getSize(), filter.getVerified(), filter.getExpired(), filter.getIsDraft());
 
-        // Set userId in filter to get only owner's listings
+        // Set userId in filter to get only owner's listings. userId here comes from the
+        // authenticated JWT (see ListingOwnerController#getMyListings), so it's safe to also
+        // mark this as an owner request — that's what lets the query below skip the
+        // isDraft=false / moderationStatus=APPROVED public-visibility gate.
         filter.setUserId(userId);
+        filter.setIsOwnerRequest(true);
 
         // The seller dashboard must show ALL of the owner's listings — including
         // expired / taken-down ones — so the "All" and "Expired" tabs aren't


### PR DESCRIPTION
…isibility gate

ListingSpecification.fromFilterRequest only applied the isDraft=false / moderationStatus=APPROVED public-visibility gate when userId was null, treating "userId present" as "this is the owner's own dashboard". But userId is also client-supplied on two anonymous, unauthenticated paths: GET /v1/listings/sellers/{userId}/{tier} (public seller-profile page) and POST /v1/listings/search (userId is just a body field). Either lets any anonymous caller see a seller's drafts, pending-review, rejected and resubmitted listings.

Verified against production: of 7 listings returned by the seller-tier endpoints for one seller, 6 returned 404 "Listing not found" from the public detail endpoint, which does correctly gate on computeListingStatus().

Add ListingFilterRequest.isOwnerRequest (@JsonIgnore, so a client can't set it directly) and set it only where userId is resolved from the authenticated JWT: ListingServiceImpl#getMyListings and ListingSearchController#searchListings' self-userId injection. The specification now gates on isOwnerRequest instead of userId == null. Also @JsonIgnore isAdminRequest, which had the same client-settable gap.