### PR TITLE
fix: restore NEW_FOLLOWER as a legacy NotificationType enum constant

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/enums/NotificationType.java
+++ b/smart-rent/src/main/java/com/smartrent/enums/NotificationType.java
@@ -49,5 +49,12 @@ public enum NotificationType {
      * type='VIEW_MILESTONE' still exist in the notifications table, same
      * failure mode as PHONE_CLICK above. Kept only so old rows load.
      */
-    VIEW_MILESTONE
+    VIEW_MILESTONE,
+
+    /**
+     * Legacy — no code path creates this anymore, but historical rows with
+     * type='NEW_FOLLOWER' still exist in the notifications table, same
+     * failure mode as PHONE_CLICK above. Kept only so old rows load.
+     */
+    NEW_FOLLOWER
 }


### PR DESCRIPTION
GET /v1/notifications threw "No enum constant
com.smartrent.enums.NotificationType.NEW_FOLLOWER" for any recipient with a historical notification row of that type -- same failure mode as PHONE_CLICK (#392) and VIEW_MILESTONE. No current code path creates NEW_FOLLOWER notifications anymore (UserFollowServiceImpl.follow() only logs, it never creates a Notification), so this only restores readability of old rows.