### PR TITLE
fix: block-eligibility uses total reports; block resubmit too

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/controller/AdminReportedAuthorController.java
+++ b/smart-rent/src/main/java/com/smartrent/controller/AdminReportedAuthorController.java
@@ -54,7 +54,7 @@ public class AdminReportedAuthorController {
             @RequestParam(required = false) String name,
             @Parameter(description = "Filter by phone number (prefix)")
             @RequestParam(required = false) String phone,
-            @Parameter(description = "Filter by block eligibility: true = enough approved reports (> 3), false = not yet")
+            @Parameter(description = "Filter by block eligibility: true = enough total reports (> 3), false = not yet")
             @RequestParam(required = false) Boolean blockEligible,
             @Parameter(description = "Page number (1-indexed)", example = "1")
             @RequestParam(defaultValue = "1") int page,

--- a/smart-rent/src/main/java/com/smartrent/infra/repository/ListingReportRepository.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/ListingReportRepository.java
@@ -103,16 +103,12 @@ public interface ListingReportRepository extends JpaRepository<ListingReport, Lo
     long countByCreatedAtBefore(LocalDateTime dateTime);
 
     /**
-     * Aggregate reports per listing author (người đăng tin). Each row is one author who
-     * has at least one report on any of their listings, with total and admin-approved
-     * (RESOLVED) report counts. Ordered by most approved reports first.
-     */
-    /**
      * Reported authors with optional filters. Empty-string text filters and a
      * {@code blockEligibleFlag} of -1 mean "no filter" (sentinels avoid binding
      * nulls in a native query). {@code blockEligibleFlag}: -1 all, 1 eligible
-     * (resolved &gt; threshold), 0 not eligible. Text filters are prefix matches so
-     * they can use the users indexes.
+     * (total reports &gt; threshold), 0 not eligible. Eligibility is based on the
+     * TOTAL report count (any status), matching {@code ReportedAuthorServiceImpl}.
+     * Text filters are prefix matches so they can use the users indexes.
      */
     @Query(value = "SELECT l.user_id AS userId, " +
             "CAST(COUNT(*) AS SIGNED) AS totalReports, " +
@@ -125,8 +121,8 @@ public interface ListingReportRepository extends JpaRepository<ListingReport, Lo
             "AND (:phone = '' OR u.phone_number LIKE CONCAT(:phone, '%')) " +
             "GROUP BY l.user_id " +
             "HAVING (:blockEligibleFlag = -1 " +
-            "  OR (:blockEligibleFlag = 1 AND SUM(CASE WHEN r.status = 'RESOLVED' THEN 1 ELSE 0 END) > :threshold) " +
-            "  OR (:blockEligibleFlag = 0 AND SUM(CASE WHEN r.status = 'RESOLVED' THEN 1 ELSE 0 END) <= :threshold)) " +
+            "  OR (:blockEligibleFlag = 1 AND COUNT(*) > :threshold) " +
+            "  OR (:blockEligibleFlag = 0 AND COUNT(*) <= :threshold)) " +
             "ORDER BY resolvedReports DESC, totalReports DESC",
             countQuery = "SELECT COUNT(*) FROM (" +
                     "SELECT l.user_id " +
@@ -138,8 +134,8 @@ public interface ListingReportRepository extends JpaRepository<ListingReport, Lo
                     "AND (:phone = '' OR u.phone_number LIKE CONCAT(:phone, '%')) " +
                     "GROUP BY l.user_id " +
                     "HAVING (:blockEligibleFlag = -1 " +
-                    "  OR (:blockEligibleFlag = 1 AND SUM(CASE WHEN r.status = 'RESOLVED' THEN 1 ELSE 0 END) > :threshold) " +
-                    "  OR (:blockEligibleFlag = 0 AND SUM(CASE WHEN r.status = 'RESOLVED' THEN 1 ELSE 0 END) <= :threshold))" +
+                    "  OR (:blockEligibleFlag = 1 AND COUNT(*) > :threshold) " +
+                    "  OR (:blockEligibleFlag = 0 AND COUNT(*) <= :threshold))" +
                     ") x",
             nativeQuery = true)
     Page<ReportedAuthorProjection> findReportedAuthors(

--- a/smart-rent/src/main/java/com/smartrent/service/moderation/impl/ListingModerationServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/moderation/impl/ListingModerationServiceImpl.java
@@ -64,6 +64,7 @@ public class ListingModerationServiceImpl implements ListingModerationService {
     MediaRepository mediaRepository;
     AdminRepository adminRepository;
     UserRepository userRepository;
+    com.smartrent.service.listing.PostingAccessGuard postingAccessGuard;
     ListingMapper listingMapper;
     UserMapper userMapper;
     EmailService emailService;
@@ -314,6 +315,9 @@ public class ListingModerationServiceImpl implements ListingModerationService {
             throw new DomainException(DomainCode.NOT_LISTING_OWNER);
         }
 
+        // Resubmitting re-lists the listing for review — block barred users
+        postingAccessGuard.ensureCanPost(userId);
+
         // A listing removed for a confirmed violation can never be resubmitted
         if (Boolean.TRUE.equals(listing.getPermanentlyRemoved())) {
             throw new DomainException(DomainCode.RESUBMIT_NOT_ALLOWED);
@@ -410,6 +414,9 @@ public class ListingModerationServiceImpl implements ListingModerationService {
         if (!listing.getUserId().equals(userId)) {
             throw new DomainException(DomainCode.NOT_LISTING_OWNER);
         }
+
+        // Resubmitting re-lists the listing for review — block barred users
+        postingAccessGuard.ensureCanPost(userId);
 
         // A listing removed for a confirmed violation can never be resubmitted
         if (Boolean.TRUE.equals(listing.getPermanentlyRemoved())) {

--- a/smart-rent/src/main/java/com/smartrent/service/report/ReportedAuthorService.java
+++ b/smart-rent/src/main/java/com/smartrent/service/report/ReportedAuthorService.java
@@ -13,7 +13,7 @@ import java.util.List;
  */
 public interface ReportedAuthorService {
 
-    /** Number of admin-approved (RESOLVED) reports beyond which an author becomes block-eligible. */
+    /** Total number of reports (any status) beyond which an author becomes block-eligible. */
     int BLOCK_ELIGIBLE_THRESHOLD = 3;
 
     /**

--- a/smart-rent/src/main/java/com/smartrent/service/report/impl/ReportedAuthorServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/report/impl/ReportedAuthorServiceImpl.java
@@ -157,7 +157,7 @@ public class ReportedAuthorServiceImpl implements ReportedAuthorService {
                     .userId(projection.getUserId())
                     .totalReports(total)
                     .resolvedReports(resolved)
-                    .blockEligible(resolved > BLOCK_ELIGIBLE_THRESHOLD)
+                    .blockEligible(total > BLOCK_ELIGIBLE_THRESHOLD)
                     .postingBlocked(false)
                     .build();
         }
@@ -174,7 +174,7 @@ public class ReportedAuthorServiceImpl implements ReportedAuthorService {
                 .avatarUrl(user.getAvatarUrl())
                 .totalReports(total)
                 .resolvedReports(resolved)
-                .blockEligible(resolved > BLOCK_ELIGIBLE_THRESHOLD)
+                .blockEligible(total > BLOCK_ELIGIBLE_THRESHOLD)
                 .postingBlocked(user.isPostingBlocked())
                 .postingBlockedReason(user.getPostingBlockedReason())
                 .postingBlockedAt(user.getPostingBlockedAt())


### PR DESCRIPTION
- Fix mismatch: eligibility (>3) is now based on TOTAL reports everywhere (query HAVING filter + response field), not just admin-approved ones — this was causing the blockEligible filter to return inconsistent results
- Resubmitting a listing (resubmitForReview / updateAndResubmitForReview) now also goes through PostingAccessGuard, so a blocked user can't get back into rotation via "Gửi lại duyệt" either