### PR TITLE
fix: admin reported-authors list shows contact phone, not signup phone

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/service/report/impl/ReportedAuthorServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/report/impl/ReportedAuthorServiceImpl.java
@@ -170,7 +170,7 @@ public class ReportedAuthorServiceImpl implements ReportedAuthorService {
                 .firstName(user.getFirstName())
                 .lastName(user.getLastName())
                 .email(user.getEmail())
-                .phoneNumber(user.getPhoneNumber())
+                .phoneNumber(user.getContactPhoneNumber() != null ? user.getContactPhoneNumber() : user.getPhoneNumber())
                 .avatarUrl(user.getAvatarUrl())
                 .totalReports(total)
                 .resolvedReports(resolved)


### PR DESCRIPTION
The seller edit page (/sellernet/personal/edit) writes to User.contactPhoneNumber, but the admin moderation/authors list was reading User.phoneNumber (the signup/OTP phone), so seller phone updates never appeared in admin.