### PR TITLE
fix: admin news media upload FK violation via admin-owned presign flow

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/controller/AdminMediaController.java
+++ b/smart-rent/src/main/java/com/smartrent/controller/AdminMediaController.java
@@ -1,6 +1,9 @@
 package com.smartrent.controller;
 
+import com.smartrent.dto.request.AdminGenerateUploadUrlRequest;
+import com.smartrent.dto.request.ConfirmUploadRequest;
 import com.smartrent.dto.response.ApiResponse;
+import com.smartrent.dto.response.GenerateUploadUrlResponse;
 import com.smartrent.dto.response.MediaResponse;
 import com.smartrent.service.media.MediaService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -11,6 +14,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
@@ -138,6 +142,54 @@ public class AdminMediaController {
         return ResponseEntity.ok(ApiResponse.<MediaResponse>builder()
                 .data(response)
                 .message("Media uploaded successfully by admin.")
+                .build());
+    }
+
+    @PostMapping("/upload-url")
+    @Operation(
+            summary = "Generate pre-signed upload URL (Admin, step 1 of 2)",
+            description = """
+                    Generates a pre-signed URL for the admin to upload a file directly to R2.
+                    The admin's ID is stored as the media owner (admin_id column, not user_id).
+
+                    **Process:**
+                    1. Backend generates a secure upload URL and a PENDING media record
+                    2. Client uploads the file directly to R2 using the URL (PUT)
+                    3. Client calls /{mediaId}/confirm to finalize
+                    """
+    )
+    public ResponseEntity<ApiResponse<GenerateUploadUrlResponse>> generateUploadUrl(
+            @Valid @RequestBody AdminGenerateUploadUrlRequest request) {
+
+        String adminId = extractAdminId();
+        log.info("POST /v1/admin/media/upload-url - admin: {}, type: {}", adminId, request.getMediaType());
+
+        GenerateUploadUrlResponse response = mediaService.adminGenerateUploadUrl(request, adminId);
+
+        return ResponseEntity.ok(ApiResponse.<GenerateUploadUrlResponse>builder()
+                .data(response)
+                .message("Upload URL generated successfully. Please upload file within "
+                        + (response.getExpiresIn() / 60) + " minutes.")
+                .build());
+    }
+
+    @PostMapping("/{mediaId}/confirm")
+    @Operation(
+            summary = "Confirm upload completion (Admin, step 2 of 2)",
+            description = "Confirms that the admin-initiated file upload is complete and makes the media active."
+    )
+    public ResponseEntity<ApiResponse<MediaResponse>> confirmUpload(
+            @Parameter(description = "Media ID from upload URL response") @PathVariable Long mediaId,
+            @Valid @RequestBody ConfirmUploadRequest request) {
+
+        String adminId = extractAdminId();
+        log.info("POST /v1/admin/media/{}/confirm - admin: {}", mediaId, adminId);
+
+        MediaResponse response = mediaService.adminConfirmUpload(mediaId, request, adminId);
+
+        return ResponseEntity.ok(ApiResponse.<MediaResponse>builder()
+                .data(response)
+                .message("Upload confirmed successfully. Media is now active.")
                 .build());
     }
 

--- a/smart-rent/src/main/java/com/smartrent/dto/request/AdminGenerateUploadUrlRequest.java
+++ b/smart-rent/src/main/java/com/smartrent/dto/request/AdminGenerateUploadUrlRequest.java
@@ -1,0 +1,49 @@
+package com.smartrent.dto.request;
+
+import jakarta.validation.constraints.*;
+import lombok.*;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AdminGenerateUploadUrlRequest {
+
+    @NotNull(message = "Media type is required")
+    private MediaType mediaType; // IMAGE or VIDEO
+
+    @NotBlank(message = "Filename is required")
+    @Size(max = 255, message = "Filename must not exceed 255 characters")
+    private String filename;
+
+    @NotBlank(message = "Content type is required")
+    @Pattern(regexp = "^(image/(jpeg|png|webp)|video/(mp4|webm|quicktime))$",
+            message = "Invalid content type. Allowed: image/jpeg, image/png, image/webp, video/mp4, video/webm, video/quicktime")
+    private String contentType;
+
+    @NotNull(message = "File size is required")
+    @Min(value = 1, message = "File size must be at least 1 byte")
+    @Max(value = 104857600, message = "File size must not exceed 100MB")
+    private Long fileSize;
+
+    private Long listingId; // Optional, no ownership check for admin
+
+    @Size(max = 255, message = "Title must not exceed 255 characters")
+    private String title;
+
+    @Size(max = 1000, message = "Description must not exceed 1000 characters")
+    private String description;
+
+    @Size(max = 255, message = "Alt text must not exceed 255 characters")
+    private String altText;
+
+    @lombok.Builder.Default
+    private Boolean isPrimary = false;
+
+    @lombok.Builder.Default
+    private Integer sortOrder = 0;
+
+    public enum MediaType {
+        IMAGE, VIDEO
+    }
+}

--- a/smart-rent/src/main/java/com/smartrent/infra/repository/MediaRepository.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/MediaRepository.java
@@ -22,6 +22,11 @@ public interface MediaRepository extends JpaRepository<Media, Long> {
     Optional<Media> findByMediaIdAndUserId(Long mediaId, String userId);
 
     /**
+     * Find media by ID and admin (for admin-owned upload confirmation)
+     */
+    Optional<Media> findByMediaIdAndAdminId(Long mediaId, String adminId);
+
+    /**
      * Find all media for a listing
      */
     List<Media> findByListing_ListingIdAndStatusOrderBySortOrderAsc(

--- a/smart-rent/src/main/java/com/smartrent/infra/repository/entity/Media.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/entity/Media.java
@@ -44,8 +44,11 @@ public class Media {
     @JoinColumn(name = "listing_id")
     Listing listing;
 
-    @Column(name = "user_id", nullable = false)
-    String userId; // Owner ID of the media
+    @Column(name = "user_id")
+    String userId; // Owner user ID of the media (mutually exclusive with adminId)
+
+    @Column(name = "admin_id")
+    String adminId; // Owner admin ID of the media (mutually exclusive with userId)
 
     @Enumerated(EnumType.STRING)
     @Column(name = "media_type", nullable = false, length = 20)
@@ -155,5 +158,9 @@ public class Media {
 
     public boolean isOwnedBy(String userId) {
         return this.userId != null && this.userId.equals(userId);
+    }
+
+    public boolean isOwnedByAdmin(String adminId) {
+        return this.adminId != null && this.adminId.equals(adminId);
     }
 }

--- a/smart-rent/src/main/java/com/smartrent/service/listing/impl/ListingServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/listing/impl/ListingServiceImpl.java
@@ -811,8 +811,8 @@ public class ListingServiceImpl implements ListingService {
                     .orElseThrow(() -> new AppException(DomainCode.ADDRESS_NOT_FOUND,
                             "Media not found with ID: " + mediaId));
 
-            // Validate ownership
-            if (!media.getUserId().equals(userId)) {
+            // Validate ownership (null-safe: admin-owned media has no userId)
+            if (!media.isOwnedBy(userId)) {
                 throw new AppException(DomainCode.UNAUTHORIZED,
                         "Media " + mediaId + " does not belong to user " + userId);
             }

--- a/smart-rent/src/main/java/com/smartrent/service/media/MediaService.java
+++ b/smart-rent/src/main/java/com/smartrent/service/media/MediaService.java
@@ -1,5 +1,6 @@
 package com.smartrent.service.media;
 
+import com.smartrent.dto.request.AdminGenerateUploadUrlRequest;
 import com.smartrent.dto.request.ConfirmUploadRequest;
 import com.smartrent.dto.request.GenerateUploadUrlRequest;
 import com.smartrent.dto.request.SaveExternalMediaRequest;
@@ -110,4 +111,15 @@ public interface MediaService {
      * Admin: Get all media (paginated) for moderation
      */
     List<MediaResponse> adminGetAllMedia(String status, int page, int size);
+
+    /**
+     * Admin: Generate pre-signed upload URL (Step 1 of presign upload flow).
+     * Stores adminId as the media owner.
+     */
+    GenerateUploadUrlResponse adminGenerateUploadUrl(AdminGenerateUploadUrlRequest request, String adminId);
+
+    /**
+     * Admin: Confirm upload completion (Step 2 of presign upload flow)
+     */
+    MediaResponse adminConfirmUpload(Long mediaId, ConfirmUploadRequest request, String adminId);
 }

--- a/smart-rent/src/main/java/com/smartrent/service/media/MediaServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/media/MediaServiceImpl.java
@@ -1,5 +1,6 @@
 package com.smartrent.service.media;
 
+import com.smartrent.dto.request.AdminGenerateUploadUrlRequest;
 import com.smartrent.dto.request.ConfirmUploadRequest;
 import com.smartrent.dto.request.GenerateUploadUrlRequest;
 import com.smartrent.dto.request.SaveExternalMediaRequest;
@@ -194,7 +195,7 @@ public class MediaServiceImpl implements MediaService {
             }
         }
 
-        return doUploadMedia(file, mediaType, listing, title, description, altText, isPrimary, sortOrder, userId);
+        return doUploadMedia(file, mediaType, listing, title, description, altText, isPrimary, sortOrder, userId, null);
     }
 
     @Override
@@ -206,6 +207,12 @@ public class MediaServiceImpl implements MediaService {
         Media media = mediaRepository.findByMediaIdAndUserId(mediaId, userId)
                 .orElseThrow(() -> new AppException(DomainCode.UNAUTHORIZED,
                         "Media not found or you don't have permission"));
+
+        return doConfirmUpload(media);
+    }
+
+    private MediaResponse doConfirmUpload(Media media) {
+        Long mediaId = media.getMediaId();
 
         // Validate status
         if (media.getStatus() != Media.MediaStatus.PENDING) {
@@ -589,7 +596,7 @@ public class MediaServiceImpl implements MediaService {
 
         // Validate admin exists
         adminRepository.findById(adminId)
-                .orElseThrow(() -> new AppException(DomainCode.USER_NOT_FOUND, "Admin not found"));
+                .orElseThrow(() -> new AppException(DomainCode.ADMIN_NOT_FOUND, "Admin not found"));
 
         // Validate listing if provided (no ownership check for admin)
         Listing listing = null;
@@ -598,7 +605,84 @@ public class MediaServiceImpl implements MediaService {
                     .orElseThrow(() -> new AppException(DomainCode.LISTING_NOT_FOUND, "Listing not found"));
         }
 
-        return doUploadMedia(file, mediaType, listing, title, description, altText, isPrimary, sortOrder, adminId);
+        return doUploadMedia(file, mediaType, listing, title, description, altText, isPrimary, sortOrder, null, adminId);
+    }
+
+    @Override
+    @Transactional
+    public GenerateUploadUrlResponse adminGenerateUploadUrl(AdminGenerateUploadUrlRequest request, String adminId) {
+        log.info("Admin generating upload URL - admin: {}, type: {}", adminId, request.getMediaType());
+
+        // Validate admin exists
+        adminRepository.findById(adminId)
+                .orElseThrow(() -> new AppException(DomainCode.ADMIN_NOT_FOUND, "Admin not found"));
+
+        boolean isImage = request.getMediaType() == AdminGenerateUploadUrlRequest.MediaType.IMAGE;
+        if (!storageService.isValidContentType(request.getContentType(), isImage)) {
+            throw new AppException(DomainCode.INVALID_FILE_TYPE,
+                    String.format("Invalid content type %s for %s", request.getContentType(), request.getMediaType()));
+        }
+        if (!storageService.isValidFileSize(request.getFileSize(), isImage)) {
+            throw new AppException(DomainCode.FILE_TOO_LARGE,
+                    String.format("File size exceeds maximum allowed for %s: %d MB",
+                            request.getMediaType(), storageService.getMaxSizeMB(isImage)));
+        }
+
+        // Validate listing if provided (no ownership check for admin)
+        Listing listing = null;
+        if (request.getListingId() != null) {
+            listing = listingRepository.findById(request.getListingId())
+                    .orElseThrow(() -> new AppException(DomainCode.LISTING_NOT_FOUND, "Listing not found"));
+        }
+
+        String storageKey = storageService.generateGenericStorageKey(
+                adminId, request.getFilename(), request.getContentType());
+
+        Media media = Media.builder()
+                .adminId(adminId)
+                .listing(listing)
+                .mediaType(isImage ? Media.MediaType.IMAGE : Media.MediaType.VIDEO)
+                .sourceType(Media.MediaSourceType.UPLOAD)
+                .status(Media.MediaStatus.PENDING)
+                .storageKey(storageKey)
+                .originalFilename(request.getFilename())
+                .mimeType(request.getContentType())
+                .fileSize(request.getFileSize())
+                .title(request.getTitle())
+                .description(request.getDescription())
+                .altText(request.getAltText())
+                .isPrimary(request.getIsPrimary() != null && request.getIsPrimary())
+                .sortOrder(request.getSortOrder() != null ? request.getSortOrder() : 0)
+                .uploadConfirmed(false)
+                .build();
+
+        media = mediaRepository.save(media);
+
+        R2StorageService.PresignedUrlResponse presignedUrl =
+                storageService.generateUploadUrl(storageKey, request.getContentType(), request.getFileSize());
+
+        log.info("Admin upload URL generated successfully for media ID: {}", media.getMediaId());
+
+        return GenerateUploadUrlResponse.builder()
+                .mediaId(media.getMediaId())
+                .uploadUrl(presignedUrl.getUrl())
+                .expiresIn(presignedUrl.getExpiresIn())
+                .storageKey(storageKey)
+                .message("Upload URL generated. Please upload the file to the provided URL within "
+                        + (presignedUrl.getExpiresIn() / 60) + " minutes.")
+                .build();
+    }
+
+    @Override
+    @Transactional
+    public MediaResponse adminConfirmUpload(Long mediaId, ConfirmUploadRequest request, String adminId) {
+        log.info("Admin confirming upload for media ID: {}, admin: {}", mediaId, adminId);
+
+        Media media = mediaRepository.findByMediaIdAndAdminId(mediaId, adminId)
+                .orElseThrow(() -> new AppException(DomainCode.UNAUTHORIZED,
+                        "Media not found or you don't have permission"));
+
+        return doConfirmUpload(media);
     }
 
     @Override
@@ -655,7 +739,10 @@ public class MediaServiceImpl implements MediaService {
             String altText,
             Boolean isPrimary,
             Integer sortOrder,
-            String ownerId) {
+            String userId,
+            String adminId) {
+
+        String ownerId = userId != null ? userId : adminId;
 
         // Validate file is not empty
         if (file.isEmpty()) {
@@ -700,7 +787,8 @@ public class MediaServiceImpl implements MediaService {
             String publicUrl = storageService.getPublicUrl(storageKey);
 
             Media media = Media.builder()
-                    .userId(ownerId)
+                    .userId(userId)
+                    .adminId(adminId)
                     .listing(listing)
                     .mediaType(mediaTypeEnum)
                     .sourceType(Media.MediaSourceType.UPLOAD)

--- a/smart-rent/src/main/java/com/smartrent/service/moderation/impl/ListingModerationServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/moderation/impl/ListingModerationServiceImpl.java
@@ -462,7 +462,7 @@ public class ListingModerationServiceImpl implements ListingModerationService {
             if (!request.getMediaIds().isEmpty()) {
                 for (Long mediaId : request.getMediaIds()) {
                     Media media = mediaRepository.findById(mediaId).orElse(null);
-                    if (media != null && media.getUserId().equals(userId) && media.getStatus() == Media.MediaStatus.ACTIVE) {
+                    if (media != null && media.isOwnedBy(userId) && media.getStatus() == Media.MediaStatus.ACTIVE) {
                         media.setListing(listing);
                         mediaRepository.save(media);
                     }

--- a/smart-rent/src/main/resources/db/migration/V105__Add_admin_id_to_media.sql
+++ b/smart-rent/src/main/resources/db/migration/V105__Add_admin_id_to_media.sql
@@ -1,0 +1,19 @@
+-- Admin-owned media (e.g. news editor images) cannot satisfy fk_media_user, since admins
+-- live in a separate `admins` table, not `users`. Add a dedicated admin_id column so admin
+-- uploads no longer need to be forced through the user FK.
+ALTER TABLE media
+    ADD COLUMN admin_id VARCHAR(36) NULL COMMENT 'Owner admin ID (mutually exclusive with user_id)' AFTER user_id,
+    MODIFY COLUMN user_id VARCHAR(36) NULL COMMENT 'Owner user ID (mutually exclusive with admin_id)';
+
+ALTER TABLE media
+    ADD CONSTRAINT fk_media_admin
+        FOREIGN KEY (admin_id)
+        REFERENCES admins(admin_id)
+        ON DELETE CASCADE,
+    ADD CONSTRAINT chk_media_owner
+        CHECK (
+            (user_id IS NOT NULL AND admin_id IS NULL) OR
+            (user_id IS NULL AND admin_id IS NOT NULL)
+        );
+
+CREATE INDEX idx_media_admin_id ON media (admin_id);


### PR DESCRIPTION
Admin media uploads (news editor images) stored the admin's ID in media.user_id, which is FK'd to the users table. Admins live in a separate admins table, so every admin upload/insert failed with a fk_media_user constraint violation.

Adds a nullable media.admin_id column (mutually exclusive with user_id) and admin-scoped presign endpoints
(POST /v1/admin/media/upload-url, POST /v1/admin/media/{id}/confirm) mirroring the existing user presign flow, so admin uploads go straight to R2 instead of proxying through the backend. Also fixes the existing direct-upload endpoint to write admin_id instead of user_id.