### PR TITLE
fix: restore VIEW_MILESTONE as a legacy NotificationType enum constant

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/enums/NotificationType.java
+++ b/smart-rent/src/main/java/com/smartrent/enums/NotificationType.java
@@ -42,5 +42,12 @@ public enum NotificationType {
      * throws IllegalArgumentException and breaks GET /v1/notifications for that
      * user, not just the read of that one row). Kept only so old rows load.
      */
-    PHONE_CLICK
+    PHONE_CLICK,
+
+    /**
+     * Legacy — no code path creates this anymore, but historical rows with
+     * type='VIEW_MILESTONE' still exist in the notifications table, same
+     * failure mode as PHONE_CLICK above. Kept only so old rows load.
+     */
+    VIEW_MILESTONE
 }


### PR DESCRIPTION
GET /v1/notifications threw "No enum constant
com.smartrent.enums.NotificationType.VIEW_MILESTONE" for any recipient with a historical notification row of that type. Notification.type is @Enumerated(EnumType.STRING), so Hibernate calls NotificationType.valueOf() on every row it hydrates -- same failure mode fixed for PHONE_CLICK in #392. No current code path creates VIEW_MILESTONE notifications anymore, so this only restores readability of old rows.