### PR TITLE
feat: enforce posting block everywhere + expose it on profile + autho…

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/controller/AdminReportedAuthorController.java
+++ b/smart-rent/src/main/java/com/smartrent/controller/AdminReportedAuthorController.java
@@ -45,14 +45,24 @@ public class AdminReportedAuthorController {
     @Operation(
             summary = "List reported listing authors (Admin)",
             description = "Paginated list of authors who have at least one report on their listings, " +
-                    "with total / approved report counts and current posting-block state.")
+                    "with total / approved report counts and current posting-block state. " +
+                    "Optional filters: email / name / phone (prefix) and blockEligible.")
     public ApiResponse<PageResponse<ReportedAuthorResponse>> getReportedAuthors(
+            @Parameter(description = "Filter by email (prefix)")
+            @RequestParam(required = false) String email,
+            @Parameter(description = "Filter by first/last name (prefix)")
+            @RequestParam(required = false) String name,
+            @Parameter(description = "Filter by phone number (prefix)")
+            @RequestParam(required = false) String phone,
+            @Parameter(description = "Filter by block eligibility: true = enough approved reports (> 3), false = not yet")
+            @RequestParam(required = false) Boolean blockEligible,
             @Parameter(description = "Page number (1-indexed)", example = "1")
             @RequestParam(defaultValue = "1") int page,
             @Parameter(description = "Items per page", example = "20")
             @RequestParam(defaultValue = "20") int size) {
 
-        PageResponse<ReportedAuthorResponse> result = reportedAuthorService.getReportedAuthors(page, size);
+        PageResponse<ReportedAuthorResponse> result =
+                reportedAuthorService.getReportedAuthors(email, name, phone, blockEligible, page, size);
         return ApiResponse.<PageResponse<ReportedAuthorResponse>>builder().data(result).build();
     }
 

--- a/smart-rent/src/main/java/com/smartrent/dto/response/GetUserResponse.java
+++ b/smart-rent/src/main/java/com/smartrent/dto/response/GetUserResponse.java
@@ -71,4 +71,12 @@ public class GetUserResponse implements Serializable {
     @Schema(description = "Current broker verification status: NONE | PENDING | APPROVED | REJECTED", example = "NONE", allowableValues = {
             "NONE", "PENDING", "APPROVED", "REJECTED" })
     String brokerVerificationStatus;
+
+    // ============ POSTING BLOCK FIELDS ============
+
+    @Schema(description = "Whether an admin has blocked this user from posting new listings", example = "false")
+    Boolean postingBlocked;
+
+    @Schema(description = "Reason for the posting block (present only when blocked)")
+    String postingBlockedReason;
 }

--- a/smart-rent/src/main/java/com/smartrent/infra/repository/ListingReportRepository.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/ListingReportRepository.java
@@ -107,16 +107,48 @@ public interface ListingReportRepository extends JpaRepository<ListingReport, Lo
      * has at least one report on any of their listings, with total and admin-approved
      * (RESOLVED) report counts. Ordered by most approved reports first.
      */
+    /**
+     * Reported authors with optional filters. Empty-string text filters and a
+     * {@code blockEligibleFlag} of -1 mean "no filter" (sentinels avoid binding
+     * nulls in a native query). {@code blockEligibleFlag}: -1 all, 1 eligible
+     * (resolved &gt; threshold), 0 not eligible. Text filters are prefix matches so
+     * they can use the users indexes.
+     */
     @Query(value = "SELECT l.user_id AS userId, " +
             "CAST(COUNT(*) AS SIGNED) AS totalReports, " +
             "CAST(SUM(CASE WHEN r.status = 'RESOLVED' THEN 1 ELSE 0 END) AS SIGNED) AS resolvedReports " +
-            "FROM listing_reports r JOIN listings l ON r.listing_id = l.listing_id " +
+            "FROM listing_reports r " +
+            "JOIN listings l ON r.listing_id = l.listing_id " +
+            "JOIN users u ON u.user_id = l.user_id " +
+            "WHERE (:email = '' OR u.email LIKE CONCAT(:email, '%')) " +
+            "AND (:name = '' OR u.first_name LIKE CONCAT(:name, '%') OR u.last_name LIKE CONCAT(:name, '%')) " +
+            "AND (:phone = '' OR u.phone_number LIKE CONCAT(:phone, '%')) " +
             "GROUP BY l.user_id " +
+            "HAVING (:blockEligibleFlag = -1 " +
+            "  OR (:blockEligibleFlag = 1 AND SUM(CASE WHEN r.status = 'RESOLVED' THEN 1 ELSE 0 END) > :threshold) " +
+            "  OR (:blockEligibleFlag = 0 AND SUM(CASE WHEN r.status = 'RESOLVED' THEN 1 ELSE 0 END) <= :threshold)) " +
             "ORDER BY resolvedReports DESC, totalReports DESC",
-            countQuery = "SELECT COUNT(DISTINCT l.user_id) " +
-                    "FROM listing_reports r JOIN listings l ON r.listing_id = l.listing_id",
+            countQuery = "SELECT COUNT(*) FROM (" +
+                    "SELECT l.user_id " +
+                    "FROM listing_reports r " +
+                    "JOIN listings l ON r.listing_id = l.listing_id " +
+                    "JOIN users u ON u.user_id = l.user_id " +
+                    "WHERE (:email = '' OR u.email LIKE CONCAT(:email, '%')) " +
+                    "AND (:name = '' OR u.first_name LIKE CONCAT(:name, '%') OR u.last_name LIKE CONCAT(:name, '%')) " +
+                    "AND (:phone = '' OR u.phone_number LIKE CONCAT(:phone, '%')) " +
+                    "GROUP BY l.user_id " +
+                    "HAVING (:blockEligibleFlag = -1 " +
+                    "  OR (:blockEligibleFlag = 1 AND SUM(CASE WHEN r.status = 'RESOLVED' THEN 1 ELSE 0 END) > :threshold) " +
+                    "  OR (:blockEligibleFlag = 0 AND SUM(CASE WHEN r.status = 'RESOLVED' THEN 1 ELSE 0 END) <= :threshold))" +
+                    ") x",
             nativeQuery = true)
-    Page<ReportedAuthorProjection> findReportedAuthors(Pageable pageable);
+    Page<ReportedAuthorProjection> findReportedAuthors(
+            @Param("email") String email,
+            @Param("name") String name,
+            @Param("phone") String phone,
+            @Param("blockEligibleFlag") int blockEligibleFlag,
+            @Param("threshold") int threshold,
+            Pageable pageable);
 
     /**
      * Find all reports for a given author (owner of the reported listings) filtered by status,
@@ -132,4 +164,15 @@ public interface ListingReportRepository extends JpaRepository<ListingReport, Lo
      */
     @Query("SELECT COUNT(r) FROM listing_reports r WHERE r.listing.userId = :userId AND r.status = :status")
     long countByAuthorIdAndStatus(@Param("userId") String userId, @Param("status") ReportStatus status);
+
+    /**
+     * Total and admin-approved (RESOLVED) report counts for a single author, in one query.
+     */
+    @Query(value = "SELECT " +
+            "CAST(COUNT(*) AS SIGNED) AS totalReports, " +
+            "CAST(SUM(CASE WHEN r.status = 'RESOLVED' THEN 1 ELSE 0 END) AS SIGNED) AS resolvedReports " +
+            "FROM listing_reports r JOIN listings l ON r.listing_id = l.listing_id " +
+            "WHERE l.user_id = :userId",
+            nativeQuery = true)
+    ReportedAuthorProjection.Counts getReportCountsByAuthor(@Param("userId") String userId);
 }

--- a/smart-rent/src/main/java/com/smartrent/infra/repository/ReportedAuthorProjection.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/ReportedAuthorProjection.java
@@ -14,4 +14,13 @@ public interface ReportedAuthorProjection {
 
     /** Number of reports admins have approved (RESOLVED) across this author's listings. */
     Long getResolvedReports();
+
+    /**
+     * Total / approved report counts for a single author (userId is not selected).
+     */
+    interface Counts {
+        Long getTotalReports();
+
+        Long getResolvedReports();
+    }
 }

--- a/smart-rent/src/main/java/com/smartrent/mapper/impl/UserMapperImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/mapper/impl/UserMapperImpl.java
@@ -89,6 +89,9 @@ public class UserMapperImpl implements UserMapper {
             user.getBrokerVerificationStatus() != null
                 ? user.getBrokerVerificationStatus().name()
                 : null)
+        // Posting block fields
+        .postingBlocked(user.isPostingBlocked())
+        .postingBlockedReason(user.getPostingBlockedReason())
         .build();
   }
 

--- a/smart-rent/src/main/java/com/smartrent/service/listing/PostingAccessGuard.java
+++ b/smart-rent/src/main/java/com/smartrent/service/listing/PostingAccessGuard.java
@@ -1,0 +1,40 @@
+package com.smartrent.service.listing;
+
+import com.smartrent.infra.exception.DomainException;
+import com.smartrent.infra.exception.model.DomainCode;
+import com.smartrent.infra.repository.UserRepository;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.FieldDefaults;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+/**
+ * Central guard that rejects listing-posting actions for users an admin has
+ * blocked from posting (too many admin-approved reports). Used by every entry
+ * point that creates or re-lists a listing (create, VIP create, publish draft
+ * via create, repost) so the block is enforced uniformly at the backend.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
+public class PostingAccessGuard {
+
+    UserRepository userRepository;
+
+    /**
+     * Throws {@link DomainCode#USER_POSTING_BLOCKED} when the user is blocked from posting.
+     */
+    public void ensureCanPost(String userId) {
+        if (userId == null) {
+            return;
+        }
+        userRepository.findById(userId).ifPresent(user -> {
+            if (user.isPostingBlocked()) {
+                log.warn("Blocked user {} attempted a posting action", userId);
+                throw new DomainException(DomainCode.USER_POSTING_BLOCKED);
+            }
+        });
+    }
+}

--- a/smart-rent/src/main/java/com/smartrent/service/listing/impl/ListingServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/listing/impl/ListingServiceImpl.java
@@ -55,6 +55,7 @@ import com.smartrent.infra.repository.entity.*;
 import com.smartrent.mapper.ListingMapper;
 import com.smartrent.service.listing.ListingService;
 import com.smartrent.service.listing.ListingQueryService;
+import com.smartrent.service.listing.PostingAccessGuard;
 import com.smartrent.service.listing.cache.ListingRequestCacheService;
 import com.smartrent.util.TextNormalizer;
 // import com.smartrent.service.pricing.LocationPricingService;  // DISABLED: Not in use
@@ -133,6 +134,7 @@ public class ListingServiceImpl implements ListingService {
     com.smartrent.service.listing.AdminListingStatsService adminListingStatsService;
     com.smartrent.service.moderation.ListingModerationService listingModerationService;
     com.smartrent.infra.repository.UserFollowRepository userFollowRepository;
+    PostingAccessGuard postingAccessGuard;
 
     @Override
     @Transactional
@@ -141,7 +143,7 @@ public class ListingServiceImpl implements ListingService {
                 request.getUserId(), request.getTitle(), request.getUseMembershipQuota());
 
         // Block users an admin has barred from posting (too many approved reports)
-        ensureUserCanPost(request.getUserId());
+        postingAccessGuard.ensureCanPost(request.getUserId());
 
         // Validate required fields for non-draft listings
         validateNonDraftListing(request);
@@ -351,7 +353,7 @@ public class ListingServiceImpl implements ListingService {
         log.info("Creating VIP listing for user: {}, vipType: {}", request.getUserId(), request.getVipType());
 
         // Block users an admin has barred from posting (too many approved reports)
-        ensureUserCanPost(request.getUserId());
+        postingAccessGuard.ensureCanPost(request.getUserId());
 
         // Fail fast on image/video limit before doing any quota/payment work so the
         // caller gets a 400 instead of consuming a benefit or being redirected to VNPay.
@@ -1162,22 +1164,6 @@ public class ListingServiceImpl implements ListingService {
             throw new AppException(DomainCode.UNKNOWN_ERROR,
                     "Failed to create VIP listing after payment: " + e.getMessage());
         }
-    }
-
-    /**
-     * Reject listing creation when an admin has blocked this user from posting.
-     * A blocked user (too many admin-approved reports) cannot create new listings.
-     */
-    private void ensureUserCanPost(String userId) {
-        if (userId == null) {
-            return;
-        }
-        userRepository.findById(userId).ifPresent(user -> {
-            if (user.isPostingBlocked()) {
-                log.warn("Blocked user {} attempted to create a listing", userId);
-                throw new DomainException(DomainCode.USER_POSTING_BLOCKED);
-            }
-        });
     }
 
     /**

--- a/smart-rent/src/main/java/com/smartrent/service/report/ReportedAuthorService.java
+++ b/smart-rent/src/main/java/com/smartrent/service/report/ReportedAuthorService.java
@@ -19,8 +19,15 @@ public interface ReportedAuthorService {
     /**
      * Paginated list of authors who have at least one report on their listings,
      * with total / approved report counts and current block state.
+     *
+     * @param email         optional email prefix filter (null/blank = no filter)
+     * @param name          optional first/last name prefix filter (null/blank = no filter)
+     * @param phone         optional phone-number prefix filter (null/blank = no filter)
+     * @param blockEligible optional filter: TRUE = only block-eligible authors,
+     *                      FALSE = only not-yet-eligible, null = all
      */
-    PageResponse<ReportedAuthorResponse> getReportedAuthors(int page, int size);
+    PageResponse<ReportedAuthorResponse> getReportedAuthors(
+            String email, String name, String phone, Boolean blockEligible, int page, int size);
 
     /**
      * All admin-approved (RESOLVED) reports across a given author's listings.

--- a/smart-rent/src/main/java/com/smartrent/service/report/impl/ReportedAuthorServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/report/impl/ReportedAuthorServiceImpl.java
@@ -50,12 +50,20 @@ public class ReportedAuthorServiceImpl implements ReportedAuthorService {
 
     @Override
     @Transactional(readOnly = true)
-    public PageResponse<ReportedAuthorResponse> getReportedAuthors(int page, int size) {
+    public PageResponse<ReportedAuthorResponse> getReportedAuthors(
+            String email, String name, String phone, Boolean blockEligible, int page, int size) {
         int safePage = Math.max(page, 1);
         int safeSize = size < 1 ? 20 : Math.min(size, 100);
         Pageable pageable = PageRequest.of(safePage - 1, safeSize);
 
-        Page<ReportedAuthorProjection> authorPage = listingReportRepository.findReportedAuthors(pageable);
+        // Sentinels avoid binding nulls in the native query
+        String emailFilter = email != null ? email.trim() : "";
+        String nameFilter = name != null ? name.trim() : "";
+        String phoneFilter = phone != null ? phone.trim() : "";
+        int blockEligibleFlag = blockEligible == null ? -1 : (blockEligible ? 1 : 0);
+
+        Page<ReportedAuthorProjection> authorPage = listingReportRepository.findReportedAuthors(
+                emailFilter, nameFilter, phoneFilter, blockEligibleFlag, BLOCK_ELIGIBLE_THRESHOLD, pageable);
 
         // Batch-load user details for the page
         List<String> userIds = authorPage.getContent().stream()
@@ -131,10 +139,10 @@ public class ReportedAuthorServiceImpl implements ReportedAuthorService {
             );
         }
 
-        long resolvedReports = listingReportRepository.countByAuthorIdAndStatus(userId, ReportStatus.RESOLVED);
-        long totalReports = listingReportRepository.countByAuthorIdAndStatus(userId, ReportStatus.PENDING)
-                + listingReportRepository.countByAuthorIdAndStatus(userId, ReportStatus.RESOLVED)
-                + listingReportRepository.countByAuthorIdAndStatus(userId, ReportStatus.REJECTED);
+        // Single combined query instead of one per status (faster toggle)
+        ReportedAuthorProjection.Counts counts = listingReportRepository.getReportCountsByAuthor(userId);
+        long totalReports = counts != null && counts.getTotalReports() != null ? counts.getTotalReports() : 0L;
+        long resolvedReports = counts != null && counts.getResolvedReports() != null ? counts.getResolvedReports() : 0L;
         return buildResponse(user, totalReports, resolvedReports);
     }
 

--- a/smart-rent/src/main/java/com/smartrent/service/repost/impl/RepostServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/repost/impl/RepostServiceImpl.java
@@ -51,6 +51,7 @@ public class RepostServiceImpl implements RepostService {
     QuotaService quotaService;
     TransactionService transactionService;
     PaymentService paymentService;
+    com.smartrent.service.listing.PostingAccessGuard postingAccessGuard;
 
     @Override
     @Transactional
@@ -62,6 +63,9 @@ public class RepostServiceImpl implements RepostService {
     })
     public RepostResponse repostListing(String userId, RepostListingRequest request) {
         log.info("Reposting listing {} for user {}", request.getListingId(), userId);
+
+        // Reposting re-lists a listing (uses quota/payment) — block barred users
+        postingAccessGuard.ensureCanPost(userId);
 
         Listing listing = listingRepository.findById(request.getListingId())
                 .orElseThrow(() -> new RuntimeException("Listing not found: " + request.getListingId()));

--- a/smart-rent/src/main/resources/db/migration/V107__Add_user_filter_indexes_for_reported_authors.sql
+++ b/smart-rent/src/main/resources/db/migration/V107__Add_user_filter_indexes_for_reported_authors.sql
@@ -1,0 +1,42 @@
+-- Indexes for the admin reported-authors filters (email / name / phone).
+-- email already has idx_users_email (V1). Add phone_number and name indexes so
+-- prefix filters on the reported-authors list are index-backed.
+-- Uses the conditional pattern (check INFORMATION_SCHEMA first) since MySQL
+-- CREATE INDEX has no IF NOT EXISTS.
+
+-- phone_number (uk_users_phone leads with phone_code, so a phone_number-only
+-- prefix filter cannot use it)
+SET @index_exists = (SELECT COUNT(*) FROM information_schema.STATISTICS
+    WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = 'users'
+    AND INDEX_NAME = 'idx_users_phone_number');
+SET @sql = IF(@index_exists = 0,
+    'CREATE INDEX idx_users_phone_number ON users (phone_number)',
+    'SELECT ''Index idx_users_phone_number already exists'' AS message');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- first_name prefix filter
+SET @index_exists = (SELECT COUNT(*) FROM information_schema.STATISTICS
+    WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = 'users'
+    AND INDEX_NAME = 'idx_users_first_name');
+SET @sql = IF(@index_exists = 0,
+    'CREATE INDEX idx_users_first_name ON users (first_name)',
+    'SELECT ''Index idx_users_first_name already exists'' AS message');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- last_name prefix filter
+SET @index_exists = (SELECT COUNT(*) FROM information_schema.STATISTICS
+    WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = 'users'
+    AND INDEX_NAME = 'idx_users_last_name');
+SET @sql = IF(@index_exists = 0,
+    'CREATE INDEX idx_users_last_name ON users (last_name)',
+    'SELECT ''Index idx_users_last_name already exists'' AS message');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;


### PR DESCRIPTION
…r filters

- Expose postingBlocked/reason on GetUserResponse profile so the FE reads it from the already-loaded user (no extra polling API)
- Central PostingAccessGuard used by createListing/createVipListing and repost so payment- and membership-quota-based posting are all blocked at the backend
- Optimize block/unblock toggle: single combined report-count query
- Reported-authors list: filter by email / name / phone (prefix) + blockEligible
- V107: indexes on users(phone_number, first_name, last_name) for those filters