### PR TITLE
feat(security): enforce role-based authorization on admin endpoints

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/controller/AdminAnalyticsController.java
+++ b/smart-rent/src/main/java/com/smartrent/controller/AdminAnalyticsController.java
@@ -20,6 +20,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
@@ -37,6 +38,7 @@ public class AdminAnalyticsController {
     AdminAnalyticsService adminAnalyticsService;
 
     @GetMapping("/revenue")
+    @PreAuthorize("hasAnyAuthority('ROLE_SA', 'ROLE_FA', 'ROLE_MA')")
     @Operation(
             summary = "Get revenue over time",
             description = """
@@ -104,6 +106,7 @@ public class AdminAnalyticsController {
     }
 
     @GetMapping("/memberships/distribution")
+    @PreAuthorize("hasAnyAuthority('ROLE_SA', 'ROLE_FA', 'ROLE_MA')")
     @Operation(
             summary = "Get active membership distribution by package level",
             description = "Returns the count and percentage of currently active memberships grouped by package level.",
@@ -148,6 +151,7 @@ public class AdminAnalyticsController {
     // ─── Analytics Charts ───
 
     @GetMapping("/users")
+    @PreAuthorize("hasAnyAuthority('ROLE_SA', 'ROLE_UA', 'ROLE_SPA', 'ROLE_MA')")
     @Operation(
             summary = "Get user growth analytics",
             description = """
@@ -218,6 +222,7 @@ public class AdminAnalyticsController {
     }
 
     @GetMapping("/reports")
+    @PreAuthorize("hasAnyAuthority('ROLE_SA', 'ROLE_FA', 'ROLE_MA')")
     @Operation(
             summary = "Get listing report analytics",
             description = """
@@ -291,6 +296,7 @@ public class AdminAnalyticsController {
     }
 
     @GetMapping("/listings")
+    @PreAuthorize("hasAnyAuthority('ROLE_SA', 'ROLE_CM', 'ROLE_MA')")
     @Operation(
             summary = "Get listing creation analytics",
             description = """

--- a/smart-rent/src/main/java/com/smartrent/controller/AdminBrokerController.java
+++ b/smart-rent/src/main/java/com/smartrent/controller/AdminBrokerController.java
@@ -47,7 +47,7 @@ public class AdminBrokerController {
     // ──────────────────────────────────────────────────────────────────
 
     @GetMapping("/broker-pending")
-    @PreAuthorize("hasAnyAuthority('ROLE_SA', 'ROLE_UA', 'ROLE_SPA')")
+    @PreAuthorize("hasAnyAuthority('ROLE_SA', 'ROLE_CM', 'ROLE_SPA')")
     @Operation(
             summary = "List users with PENDING broker registration (Admin only)",
             description = """
@@ -129,7 +129,7 @@ public class AdminBrokerController {
     // ──────────────────────────────────────────────────────────────────
 
     @PatchMapping("/{userId}/broker-verification")
-    @PreAuthorize("hasAnyAuthority('ROLE_SA', 'ROLE_UA', 'ROLE_SPA')")
+    @PreAuthorize("hasAnyAuthority('ROLE_SA', 'ROLE_CM', 'ROLE_SPA')")
     @Operation(
             summary = "Approve or reject a user's broker registration (Admin only)",
             description = """
@@ -224,7 +224,9 @@ public class AdminBrokerController {
     }
 
     @DeleteMapping("/{userId}/broker")
-    @PreAuthorize("hasAnyAuthority('ROLE_SA', 'ROLE_UA', 'ROLE_SPA')")
+    // Triggered from the Users management page (SA, UA), not the broker-pending
+    // moderation list — so it follows user-management write access.
+    @PreAuthorize("hasAnyAuthority('ROLE_SA', 'ROLE_UA')")
     @Operation(
             summary = "Remove broker role from a user (Admin only)",
             description = """

--- a/smart-rent/src/main/java/com/smartrent/controller/AdminListingReportController.java
+++ b/smart-rent/src/main/java/com/smartrent/controller/AdminListingReportController.java
@@ -17,6 +17,7 @@ import jakarta.validation.Valid;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
@@ -30,6 +31,7 @@ import java.util.Map;
 @FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
 @Tag(name = "Admin - Listing Reports", description = "Admin APIs for managing and resolving listing reports")
 @SecurityRequirement(name = "Bearer Authentication")
+@PreAuthorize("hasAnyAuthority('ROLE_SA', 'ROLE_CM', 'ROLE_SPA')")
 public class AdminListingReportController {
 
     ListingReportService listingReportService;

--- a/smart-rent/src/main/java/com/smartrent/controller/AdminMediaController.java
+++ b/smart-rent/src/main/java/com/smartrent/controller/AdminMediaController.java
@@ -34,7 +34,7 @@ import java.util.List;
 @FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
 @Tag(name = "Admin - Media", description = "Admin APIs for managing media uploads")
 @SecurityRequirement(name = "Bearer Authentication")
-@PreAuthorize("hasAnyAuthority('ROLE_SA', 'ROLE_UA', 'ROLE_SPA')")
+@PreAuthorize("hasAnyAuthority('ROLE_SA', 'ROLE_CM', 'ROLE_MA')")
 @Slf4j
 public class AdminMediaController {
 

--- a/smart-rent/src/main/java/com/smartrent/controller/AdminMembershipController.java
+++ b/smart-rent/src/main/java/com/smartrent/controller/AdminMembershipController.java
@@ -41,7 +41,7 @@ public class AdminMembershipController {
         MembershipService membershipService;
 
         @GetMapping("/packages")
-        @PreAuthorize("hasAnyAuthority('ROLE_SA', 'ROLE_UA', 'ROLE_SPA')")
+        @PreAuthorize("hasAnyAuthority('ROLE_SA', 'ROLE_SPA', 'ROLE_FA', 'ROLE_MA')")
         @Operation(summary = "List all membership packages (Admin)", description = "Returns all membership packages including inactive ones, with pagination. "
                         +
                         "Use this endpoint in the admin console so administrators can see and re-enable packages that have been deactivated.", responses = {
@@ -79,7 +79,7 @@ public class AdminMembershipController {
         }
 
         @PutMapping("/packages/{membershipId}")
-        @PreAuthorize("hasAnyAuthority('ROLE_SA', 'ROLE_UA', 'ROLE_SPA')")
+        @PreAuthorize("hasAnyAuthority('ROLE_SA', 'ROLE_FA', 'ROLE_MA')")
         @Operation(summary = "Update membership package (Admin)", description = "Updates an existing membership package. "
                         + "Sale price is automatically computed by the server as "
                         + "salePrice = originalPrice * (1 - discountPercentage / 100). "
@@ -108,7 +108,9 @@ public class AdminMembershipController {
 
         @DeleteMapping("/users/{userId}")
         @ResponseStatus(HttpStatus.NO_CONTENT)
-        @PreAuthorize("hasAnyAuthority('ROLE_SA', 'ROLE_UA', 'ROLE_SPA')")
+        // Triggered from the Users management page (SA, UA), not the membership
+        // package screen — so it follows user-management write access.
+        @PreAuthorize("hasAnyAuthority('ROLE_SA', 'ROLE_UA')")
         @Operation(summary = "Clear user active memberships (Admin)", description = "Expires all ACTIVE membership records for a user. Use this to fix duplicate-active-membership issues.")
         public void clearUserMembership(
                         @Parameter(description = "User ID", required = true) @PathVariable String userId) {
@@ -118,7 +120,7 @@ public class AdminMembershipController {
 
         @DeleteMapping("/packages/{membershipId}")
         @ResponseStatus(HttpStatus.NO_CONTENT)
-        @PreAuthorize("hasAnyAuthority('ROLE_SA', 'ROLE_UA', 'ROLE_SPA')")
+        @PreAuthorize("hasAnyAuthority('ROLE_SA', 'ROLE_FA', 'ROLE_MA')")
         @Operation(summary = "Delete membership package (Admin)", description = "Deletes a membership package.", responses = {
                         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "204", description = "Package deleted successfully"),
                         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "Package not found", content = @Content(mediaType = "application/json", examples = @ExampleObject(name = "Not Found Error", value = """

--- a/smart-rent/src/main/java/com/smartrent/controller/AdminNewsController.java
+++ b/smart-rent/src/main/java/com/smartrent/controller/AdminNewsController.java
@@ -24,6 +24,7 @@ import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
@@ -39,6 +40,7 @@ import org.springframework.web.bind.annotation.*;
 @Tag(name = "Admin - News & Blog", description = "Admin APIs for managing news and blog posts")
 @SecurityRequirement(name = "Bearer Authentication")
 @Slf4j
+@PreAuthorize("hasAnyAuthority('ROLE_SA', 'ROLE_CM', 'ROLE_MA')")
 public class AdminNewsController {
 
         NewsService newsService;

--- a/smart-rent/src/main/java/com/smartrent/controller/AdminReportedAuthorController.java
+++ b/smart-rent/src/main/java/com/smartrent/controller/AdminReportedAuthorController.java
@@ -41,7 +41,7 @@ public class AdminReportedAuthorController {
     ReportedAuthorService reportedAuthorService;
 
     @GetMapping
-    @PreAuthorize("hasAnyAuthority('ROLE_SA', 'ROLE_UA', 'ROLE_SPA')")
+    @PreAuthorize("hasAnyAuthority('ROLE_SA', 'ROLE_CM', 'ROLE_SPA')")
     @Operation(
             summary = "List reported listing authors (Admin)",
             description = "Paginated list of authors who have at least one report on their listings, " +
@@ -57,7 +57,7 @@ public class AdminReportedAuthorController {
     }
 
     @GetMapping("/{userId}/reports")
-    @PreAuthorize("hasAnyAuthority('ROLE_SA', 'ROLE_UA', 'ROLE_SPA')")
+    @PreAuthorize("hasAnyAuthority('ROLE_SA', 'ROLE_CM', 'ROLE_SPA')")
     @Operation(
             summary = "Get an author's admin-approved reports (Admin)",
             description = "All reports across the author's listings that an admin has approved (RESOLVED).")
@@ -69,7 +69,7 @@ public class AdminReportedAuthorController {
     }
 
     @PatchMapping("/{userId}/posting-block")
-    @PreAuthorize("hasAnyAuthority('ROLE_SA', 'ROLE_UA', 'ROLE_SPA')")
+    @PreAuthorize("hasAnyAuthority('ROLE_SA', 'ROLE_CM', 'ROLE_SPA')")
     @Operation(
             summary = "Block or unblock an author from posting (Admin)",
             description = "Blocks the author from creating new listings (or lifts an existing block). " +

--- a/smart-rent/src/main/java/com/smartrent/controller/AdminTransactionController.java
+++ b/smart-rent/src/main/java/com/smartrent/controller/AdminTransactionController.java
@@ -27,7 +27,7 @@ import java.util.List;
 @RequiredArgsConstructor
 @FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
 @SecurityRequirement(name = "Bearer Authentication")
-@PreAuthorize("hasAnyAuthority('ROLE_SA', 'ROLE_UA', 'ROLE_SPA')")
+@PreAuthorize("hasAnyAuthority('ROLE_SA', 'ROLE_SPA', 'ROLE_FA')")
 @Tag(name = "Admin Transaction Management", description = "Admin transaction search, detail, statistics, and export APIs")
 public class AdminTransactionController {
 

--- a/smart-rent/src/main/java/com/smartrent/controller/ListingAdminController.java
+++ b/smart-rent/src/main/java/com/smartrent/controller/ListingAdminController.java
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -44,6 +45,7 @@ import org.springframework.web.bind.annotation.*;
         """
 )
 @RequiredArgsConstructor
+@PreAuthorize("hasAnyAuthority('ROLE_SA', 'ROLE_CM')")
 public class ListingAdminController {
 
     private final ListingService listingService;

--- a/smart-rent/src/main/java/com/smartrent/controller/RoleController.java
+++ b/smart-rent/src/main/java/com/smartrent/controller/RoleController.java
@@ -21,6 +21,7 @@ import java.util.List;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.http.HttpStatus;
 
@@ -29,6 +30,9 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 @FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
 @Tag(name = "Role Management", description = "APIs for managing system roles and permissions")
+// Viewing roles is available to Super Admin and User Admin (needed for the admin
+// creation form); creating/updating/deleting roles is Super Admin only.
+@PreAuthorize("hasAnyAuthority('ROLE_SA', 'ROLE_UA')")
 public class RoleController {
 
     RoleService roleService;
@@ -98,6 +102,7 @@ public class RoleController {
     }
 
     @PostMapping
+    @PreAuthorize("hasAuthority('ROLE_SA')")
     @ResponseStatus(HttpStatus.CREATED)
     @Operation(summary = "Create new role", description = "Creates a new role in the system", security = @SecurityRequirement(name = "Bearer Authentication"))
     @ApiResponses(value = {
@@ -128,6 +133,7 @@ public class RoleController {
     }
 
     @PutMapping("/{roleId}")
+    @PreAuthorize("hasAuthority('ROLE_SA')")
     @Operation(summary = "Update role", description = "Updates an existing role's information", security = @SecurityRequirement(name = "Bearer Authentication"))
     @ApiResponses(value = {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Role updated successfully", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiResponse.class), examples = @ExampleObject(name = "Success Response", value = """
@@ -158,6 +164,7 @@ public class RoleController {
     }
 
     @DeleteMapping("/{roleId}")
+    @PreAuthorize("hasAuthority('ROLE_SA')")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @Operation(summary = "Delete role", description = "Deletes a role from the system", security = @SecurityRequirement(name = "Bearer Authentication"))
     @ApiResponses(value = {

--- a/smart-rent/src/main/java/com/smartrent/controller/UserController.java
+++ b/smart-rent/src/main/java/com/smartrent/controller/UserController.java
@@ -142,6 +142,7 @@ public class UserController {
         }
 
         @GetMapping("/list")
+        @PreAuthorize("hasAnyAuthority('ROLE_SA', 'ROLE_UA', 'ROLE_SPA')")
         @Operation(summary = "Get paginated list of users with flexible filtering", description = "Retrieves a paginated list of all users in the system. Supports flexible key:value filtering.\n\nFilters format: filter=key:value\n- Example: filter=firstName:John&filter=isBroker:true", security = @SecurityRequirement(name = "Bearer Authentication"))
         @ApiResponses(value = {
                         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Users retrieved successfully"),
@@ -340,7 +341,7 @@ public class UserController {
         }
 
         @PutMapping("/{userId}")
-        @PreAuthorize("hasAnyAuthority('ROLE_SA', 'ROLE_UA', 'ROLE_SPA')")
+        @PreAuthorize("hasAnyAuthority('ROLE_SA', 'ROLE_UA')")
         @Operation(summary = "Update user (Admin operation)", description = "Updates an existing user's information. This is an admin operation.", security = @SecurityRequirement(name = "Bearer Authentication"))
         @ApiResponses(value = {
                         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "User updated successfully", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiResponse.class), examples = @ExampleObject(name = "Success Response", value = """
@@ -387,7 +388,7 @@ public class UserController {
         }
 
         @DeleteMapping("/{userId}")
-        @PreAuthorize("hasAnyAuthority('ROLE_SA', 'ROLE_UA', 'ROLE_SPA')")
+        @PreAuthorize("hasAnyAuthority('ROLE_SA', 'ROLE_UA')")
         @Operation(summary = "Delete user (Admin operation)", description = "Deletes a user from the system. This is an admin operation.", security = @SecurityRequirement(name = "Bearer Authentication"))
         @ApiResponses(value = {
                         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "User deleted successfully"),

--- a/smart-rent/src/main/java/com/smartrent/controller/VerifyListingController.java
+++ b/smart-rent/src/main/java/com/smartrent/controller/VerifyListingController.java
@@ -32,7 +32,7 @@ public class VerifyListingController {
     VerifyListingService verifyListingService;
 
     @PutMapping("/{listingId}/status")
-    @PreAuthorize("hasAnyAuthority('ROLE_SA', 'ROLE_UA', 'ROLE_SPA')")
+    @PreAuthorize("hasAnyAuthority('ROLE_SA', 'ROLE_CM')")
     @Operation(
         summary = "Change listing verification status",
         description = """


### PR DESCRIPTION
## What
Aligns `@PreAuthorize` across the admin controllers with the 6-role model — **SA / UA / CM / SPA / FA / MA** — so backend access matches the admin console's page permissions instead of relying on UI hiding. Several admin controllers were previously reachable by **any authenticated user** (including regular `ROLE_USER`).

## Endpoint authorization
| Controller / endpoint | Roles |
|---|---|
| `RoleController` (view) | SA, UA |
| `RoleController` (create/update/delete) | SA |
| `AdminAnalyticsController` /users | SA, UA, SPA, MA |
| `AdminAnalyticsController` /listings | SA, CM, MA |
| `AdminAnalyticsController` /revenue, /reports, /memberships | SA, FA, MA |
| `AdminTransactionController` | SA, SPA, FA |
| `AdminMembershipController` (view) | SA, SPA, FA, MA |
| `AdminMembershipController` (mutate packages) | SA, FA, MA |
| `AdminListingReportController` | SA, CM, SPA |
| `AdminReportedAuthorController` | SA, CM, SPA |
| `AdminBrokerController` (pending list / verify) | SA, CM, SPA |
| `AdminNewsController`, `AdminMediaController` | SA, CM, MA |
| `ListingAdminController`, `VerifyListingController` | SA, CM |
| `UserController` GET /list | SA, UA, SPA |
| `UserController` PUT/DELETE user | SA, UA |

## Notable fixes
- **Closed open endpoints**: `RoleController`, `AdminAnalyticsController`, `AdminNewsController`, `AdminListingReportController`, `ListingAdminController`, and `UserController` GET /list had no authorization.
- **Cross-page actions**: "remove broker" (`AdminBrokerController`) and "clear user membership" (`AdminMembershipController`) are triggered from the Users page, so they follow user-management write access (**SA, UA**) rather than their controller's default.
- Roles come from the JWT `scope` claim as `ROLE_<role_id>`, so `hasAnyAuthority('ROLE_SA', …)` matches directly.

## Notes
- Companion frontend PR: `Shungisme/smartrent-fe#82` (sidebar + page-action gating for the same matrix).
- `AdminController` is intentionally left as-is: admin-account writes stay **SA-only** (prevents User Admin from minting a Super Admin).

## Testing
- `./gradlew compileJava` passes.
- Manual: call each admin endpoint with a token per role and confirm 200 vs 403 against the table above.