### PR TITLE
fix: totalSaves in saves-trend now respects the period filter

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/infra/repository/SavedListingRepository.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/SavedListingRepository.java
@@ -71,6 +71,8 @@ public interface SavedListingRepository extends JpaRepository<SavedListing, Save
 
     long countByIdListingId(Long listingId);
 
+    long countByIdListingIdAndCreatedAtGreaterThanEqual(Long listingId, LocalDateTime since);
+
     @Query(value = "SELECT DATE(sl.created_at) AS save_date, COUNT(*) AS save_count " +
             "FROM saved_listings sl " +
             "WHERE sl.listing_id = :listingId AND sl.created_at >= :since " +

--- a/smart-rent/src/main/java/com/smartrent/service/analytics/impl/AnalyticsServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/analytics/impl/AnalyticsServiceImpl.java
@@ -132,12 +132,13 @@ public class AnalyticsServiceImpl implements AnalyticsService {
             throw new RuntimeException("You are not the owner of this listing");
         }
 
-        long totalSaves = savedListingRepository.countByIdListingId(listingId);
-
+        long totalSaves;
         List<Object[]> rawData;
         if (since != null) {
+            totalSaves = savedListingRepository.countByIdListingIdAndCreatedAtGreaterThanEqual(listingId, since);
             rawData = savedListingRepository.countSavesGroupedByDateSince(listingId, since);
         } else {
+            totalSaves = savedListingRepository.countByIdListingId(listingId);
             rawData = savedListingRepository.countSavesGroupedByDate(listingId);
         }
 


### PR DESCRIPTION
totalSaves was always all-time while savesOverTime was filtered by since, so a listing could show totalSaves > 0 with an empty savesOverTime chart for the selected period.