### PR TITLE
fix: block-eligibility must use admin-approved reports, not total

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/infra/exception/UserNotBlockEligibleException.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/exception/UserNotBlockEligibleException.java
@@ -1,0 +1,10 @@
+package com.smartrent.infra.exception;
+
+import com.smartrent.infra.exception.model.DomainCode;
+
+public class UserNotBlockEligibleException extends DomainException {
+
+  public UserNotBlockEligibleException(int threshold, long resolvedReports) {
+    super(DomainCode.USER_NOT_BLOCK_ELIGIBLE, threshold, resolvedReports);
+  }
+}

--- a/smart-rent/src/main/java/com/smartrent/infra/exception/model/DomainCode.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/exception/model/DomainCode.java
@@ -153,7 +153,9 @@ public enum DomainCode {
   LISTING_REPORT_NOT_AVAILABLE("22001", HttpStatus.BAD_REQUEST, "Listing is no longer available and cannot be reported"),
   //    User Posting Block Error 23xxx
   USER_POSTING_BLOCKED("23001", HttpStatus.FORBIDDEN,
-      "Tài khoản của bạn đã bị chặn đăng tin do có nhiều tin vi phạm bị báo cáo. Vui lòng liên hệ quản trị viên để được hỗ trợ.")
+      "Tài khoản của bạn đã bị chặn đăng tin do có nhiều tin vi phạm bị báo cáo. Vui lòng liên hệ quản trị viên để được hỗ trợ."),
+  USER_NOT_BLOCK_ELIGIBLE("23002", HttpStatus.BAD_REQUEST,
+      "Người dùng chưa đủ điều kiện bị chặn đăng tin. Cần trên %d report đã được admin duyệt, hiện tại chỉ có %d.")
   ;
 
   private final String value;

--- a/smart-rent/src/main/java/com/smartrent/infra/repository/ListingReportRepository.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/ListingReportRepository.java
@@ -106,8 +106,9 @@ public interface ListingReportRepository extends JpaRepository<ListingReport, Lo
      * Reported authors with optional filters. Empty-string text filters and a
      * {@code blockEligibleFlag} of -1 mean "no filter" (sentinels avoid binding
      * nulls in a native query). {@code blockEligibleFlag}: -1 all, 1 eligible
-     * (total reports &gt; threshold), 0 not eligible. Eligibility is based on the
-     * TOTAL report count (any status), matching {@code ReportedAuthorServiceImpl}.
+     * (resolved reports &gt; threshold), 0 not eligible. Eligibility is based on
+     * the RESOLVED (admin-approved) report count only, matching
+     * {@code ReportedAuthorServiceImpl}.
      * Text filters are prefix matches so they can use the users indexes.
      */
     @Query(value = "SELECT l.user_id AS userId, " +
@@ -121,8 +122,8 @@ public interface ListingReportRepository extends JpaRepository<ListingReport, Lo
             "AND (:phone = '' OR u.phone_number LIKE CONCAT(:phone, '%')) " +
             "GROUP BY l.user_id " +
             "HAVING (:blockEligibleFlag = -1 " +
-            "  OR (:blockEligibleFlag = 1 AND COUNT(*) > :threshold) " +
-            "  OR (:blockEligibleFlag = 0 AND COUNT(*) <= :threshold)) " +
+            "  OR (:blockEligibleFlag = 1 AND SUM(CASE WHEN r.status = 'RESOLVED' THEN 1 ELSE 0 END) > :threshold) " +
+            "  OR (:blockEligibleFlag = 0 AND SUM(CASE WHEN r.status = 'RESOLVED' THEN 1 ELSE 0 END) <= :threshold)) " +
             "ORDER BY resolvedReports DESC, totalReports DESC",
             countQuery = "SELECT COUNT(*) FROM (" +
                     "SELECT l.user_id " +
@@ -134,8 +135,8 @@ public interface ListingReportRepository extends JpaRepository<ListingReport, Lo
                     "AND (:phone = '' OR u.phone_number LIKE CONCAT(:phone, '%')) " +
                     "GROUP BY l.user_id " +
                     "HAVING (:blockEligibleFlag = -1 " +
-                    "  OR (:blockEligibleFlag = 1 AND COUNT(*) > :threshold) " +
-                    "  OR (:blockEligibleFlag = 0 AND COUNT(*) <= :threshold))" +
+                    "  OR (:blockEligibleFlag = 1 AND SUM(CASE WHEN r.status = 'RESOLVED' THEN 1 ELSE 0 END) > :threshold) " +
+                    "  OR (:blockEligibleFlag = 0 AND SUM(CASE WHEN r.status = 'RESOLVED' THEN 1 ELSE 0 END) <= :threshold))" +
                     ") x",
             nativeQuery = true)
     Page<ReportedAuthorProjection> findReportedAuthors(

--- a/smart-rent/src/main/java/com/smartrent/service/report/ReportedAuthorService.java
+++ b/smart-rent/src/main/java/com/smartrent/service/report/ReportedAuthorService.java
@@ -13,7 +13,7 @@ import java.util.List;
  */
 public interface ReportedAuthorService {
 
-    /** Total number of reports (any status) beyond which an author becomes block-eligible. */
+    /** Number of admin-approved (RESOLVED) reports beyond which an author becomes block-eligible. */
     int BLOCK_ELIGIBLE_THRESHOLD = 3;
 
     /**

--- a/smart-rent/src/main/java/com/smartrent/service/report/impl/ReportedAuthorServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/report/impl/ReportedAuthorServiceImpl.java
@@ -8,6 +8,7 @@ import com.smartrent.dto.response.ReportedAuthorResponse;
 import com.smartrent.enums.NotificationType;
 import com.smartrent.enums.RecipientType;
 import com.smartrent.enums.ReportStatus;
+import com.smartrent.infra.exception.UserNotBlockEligibleException;
 import com.smartrent.infra.exception.UserNotFoundException;
 import com.smartrent.infra.repository.AdminRepository;
 import com.smartrent.infra.repository.ListingReportRepository;
@@ -104,8 +105,16 @@ public class ReportedAuthorServiceImpl implements ReportedAuthorService {
     public ReportedAuthorResponse setPostingBlock(String userId, PostingBlockRequest request, String adminId) {
         User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
 
+        // Single combined query instead of one per status (faster toggle)
+        ReportedAuthorProjection.Counts counts = listingReportRepository.getReportCountsByAuthor(userId);
+        long totalReports = counts != null && counts.getTotalReports() != null ? counts.getTotalReports() : 0L;
+        long resolvedReports = counts != null && counts.getResolvedReports() != null ? counts.getResolvedReports() : 0L;
+
         boolean block = Boolean.TRUE.equals(request.getBlocked());
         if (block) {
+            if (resolvedReports <= BLOCK_ELIGIBLE_THRESHOLD) {
+                throw new UserNotBlockEligibleException(BLOCK_ELIGIBLE_THRESHOLD, resolvedReports);
+            }
             user.setPostingBlocked(true);
             user.setPostingBlockedReason(request.getReason());
             user.setPostingBlockedByAdminId(adminId);
@@ -139,10 +148,6 @@ public class ReportedAuthorServiceImpl implements ReportedAuthorService {
             );
         }
 
-        // Single combined query instead of one per status (faster toggle)
-        ReportedAuthorProjection.Counts counts = listingReportRepository.getReportCountsByAuthor(userId);
-        long totalReports = counts != null && counts.getTotalReports() != null ? counts.getTotalReports() : 0L;
-        long resolvedReports = counts != null && counts.getResolvedReports() != null ? counts.getResolvedReports() : 0L;
         return buildResponse(user, totalReports, resolvedReports);
     }
 
@@ -157,7 +162,7 @@ public class ReportedAuthorServiceImpl implements ReportedAuthorService {
                     .userId(projection.getUserId())
                     .totalReports(total)
                     .resolvedReports(resolved)
-                    .blockEligible(total > BLOCK_ELIGIBLE_THRESHOLD)
+                    .blockEligible(resolved > BLOCK_ELIGIBLE_THRESHOLD)
                     .postingBlocked(false)
                     .build();
         }
@@ -174,7 +179,7 @@ public class ReportedAuthorServiceImpl implements ReportedAuthorService {
                 .avatarUrl(user.getAvatarUrl())
                 .totalReports(total)
                 .resolvedReports(resolved)
-                .blockEligible(total > BLOCK_ELIGIBLE_THRESHOLD)
+                .blockEligible(resolved > BLOCK_ELIGIBLE_THRESHOLD)
                 .postingBlocked(user.isPostingBlocked())
                 .postingBlockedReason(user.getPostingBlockedReason())
                 .postingBlockedAt(user.getPostingBlockedAt())


### PR DESCRIPTION
blockEligible was flipped to use TOTAL report count in a prior commit, but the admin UI hint ("Cần trên 3 report đã duyệt") and product intent require eligibility to be based on RESOLVED (admin-approved) reports only — an author shouldn't become block-eligible from pending/rejected reports alone.

- findReportedAuthors HAVING filter and blockEligible response field now key off resolved report count again
- setPostingBlock now rejects blocking server-side when resolved reports are at/below the threshold, so the rule holds even if called directly (not just via the disabled UI button)