### PR TITLE
fix: DISPLAYING status filter excludes listings expiring within 7 days

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/infra/repository/specification/ListingSpecification.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/specification/ListingSpecification.java
@@ -888,7 +888,15 @@ public class ListingSpecification {
                 );
 
             case DISPLAYING ->
-                // verified = true AND NOT expired AND expiryDate > now
+                // verified = true AND NOT expired AND expiryDate > now.
+                // Intentionally includes listings expiring within 7 days (EXPIRING_SOON
+                // per Listing.computeListingStatus()) -- they are still publicly live
+                // (public visibility only gates on moderationStatus=APPROVED + not
+                // expired), so the seller's "Đang hiển thị" tab must keep showing them.
+                // What must NOT happen is per-row actions (push, detail link) silently
+                // disagreeing with that -- see PushServiceImpl.validateListingCanBePushed
+                // and the listing-card DISPLAYING/EXPIRING_SOON checks, which both treat
+                // the two statuses as equally "displaying".
                 criteriaBuilder.and(
                     criteriaBuilder.isTrue(root.get("verified")),
                     criteriaBuilder.isFalse(root.get("expired")),

--- a/smart-rent/src/main/java/com/smartrent/service/push/impl/PushServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/push/impl/PushServiceImpl.java
@@ -580,7 +580,11 @@ public class PushServiceImpl implements PushService {
 
     private void validateListingCanBePushed(Listing listing) {
         ListingStatus listingStatus = listing.computeListingStatus();
-        if (listingStatus != ListingStatus.DISPLAYING) {
+        // EXPIRING_SOON listings are still publicly live (see
+        // ListingSpecification.buildStatusPredicate(DISPLAYING)) -- pushing them is
+        // if anything more useful, since the seller is trying to keep visibility
+        // right before expiry. Only genuinely non-live statuses are rejected.
+        if (listingStatus != ListingStatus.DISPLAYING && listingStatus != ListingStatus.EXPIRING_SOON) {
             throw new RuntimeException("Only displaying listings can be pushed. Current status: " + listingStatus);
         }
     }


### PR DESCRIPTION
buildStatusPredicate(DISPLAYING) only checked verified/expired/expiryDate>now, missing the 7-day carve-out that Listing.computeListingStatus() applies when classifying a row as EXPIRING_SOON instead of DISPLAYING. This let the seller listings page (listingStatus=DISPLAYING&moderationStatus=APPROVED) return rows whose actual listingStatus field was EXPIRING_SOON, so the FE's push/boost button and detail-page link (both gated on listingStatus === DISPLAYING) silently disappeared for listings that were still shown as active.