### PR TITLE
fix: resolve legacy news author name instead of showing raw admin ID

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/controller/AdminNewsController.java
+++ b/smart-rent/src/main/java/com/smartrent/controller/AdminNewsController.java
@@ -69,7 +69,7 @@ public class AdminNewsController {
                 // Resolve the admin's display name from the database, falling back to the
                 // admin ID only if the record cannot be found
                 String adminName = adminRepository.findById(adminId)
-                                .map(AdminNewsController::buildAdminName)
+                                .map(Admin::getDisplayName)
                                 .orElse(adminId);
 
                 log.info("POST /v1/admin/news - Creating news by admin: {}", adminId);
@@ -217,10 +217,4 @@ public class AdminNewsController {
                                 .build();
         }
 
-        private static String buildAdminName(Admin admin) {
-                String firstName = admin.getFirstName() != null ? admin.getFirstName().trim() : "";
-                String lastName = admin.getLastName() != null ? admin.getLastName().trim() : "";
-                String fullName = (firstName + " " + lastName).trim();
-                return fullName.isEmpty() ? admin.getEmail() : fullName;
-        }
 }

--- a/smart-rent/src/main/java/com/smartrent/infra/repository/entity/Admin.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/entity/Admin.java
@@ -52,4 +52,15 @@ public class Admin extends AbstractUser {
   )
   List<Role> roles;
 
+  /**
+   * Human-readable display name, falling back to the admin's email when
+   * first/last name are unavailable.
+   */
+  public String getDisplayName() {
+    String firstName = getFirstName() != null ? getFirstName().trim() : "";
+    String lastName = getLastName() != null ? getLastName().trim() : "";
+    String fullName = (firstName + " " + lastName).trim();
+    return fullName.isEmpty() ? getEmail() : fullName;
+  }
+
 }

--- a/smart-rent/src/main/java/com/smartrent/service/news/impl/NewsServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/news/impl/NewsServiceImpl.java
@@ -11,7 +11,9 @@ import com.smartrent.enums.NewsCategory;
 import com.smartrent.enums.NewsStatus;
 import com.smartrent.infra.exception.AppException;
 import com.smartrent.infra.exception.model.DomainCode;
+import com.smartrent.infra.repository.AdminRepository;
 import com.smartrent.infra.repository.NewsRepository;
+import com.smartrent.infra.repository.entity.Admin;
 import com.smartrent.infra.repository.entity.News;
 import com.smartrent.mapper.NewsMapper;
 import com.smartrent.service.news.NewsService;
@@ -37,6 +39,7 @@ public class NewsServiceImpl implements NewsService {
 
     private final NewsRepository newsRepository;
     private final NewsMapper newsMapper;
+    private final AdminRepository adminRepository;
 
     @Override
     @Transactional(readOnly = true)
@@ -340,7 +343,11 @@ public class NewsServiceImpl implements NewsService {
         }
 
         List<NewsSummaryResponse> newsList = newsPage.getContent().stream()
-                .map(newsMapper::toSummaryResponse)
+                .map(news -> {
+                    NewsSummaryResponse response = newsMapper.toSummaryResponse(news);
+                    response.setAuthorName(resolveAuthorName(news.getAuthorId(), news.getAuthorName()));
+                    return response;
+                })
                 .collect(Collectors.toList());
 
         return NewsListResponse.builder()
@@ -360,10 +367,29 @@ public class NewsServiceImpl implements NewsService {
         News news = newsRepository.findById(newsId)
                 .orElseThrow(() -> new AppException(DomainCode.NEWS_NOT_FOUND));
 
-        return newsMapper.toResponse(news);
+        NewsResponse response = newsMapper.toResponse(news);
+        response.setAuthorName(resolveAuthorName(news.getAuthorId(), news.getAuthorName()));
+        return response;
     }
 
     // ========== Helper Methods ==========
+
+    /**
+     * Legacy news rows created before author names were resolved on write may have
+     * their author_name column stored as the raw admin ID. Repair that here so the
+     * admin UI always shows a display name instead of an ID.
+     */
+    private String resolveAuthorName(String authorId, String authorName) {
+        if (authorId == null) {
+            return authorName;
+        }
+        if (authorName == null || authorName.isBlank() || authorName.equals(authorId)) {
+            return adminRepository.findById(authorId)
+                    .map(Admin::getDisplayName)
+                    .orElse(authorName);
+        }
+        return authorName;
+    }
 
     /**
      * Generate URL-friendly slug from title


### PR DESCRIPTION
News created before the author-name-resolution fix (962614e) had their author_name column persisted as the raw admin ID, so the admin news list still displays IDs instead of names for those older rows. Repair the value on read in NewsServiceImpl (getAllNews/getNewsById) by resolving it from AdminRepository whenever the stored name is blank or equals the author ID. Also dedupes the admin display-name logic into Admin.getDisplayName().