### PR TITLE
feat: block reported authors from posting + admin reported-authors API

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/controller/AdminReportedAuthorController.java
+++ b/smart-rent/src/main/java/com/smartrent/controller/AdminReportedAuthorController.java
@@ -1,0 +1,88 @@
+package com.smartrent.controller;
+
+import com.smartrent.dto.request.PostingBlockRequest;
+import com.smartrent.dto.response.ApiResponse;
+import com.smartrent.dto.response.ListingReportResponse;
+import com.smartrent.dto.response.PageResponse;
+import com.smartrent.dto.response.ReportedAuthorResponse;
+import com.smartrent.service.report.ReportedAuthorService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.FieldDefaults;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Slf4j
+@RestController
+@RequestMapping("/v1/admin/reported-authors")
+@RequiredArgsConstructor
+@FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
+@Tag(name = "Admin - Reported Authors",
+        description = "Admin APIs for tracking listing authors by their reports and blocking them from posting")
+@SecurityRequirement(name = "Bearer Authentication")
+public class AdminReportedAuthorController {
+
+    ReportedAuthorService reportedAuthorService;
+
+    @GetMapping
+    @PreAuthorize("hasAnyAuthority('ROLE_SA', 'ROLE_UA', 'ROLE_SPA')")
+    @Operation(
+            summary = "List reported listing authors (Admin)",
+            description = "Paginated list of authors who have at least one report on their listings, " +
+                    "with total / approved report counts and current posting-block state.")
+    public ApiResponse<PageResponse<ReportedAuthorResponse>> getReportedAuthors(
+            @Parameter(description = "Page number (1-indexed)", example = "1")
+            @RequestParam(defaultValue = "1") int page,
+            @Parameter(description = "Items per page", example = "20")
+            @RequestParam(defaultValue = "20") int size) {
+
+        PageResponse<ReportedAuthorResponse> result = reportedAuthorService.getReportedAuthors(page, size);
+        return ApiResponse.<PageResponse<ReportedAuthorResponse>>builder().data(result).build();
+    }
+
+    @GetMapping("/{userId}/reports")
+    @PreAuthorize("hasAnyAuthority('ROLE_SA', 'ROLE_UA', 'ROLE_SPA')")
+    @Operation(
+            summary = "Get an author's admin-approved reports (Admin)",
+            description = "All reports across the author's listings that an admin has approved (RESOLVED).")
+    public ApiResponse<List<ListingReportResponse>> getApprovedReports(
+            @Parameter(description = "Author user ID", required = true) @PathVariable String userId) {
+
+        List<ListingReportResponse> reports = reportedAuthorService.getApprovedReports(userId);
+        return ApiResponse.<List<ListingReportResponse>>builder().data(reports).build();
+    }
+
+    @PatchMapping("/{userId}/posting-block")
+    @PreAuthorize("hasAnyAuthority('ROLE_SA', 'ROLE_UA', 'ROLE_SPA')")
+    @Operation(
+            summary = "Block or unblock an author from posting (Admin)",
+            description = "Blocks the author from creating new listings (or lifts an existing block). " +
+                    "A blocked user is rejected at listing creation on the backend.")
+    public ApiResponse<ReportedAuthorResponse> setPostingBlock(
+            @Parameter(description = "Author user ID", required = true) @PathVariable String userId,
+            @Valid @RequestBody PostingBlockRequest request) {
+
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        String adminId = auth.getName();
+        log.info("Admin {} setting posting-block={} for user {}", adminId, request.getBlocked(), userId);
+
+        ReportedAuthorResponse response = reportedAuthorService.setPostingBlock(userId, request, adminId);
+        return ApiResponse.<ReportedAuthorResponse>builder().data(response).build();
+    }
+}

--- a/smart-rent/src/main/java/com/smartrent/dto/request/PostingBlockRequest.java
+++ b/smart-rent/src/main/java/com/smartrent/dto/request/PostingBlockRequest.java
@@ -1,0 +1,32 @@
+package com.smartrent.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.FieldDefaults;
+
+/**
+ * Admin request to block or unblock a listing author from posting new listings.
+ */
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@FieldDefaults(level = AccessLevel.PRIVATE)
+@Schema(description = "Request to block or unblock a user from posting listings")
+public class PostingBlockRequest {
+
+    @NotNull(message = "blocked is required")
+    @Schema(description = "true to block the user from posting, false to unblock", example = "true", required = true)
+    Boolean blocked;
+
+    @Schema(description = "Reason for the block (recommended when blocking)",
+            example = "Nhiều tin đăng vi phạm bị báo cáo và đã được duyệt")
+    String reason;
+}

--- a/smart-rent/src/main/java/com/smartrent/dto/response/ReportedAuthorResponse.java
+++ b/smart-rent/src/main/java/com/smartrent/dto/response/ReportedAuthorResponse.java
@@ -1,0 +1,64 @@
+package com.smartrent.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.FieldDefaults;
+
+import java.time.LocalDateTime;
+
+/**
+ * Admin view of a listing author (người đăng tin) together with their report counts
+ * and current posting-block state.
+ */
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@FieldDefaults(level = AccessLevel.PRIVATE)
+@Schema(description = "A reported listing author with report counts and block state")
+public class ReportedAuthorResponse {
+
+    @Schema(description = "Author's user ID", example = "user-123e4567-e89b-12d3-a456-426614174000")
+    String userId;
+
+    @Schema(description = "Author's first name", example = "Nguyen")
+    String firstName;
+
+    @Schema(description = "Author's last name", example = "Van A")
+    String lastName;
+
+    @Schema(description = "Author's email", example = "nguyen.vana@example.com")
+    String email;
+
+    @Schema(description = "Author's phone number", example = "0912345678")
+    String phoneNumber;
+
+    @Schema(description = "Author's avatar URL")
+    String avatarUrl;
+
+    @Schema(description = "Total reports across all of the author's listings", example = "7")
+    Long totalReports;
+
+    @Schema(description = "Reports approved (RESOLVED) by an admin", example = "4")
+    Long resolvedReports;
+
+    @Schema(description = "Whether the author has enough approved reports (> 3) to be blocked", example = "true")
+    Boolean blockEligible;
+
+    @Schema(description = "Whether the author is currently blocked from posting", example = "false")
+    Boolean postingBlocked;
+
+    @Schema(description = "Reason for the posting block (present when blocked)")
+    String postingBlockedReason;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    @Schema(description = "When the posting block was applied")
+    LocalDateTime postingBlockedAt;
+}

--- a/smart-rent/src/main/java/com/smartrent/enums/NotificationType.java
+++ b/smart-rent/src/main/java/com/smartrent/enums/NotificationType.java
@@ -30,5 +30,8 @@ public enum NotificationType {
 
     // Membership lifecycle
     MEMBERSHIP_EXPIRING,            // member is notified at D-7 / D-3 before membership expiry
-    MEMBERSHIP_ACTIVATED            // member is notified when their queued membership activates
+    MEMBERSHIP_ACTIVATED,           // member is notified when their queued membership activates
+    // Posting block
+    POSTING_BLOCKED,                // user is notified when admin blocks them from posting listings
+    POSTING_UNBLOCKED               // user is notified when admin lifts the posting block
 }

--- a/smart-rent/src/main/java/com/smartrent/infra/exception/model/DomainCode.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/exception/model/DomainCode.java
@@ -150,7 +150,10 @@ public enum DomainCode {
   VIP_TIER_NOT_CONFIGURED("21003", HttpStatus.INTERNAL_SERVER_ERROR,
       "Không tìm thấy cấu hình giới hạn cho gói VIP: %s"),
   //    Listing Report Error 22xxx
-  LISTING_REPORT_NOT_AVAILABLE("22001", HttpStatus.BAD_REQUEST, "Listing is no longer available and cannot be reported")
+  LISTING_REPORT_NOT_AVAILABLE("22001", HttpStatus.BAD_REQUEST, "Listing is no longer available and cannot be reported"),
+  //    User Posting Block Error 23xxx
+  USER_POSTING_BLOCKED("23001", HttpStatus.FORBIDDEN,
+      "Tài khoản của bạn đã bị chặn đăng tin do có nhiều tin vi phạm bị báo cáo. Vui lòng liên hệ quản trị viên để được hỗ trợ.")
   ;
 
   private final String value;

--- a/smart-rent/src/main/java/com/smartrent/infra/repository/ListingReportRepository.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/ListingReportRepository.java
@@ -101,4 +101,35 @@ public interface ListingReportRepository extends JpaRepository<ListingReport, Lo
     Double avgResolutionMinutes(@Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
 
     long countByCreatedAtBefore(LocalDateTime dateTime);
+
+    /**
+     * Aggregate reports per listing author (người đăng tin). Each row is one author who
+     * has at least one report on any of their listings, with total and admin-approved
+     * (RESOLVED) report counts. Ordered by most approved reports first.
+     */
+    @Query(value = "SELECT l.user_id AS userId, " +
+            "CAST(COUNT(*) AS SIGNED) AS totalReports, " +
+            "CAST(SUM(CASE WHEN r.status = 'RESOLVED' THEN 1 ELSE 0 END) AS SIGNED) AS resolvedReports " +
+            "FROM listing_reports r JOIN listings l ON r.listing_id = l.listing_id " +
+            "GROUP BY l.user_id " +
+            "ORDER BY resolvedReports DESC, totalReports DESC",
+            countQuery = "SELECT COUNT(DISTINCT l.user_id) " +
+                    "FROM listing_reports r JOIN listings l ON r.listing_id = l.listing_id",
+            nativeQuery = true)
+    Page<ReportedAuthorProjection> findReportedAuthors(Pageable pageable);
+
+    /**
+     * Find all reports for a given author (owner of the reported listings) filtered by status,
+     * newest first. Used to show an author's admin-approved reports.
+     */
+    @Query("SELECT r FROM listing_reports r WHERE r.listing.userId = :userId AND r.status = :status " +
+            "ORDER BY r.resolvedAt DESC, r.createdAt DESC")
+    List<ListingReport> findByAuthorIdAndStatus(@Param("userId") String userId,
+                                                @Param("status") ReportStatus status);
+
+    /**
+     * Count reports of a given status across all of an author's listings.
+     */
+    @Query("SELECT COUNT(r) FROM listing_reports r WHERE r.listing.userId = :userId AND r.status = :status")
+    long countByAuthorIdAndStatus(@Param("userId") String userId, @Param("status") ReportStatus status);
 }

--- a/smart-rent/src/main/java/com/smartrent/infra/repository/ReportedAuthorProjection.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/ReportedAuthorProjection.java
@@ -1,0 +1,17 @@
+package com.smartrent.infra.repository;
+
+/**
+ * Aggregated report counts for a listing author (người đăng tin).
+ * Produced by {@link ListingReportRepository#findReportedAuthors}.
+ */
+public interface ReportedAuthorProjection {
+
+    /** The listing author's user id. */
+    String getUserId();
+
+    /** Total number of reports across all of this author's listings. */
+    Long getTotalReports();
+
+    /** Number of reports admins have approved (RESOLVED) across this author's listings. */
+    Long getResolvedReports();
+}

--- a/smart-rent/src/main/java/com/smartrent/infra/repository/entity/User.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/entity/User.java
@@ -65,6 +65,26 @@ public class User extends AbstractUser {
     @Column(name = "avatar_media_id")
     Long avatarMediaId;
 
+    // ============ POSTING BLOCK FIELDS ============
+
+    /** True when an admin has blocked this user from creating new listings. */
+    @Builder.Default
+    @Column(name = "posting_blocked", nullable = false)
+    boolean postingBlocked = false;
+
+    /** Admin-provided reason for the posting block. Null when not blocked. */
+    @Column(name = "posting_blocked_reason", length = 500)
+    String postingBlockedReason;
+
+    /** Admin ID who blocked the user from posting (VARCHAR(36) for UUID-style ids). */
+    @Column(name = "posting_blocked_by_admin_id", length = 36)
+    String postingBlockedByAdminId;
+
+    /** Timestamp when the posting block was applied. Null when not blocked. */
+    @Column(name = "posting_blocked_at")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    LocalDateTime postingBlockedAt;
+
     // ============ BROKER FIELDS ============
 
     /** True when the user is an approved broker. */

--- a/smart-rent/src/main/java/com/smartrent/service/listing/impl/ListingServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/listing/impl/ListingServiceImpl.java
@@ -140,6 +140,9 @@ public class ListingServiceImpl implements ListingService {
         log.info("Creating listing with address - User: {}, Title: {}, UseMembershipQuota: {}",
                 request.getUserId(), request.getTitle(), request.getUseMembershipQuota());
 
+        // Block users an admin has barred from posting (too many approved reports)
+        ensureUserCanPost(request.getUserId());
+
         // Validate required fields for non-draft listings
         validateNonDraftListing(request);
 
@@ -346,6 +349,9 @@ public class ListingServiceImpl implements ListingService {
     @Transactional
     public Object createVipListing(VipListingCreationRequest request) {
         log.info("Creating VIP listing for user: {}, vipType: {}", request.getUserId(), request.getVipType());
+
+        // Block users an admin has barred from posting (too many approved reports)
+        ensureUserCanPost(request.getUserId());
 
         // Fail fast on image/video limit before doing any quota/payment work so the
         // caller gets a 400 instead of consuming a benefit or being redirected to VNPay.
@@ -1156,6 +1162,22 @@ public class ListingServiceImpl implements ListingService {
             throw new AppException(DomainCode.UNKNOWN_ERROR,
                     "Failed to create VIP listing after payment: " + e.getMessage());
         }
+    }
+
+    /**
+     * Reject listing creation when an admin has blocked this user from posting.
+     * A blocked user (too many admin-approved reports) cannot create new listings.
+     */
+    private void ensureUserCanPost(String userId) {
+        if (userId == null) {
+            return;
+        }
+        userRepository.findById(userId).ifPresent(user -> {
+            if (user.isPostingBlocked()) {
+                log.warn("Blocked user {} attempted to create a listing", userId);
+                throw new DomainException(DomainCode.USER_POSTING_BLOCKED);
+            }
+        });
     }
 
     /**

--- a/smart-rent/src/main/java/com/smartrent/service/report/ReportedAuthorService.java
+++ b/smart-rent/src/main/java/com/smartrent/service/report/ReportedAuthorService.java
@@ -1,0 +1,34 @@
+package com.smartrent.service.report;
+
+import com.smartrent.dto.request.PostingBlockRequest;
+import com.smartrent.dto.response.ListingReportResponse;
+import com.smartrent.dto.response.PageResponse;
+import com.smartrent.dto.response.ReportedAuthorResponse;
+
+import java.util.List;
+
+/**
+ * Admin service for tracking listing authors (người đăng tin) by their report history
+ * and for blocking / unblocking them from posting new listings.
+ */
+public interface ReportedAuthorService {
+
+    /** Number of admin-approved (RESOLVED) reports beyond which an author becomes block-eligible. */
+    int BLOCK_ELIGIBLE_THRESHOLD = 3;
+
+    /**
+     * Paginated list of authors who have at least one report on their listings,
+     * with total / approved report counts and current block state.
+     */
+    PageResponse<ReportedAuthorResponse> getReportedAuthors(int page, int size);
+
+    /**
+     * All admin-approved (RESOLVED) reports across a given author's listings.
+     */
+    List<ListingReportResponse> getApprovedReports(String userId);
+
+    /**
+     * Block or unblock an author from posting new listings.
+     */
+    ReportedAuthorResponse setPostingBlock(String userId, PostingBlockRequest request, String adminId);
+}

--- a/smart-rent/src/main/java/com/smartrent/service/report/impl/ReportedAuthorServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/report/impl/ReportedAuthorServiceImpl.java
@@ -1,0 +1,184 @@
+package com.smartrent.service.report.impl;
+
+import com.smartrent.config.Constants;
+import com.smartrent.dto.request.PostingBlockRequest;
+import com.smartrent.dto.response.ListingReportResponse;
+import com.smartrent.dto.response.PageResponse;
+import com.smartrent.dto.response.ReportedAuthorResponse;
+import com.smartrent.enums.NotificationType;
+import com.smartrent.enums.RecipientType;
+import com.smartrent.enums.ReportStatus;
+import com.smartrent.infra.exception.UserNotFoundException;
+import com.smartrent.infra.repository.AdminRepository;
+import com.smartrent.infra.repository.ListingReportRepository;
+import com.smartrent.infra.repository.ReportedAuthorProjection;
+import com.smartrent.infra.repository.UserRepository;
+import com.smartrent.infra.repository.entity.ListingReport;
+import com.smartrent.infra.repository.entity.User;
+import com.smartrent.mapper.ListingReportMapper;
+import com.smartrent.service.notification.NotificationService;
+import com.smartrent.service.report.ReportedAuthorService;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.FieldDefaults;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Caching;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
+public class ReportedAuthorServiceImpl implements ReportedAuthorService {
+
+    UserRepository userRepository;
+    ListingReportRepository listingReportRepository;
+    ListingReportMapper listingReportMapper;
+    AdminRepository adminRepository;
+    NotificationService notificationService;
+
+    @Override
+    @Transactional(readOnly = true)
+    public PageResponse<ReportedAuthorResponse> getReportedAuthors(int page, int size) {
+        int safePage = Math.max(page, 1);
+        int safeSize = size < 1 ? 20 : Math.min(size, 100);
+        Pageable pageable = PageRequest.of(safePage - 1, safeSize);
+
+        Page<ReportedAuthorProjection> authorPage = listingReportRepository.findReportedAuthors(pageable);
+
+        // Batch-load user details for the page
+        List<String> userIds = authorPage.getContent().stream()
+                .map(ReportedAuthorProjection::getUserId)
+                .collect(Collectors.toList());
+        Map<String, User> usersById = userRepository.findAllById(userIds).stream()
+                .collect(Collectors.toMap(User::getUserId, Function.identity()));
+
+        List<ReportedAuthorResponse> authors = authorPage.getContent().stream()
+                .map(p -> toAuthorResponse(p, usersById.get(p.getUserId())))
+                .collect(Collectors.toList());
+
+        return PageResponse.<ReportedAuthorResponse>builder()
+                .page(safePage)
+                .size(authorPage.getSize())
+                .totalPages(authorPage.getTotalPages())
+                .totalElements(authorPage.getTotalElements())
+                .data(authors)
+                .build();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<ListingReportResponse> getApprovedReports(String userId) {
+        List<ListingReport> reports =
+                listingReportRepository.findByAuthorIdAndStatus(userId, ReportStatus.RESOLVED);
+        return reports.stream()
+                .map(this::mapToResponseWithAdminInfo)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    @Transactional
+    @Caching(evict = {
+            @CacheEvict(cacheNames = Constants.CacheNames.USER_DETAILS, key = "#userId"),
+            @CacheEvict(cacheNames = Constants.CacheNames.USER_DETAILS, allEntries = true)
+    })
+    public ReportedAuthorResponse setPostingBlock(String userId, PostingBlockRequest request, String adminId) {
+        User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
+
+        boolean block = Boolean.TRUE.equals(request.getBlocked());
+        if (block) {
+            user.setPostingBlocked(true);
+            user.setPostingBlockedReason(request.getReason());
+            user.setPostingBlockedByAdminId(adminId);
+            user.setPostingBlockedAt(LocalDateTime.now());
+            userRepository.save(user);
+            log.info("Admin {} BLOCKED user {} from posting. Reason: {}", adminId, userId, request.getReason());
+
+            notificationService.sendNotification(
+                    userId, RecipientType.USER,
+                    NotificationType.POSTING_BLOCKED,
+                    "Tài khoản bị chặn đăng tin",
+                    "Tài khoản của bạn đã bị chặn đăng tin do có nhiều tin đăng vi phạm bị báo cáo và đã được duyệt."
+                            + (request.getReason() != null && !request.getReason().isBlank()
+                                    ? " Lý do: " + request.getReason() : ""),
+                    null, "USER"
+            );
+        } else {
+            user.setPostingBlocked(false);
+            user.setPostingBlockedReason(null);
+            user.setPostingBlockedByAdminId(adminId);
+            user.setPostingBlockedAt(null);
+            userRepository.save(user);
+            log.info("Admin {} UNBLOCKED user {} for posting", adminId, userId);
+
+            notificationService.sendNotification(
+                    userId, RecipientType.USER,
+                    NotificationType.POSTING_UNBLOCKED,
+                    "Tài khoản được mở lại quyền đăng tin",
+                    "Tài khoản của bạn đã được mở lại quyền đăng tin. Bạn có thể tiếp tục đăng tin trên SmartRent.",
+                    null, "USER"
+            );
+        }
+
+        long resolvedReports = listingReportRepository.countByAuthorIdAndStatus(userId, ReportStatus.RESOLVED);
+        long totalReports = listingReportRepository.countByAuthorIdAndStatus(userId, ReportStatus.PENDING)
+                + listingReportRepository.countByAuthorIdAndStatus(userId, ReportStatus.RESOLVED)
+                + listingReportRepository.countByAuthorIdAndStatus(userId, ReportStatus.REJECTED);
+        return buildResponse(user, totalReports, resolvedReports);
+    }
+
+    // ────────────────────────────── helpers ──────────────────────────────
+
+    private ReportedAuthorResponse toAuthorResponse(ReportedAuthorProjection projection, User user) {
+        long total = projection.getTotalReports() != null ? projection.getTotalReports() : 0L;
+        long resolved = projection.getResolvedReports() != null ? projection.getResolvedReports() : 0L;
+        if (user == null) {
+            // Author account no longer exists — still surface the counts
+            return ReportedAuthorResponse.builder()
+                    .userId(projection.getUserId())
+                    .totalReports(total)
+                    .resolvedReports(resolved)
+                    .blockEligible(resolved > BLOCK_ELIGIBLE_THRESHOLD)
+                    .postingBlocked(false)
+                    .build();
+        }
+        return buildResponse(user, total, resolved);
+    }
+
+    private ReportedAuthorResponse buildResponse(User user, long total, long resolved) {
+        return ReportedAuthorResponse.builder()
+                .userId(user.getUserId())
+                .firstName(user.getFirstName())
+                .lastName(user.getLastName())
+                .email(user.getEmail())
+                .phoneNumber(user.getPhoneNumber())
+                .avatarUrl(user.getAvatarUrl())
+                .totalReports(total)
+                .resolvedReports(resolved)
+                .blockEligible(resolved > BLOCK_ELIGIBLE_THRESHOLD)
+                .postingBlocked(user.isPostingBlocked())
+                .postingBlockedReason(user.getPostingBlockedReason())
+                .postingBlockedAt(user.getPostingBlockedAt())
+                .build();
+    }
+
+    private ListingReportResponse mapToResponseWithAdminInfo(ListingReport report) {
+        ListingReportResponse response = listingReportMapper.mapFromListingReportEntityToResponse(report);
+        if (report.getResolvedBy() != null) {
+            adminRepository.findById(report.getResolvedBy()).ifPresent(admin ->
+                    response.setResolvedByName(admin.getFirstName() + " " + admin.getLastName()));
+        }
+        return response;
+    }
+}

--- a/smart-rent/src/main/resources/db/migration/V106__Add_user_posting_block.sql
+++ b/smart-rent/src/main/resources/db/migration/V106__Add_user_posting_block.sql
@@ -1,0 +1,23 @@
+-- Add posting-block fields to users table
+-- Lets admins block a user from creating new listings (đăng tin) when their
+-- listings accumulate too many admin-approved (RESOLVED) reports.
+
+ALTER TABLE users
+ADD COLUMN posting_blocked BOOLEAN NOT NULL DEFAULT FALSE AFTER is_verified;
+
+ALTER TABLE users
+ADD COLUMN posting_blocked_reason VARCHAR(500) NULL AFTER posting_blocked;
+
+ALTER TABLE users
+ADD COLUMN posting_blocked_by_admin_id VARCHAR(36) NULL AFTER posting_blocked_reason;
+
+ALTER TABLE users
+ADD COLUMN posting_blocked_at TIMESTAMP NULL AFTER posting_blocked_by_admin_id;
+
+-- Track which admin performed the block (nullable, cleared admin -> keep row)
+ALTER TABLE users
+ADD CONSTRAINT fk_users_posting_blocked_admin
+FOREIGN KEY (posting_blocked_by_admin_id) REFERENCES admins(admin_id) ON DELETE SET NULL;
+
+-- Index to quickly filter blocked users
+CREATE INDEX idx_users_posting_blocked ON users(posting_blocked);


### PR DESCRIPTION
Track listing authors by their reports and let admins block repeat offenders (more than 3 admin-approved reports) from posting new listings.

- V106 migration + User posting-block fields
- ensureUserCanPost guard in createListing/createVipListing (DomainCode 23001)
- /v1/admin/reported-authors: list authors, view approved reports, block/unblock
- POSTING_BLOCKED / POSTING_UNBLOCKED notifications