### PR TITLE
perf(listings): sort indexes for following feed and admin moderation tabs

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/infra/repository/entity/Listing.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/entity/Listing.java
@@ -87,7 +87,24 @@ import java.util.List;
                 // ICP can filter them from index data alone (avoiding a full-row fetch for the
                 // ~half of candidates that turn out expired), then the sort columns trailing.
                 @Index(name = "idx_listings_admin_review_queue",
-                        columnList = "is_shadow, is_verify, verified, expired, moderation_status, expiry_date, vip_type_sort_order, updated_at")
+                        columnList = "is_shadow, is_verify, verified, expired, moderation_status, expiry_date, vip_type_sort_order, updated_at"),
+                // "From users I follow" feed (GET /v1/listings/my-following-feed ->
+                // findPublicListingsByUserIdIn) — always scoped to a single followed
+                // user in practice. Equality prefix (user_id + the four visibility
+                // booleans) + ordered suffix (post_date, created_at) so the feed is an
+                // index-ordered range scan instead of a filesort. Mirrors
+                // idx_listings_reco_* / idx_listings_map_bounds. Built by V108.
+                @Index(name = "idx_listings_follow_feed",
+                        columnList = "user_id, is_draft, is_shadow, verified, expired, post_date, created_at"),
+                // Admin list, moderation-status-filtered tabs (POST /v1/listings/admin/list
+                // with moderationStatus set — "Đã Duyệt"/"Từ Chối"/etc.). Equality prefix
+                // (is_shadow, moderation_status) + sort columns (vip_type_sort_order ASC,
+                // updated_at DESC — real directions built by V109) so each status tab is an
+                // ordered index range scan instead of the index_merge + 71k-row filesort
+                // (~9.3s measured) the APPROVED tab hit. Mirrors idx_listings_admin_default_sort
+                // (V100) with moderation_status inserted. Built by V109.
+                @Index(name = "idx_listings_admin_moderation_sort",
+                        columnList = "is_shadow, moderation_status, vip_type_sort_order, updated_at")
         })
 @Getter
 @Setter

--- a/smart-rent/src/main/resources/db/migration/V108__Add_following_feed_sort_index.sql
+++ b/smart-rent/src/main/resources/db/migration/V108__Add_following_feed_sort_index.sql
@@ -1,0 +1,43 @@
+-- Migration V108: the "from users I follow" feed
+-- (GET /v1/listings/my-following-feed -> getListingsFromFollowedUsers ->
+-- findPublicListingsByUserIdIn) is always scoped to a single followed user in
+-- practice, so the hot query is:
+--
+--   WHERE user_id = ? AND is_draft = 0 AND is_shadow = 0
+--         AND expired = 0 AND verified = 1
+--   ORDER BY post_date DESC, created_at DESC
+--   LIMIT ...
+--
+-- The only user_id-leading indexes are idx_user_created (user_id, created_at),
+-- idx_listings_user_draft_updated (user_id, is_draft, updated_at) and
+-- idx_listings_user_vip_updated (user_id, vip_type, updated_at). None of them
+-- orders by post_date after user_id, so the planner reads the user's rows via
+-- idx_user_created, applies the four boolean filters, then FILESORTS by
+-- (post_date, created_at) to satisfy the ORDER BY.
+--
+-- Add a dedicated index whose equality prefix (user_id + the four visibility
+-- booleans) is followed by the ORDER BY keys, so the feed becomes a single
+-- index-ordered range scan with no filesort -- mirroring idx_listings_reco_*
+-- (V97) and the map-bounds index (V98/V99). Both sort keys are DESC, so an
+-- ascending index serves them via a backward index scan on MySQL 8.
+--
+-- Idempotent via information_schema checks, matching V97-V99 style.
+-- ============================================================================
+
+-- ---------------------------------------------------------------------------
+-- 1. Create the follow-feed sort index if it does not already exist.
+-- ---------------------------------------------------------------------------
+SET @idx_exists = (SELECT COUNT(*) FROM information_schema.statistics
+                   WHERE table_schema = DATABASE()
+                     AND table_name = 'listings'
+                     AND index_name = 'idx_listings_follow_feed');
+SET @sql = IF(@idx_exists = 0,
+    'CREATE INDEX idx_listings_follow_feed ON listings (user_id, is_draft, is_shadow, verified, expired, post_date, created_at)',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- ---------------------------------------------------------------------------
+-- 2. Refresh optimizer statistics so the planner adopts the new index
+--    immediately.
+-- ---------------------------------------------------------------------------
+ANALYZE TABLE listings;

--- a/smart-rent/src/main/resources/db/migration/V109__Admin_moderation_status_sort_index.sql
+++ b/smart-rent/src/main/resources/db/migration/V109__Admin_moderation_status_sort_index.sql
@@ -1,0 +1,73 @@
+-- Migration V109: index the admin list's moderation-status-filtered browse+sort
+-- path (the "Đã Duyệt" / "Từ Chối" / etc. tabs of POST /v1/listings/admin/list).
+-- ============================================================================
+-- When an admin picks a status tab, ListingSpecification.fromFilterRequest emits
+-- (for the APPROVED / "Đã Duyệt" tab, 73k rows on prod):
+--
+--     WHERE is_shadow = 0
+--           AND moderation_status = 'APPROVED'
+--           AND verified = 1 AND expired = 0
+--           AND (expiry_date IS NULL OR expiry_date > NOW())
+--     ORDER BY vip_type_sort_order ASC, updated_at DESC
+--     LIMIT 20
+--
+-- EXPLAIN ANALYZE on prod measured this at ~9.3s. No single index fit, so the
+-- optimizer index_merge-INTERSECTED three single-column indexes
+-- (idx_status ∩ idx_is_shadow ∩ idx_listings_moderation_status → 71,591 row IDs)
+-- and then FILESORTED all 71,591 rows to return the top 20.
+--
+-- Why the existing indexes don't serve it:
+--   * idx_listings_public_cursor_default
+--       (moderation_status, is_draft, is_shadow, vip_type_sort_order ASC,
+--        updated_at DESC, listing_id DESC)
+--     has the right sort directions but leads its prefix with is_draft AFTER
+--     moderation_status. The admin status tabs do NOT constrain is_draft (the
+--     admin path deliberately leaves it unbound — see
+--     ListingSpecification line ~73), so is_draft is an unconstrained gap and
+--     the planner can't walk the sort columns through it. (This is exactly the
+--     REJECTED tab's saving grace — that tab DOES bind is_draft=0 via its
+--     listingStatus=REJECTED predicate, so cursor_default serves it with no
+--     filesort. APPROVED/DISPLAYING does not.)
+--   * idx_listings_admin_default_sort (is_shadow, vip_type_sort_order,
+--     updated_at) — no moderation_status in the prefix, and stored all-ASC, so
+--     it can't satisfy the mixed ASC/DESC order either (see V94's note).
+--
+-- Fix: mirror idx_listings_admin_default_sort (V100) with moderation_status
+-- inserted into the equality prefix and the sort columns in their REAL
+-- directions:
+--
+--     (is_shadow, moderation_status, vip_type_sort_order ASC, updated_at DESC)
+--
+-- Both leading columns are pure equality for every status tab ⇒ an ordered
+-- index range scan on (is_shadow=0, moderation_status=?) that yields
+-- vip_type_sort_order ASC / updated_at DESC directly — no index_merge, no
+-- filesort, O(LIMIT). verified / expired / expiry_date remain residual filters
+-- (near-100% hit rate for APPROVED, so the LIMIT fills within a few tens of
+-- rows). Serves every moderation-status tab (APPROVED, REVISION_REQUIRED,
+-- SUSPENDED, …), not just APPROVED.
+--
+-- The mixed ASC/DESC order needs a descending index column, honoured only on
+-- MySQL 8.0+ (this project targets MySQL 8 — same basis as V94). On older
+-- engines the DESC keyword is ignored and the query falls back to filesort,
+-- i.e. no worse than today.
+--
+-- The pagination COUNT keeps using the covering idx_listings_admin_review_queue
+-- (this index isn't covering for verified/expired, so the optimizer won't
+-- adopt it there) — no count regression; the ~9.3s was the ORDER BY data query.
+--
+-- Idempotent via information_schema check, matching the V94-V108 style.
+-- ============================================================================
+
+SET @idx_exists = (SELECT COUNT(*) FROM information_schema.statistics
+                   WHERE table_schema = DATABASE()
+                     AND table_name = 'listings'
+                     AND index_name = 'idx_listings_admin_moderation_sort');
+SET @sql = IF(@idx_exists = 0,
+    'CREATE INDEX idx_listings_admin_moderation_sort ON listings (is_shadow, moderation_status, vip_type_sort_order ASC, updated_at DESC)',
+    'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- Refresh optimizer statistics so the planner adopts the new index immediately.
+ANALYZE TABLE listings;


### PR DESCRIPTION
## What

Two index-only, idempotent migrations that replace filesorts with index-ordered range scans on `listings`.

### V108 `idx_listings_follow_feed`
`(user_id, is_draft, is_shadow, verified, expired, post_date, created_at)`

The `/following` feed (`getListingsFromFollowedUsers` -> `findPublicListingsByUserIdIn`) is always scoped to a single followed user and sorts `post_date DESC, created_at DESC`. No `user_id`-leading index supported that order, so the query filesorted. Equality prefix + ordered suffix makes it an index-ordered range scan.

### V109 `idx_listings_admin_moderation_sort`
`(is_shadow, moderation_status, vip_type_sort_order ASC, updated_at DESC)`

The admin moderation-status tabs (`POST /v1/listings/admin/list`). `EXPLAIN ANALYZE` on prod measured the **APPROVED tab (73k rows) at ~9.3s**:

```
Limit: 20  (actual time=9342..9342 rows=20)
  Sort: vip_type_sort_order, updated_at DESC  (actual time=9342..9342)
    Filter: is_shadow=0 AND ... moderation_status='APPROVED'  (rows=71591)
      Intersect rows sorted by row ID  (rows=71591)
        idx_status ∩ idx_is_shadow ∩ idx_listings_moderation_status
```

`is_draft` is unbound on that path, so `idx_listings_public_cursor_default`'s prefix breaks and the optimizer index_merge-intersected three single-column indexes, then filesorted 71,591 rows. The `DESC` on `updated_at` is load-bearing — the sort is mixed `vip ASC, updated DESC`, which an all-ascending index cannot serve on MySQL 8 (same basis as V94). The REJECTED tab was already fine (`cursor_default` fully bound).

## Notes

- Both guard on `information_schema`, so a **manual prod `CREATE INDEX` and the deployed migration coexist without conflict** (the migration no-ops if the index already exists).
- The admin query is a JPA `Specification` (no `FORCE INDEX`), so **optimizer adoption must be confirmed with `EXPLAIN ANALYZE` after deploy**. If it still shows a `Sort` node, the escalation is a native `FORCE INDEX` fast-path mirroring `findAdminPendingReviewQueueIds` (V102).
- Numbered V108/V109 (main already has V107). No functional/behavioral change — indexes only.

## Verify after deploy

```sql
EXPLAIN ANALYZE
SELECT l.* FROM listings l
WHERE l.moderation_status='APPROVED' AND l.verified=1 AND l.expired=0
  AND (l.expiry_date IS NULL OR l.expiry_date > NOW()) AND l.is_shadow=0
ORDER BY l.vip_type_sort_order ASC, l.updated_at DESC LIMIT 20;
-- PASS: key = idx_listings_admin_moderation_sort, no Sort/index_merge, ms not seconds.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
