### PR TITLE
fix: restore PAYOS as a legacy PaymentProvider enum constant

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/enums/PaymentProvider.java
+++ b/smart-rent/src/main/java/com/smartrent/enums/PaymentProvider.java
@@ -19,7 +19,18 @@ public enum PaymentProvider {
      * SePay migration can still be read. No provider bean is registered for it,
      * so it must not be used to initiate new payments.
      */
-    VNPAY("vnpay", "VNPay Payment Gateway (legacy)");
+    VNPAY("vnpay", "VNPay Payment Gateway (legacy)"),
+
+    /**
+     * Legacy provider — PayOS was the default gateway before the SePay
+     * migration (see V88/V89). Kept only so historical transactions created
+     * during that window can still be read (@Enumerated(EnumType.STRING) on
+     * Transaction.paymentProvider throws IllegalArgumentException on any DB
+     * value with no matching constant, breaking GET /v1/me/transactions for
+     * any user with an old PayOS transaction). No provider bean is registered
+     * for it, so it must not be used to initiate new payments.
+     */
+    PAYOS("payos", "PayOS Payment Gateway (legacy)");
 
     String code;
     String displayName;

--- a/smart-rent/src/main/java/com/smartrent/service/payment/impl/PaymentServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/payment/impl/PaymentServiceImpl.java
@@ -240,8 +240,9 @@ public class PaymentServiceImpl implements PaymentService {
             case PAYPAL -> params.get("token");
             case MOMO -> params.get("orderId");
             case ZALOPAY -> params.get("apptransid");
-            // Legacy provider; no new callbacks expected, but kept for exhaustiveness.
+            // Legacy providers; no new callbacks expected, but kept for exhaustiveness.
             case VNPAY -> params.get("vnp_TxnRef");
+            case PAYOS -> params.get("orderCode");
         };
     }
 


### PR DESCRIPTION
GET /v1/me/transactions (and any other read of a Transaction row) threw "No enum constant com.smartrent.enums.PaymentProvider.PAYOS" for any user with a transaction created while PAYOS was still the default gateway (see V88__Add_payos_to_payment_provider_enum.sql, before the V89 SePay migration). Transaction.paymentProvider is @Enumerated(EnumType.STRING), so Hibernate calls PaymentProvider.valueOf() on every row it hydrates — a DB value with no matching Java constant crashes the whole listing query, not just that one row.

VNPAY was already kept around as a documented legacy constant for the same reason; PAYOS needs the same treatment. No provider bean is registered for it, so PaymentProviderFactory still rejects it for new payments (matching VNPAY's behavior) — this only fixes reading old rows.