### PR TITLE
perf(reco): IDs-only recently-viewed read + interactions split-timing

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/service/recentlyviewed/RecentlyViewedService.java
+++ b/smart-rent/src/main/java/com/smartrent/service/recentlyviewed/RecentlyViewedService.java
@@ -28,4 +28,13 @@ public interface RecentlyViewedService {
      * @return List of recently viewed listings sorted by most recent (up to 20 listings)
      */
     List<RecentlyViewedItemResponse> getRecentlyViewed(String userId);
+
+    /**
+     * Ordered recently-viewed listing IDs (most recent first) straight from the
+     * Redis ZSET, WITHOUT hydrating listing details. For internal callers (e.g.
+     * recommendations) that only need the IDs and their recency order — avoids
+     * the getDisplayingListingsByIds full-DTO build of up to 20 listings.
+     * @return listing IDs, most recent first (empty if none)
+     */
+    List<Long> getRecentlyViewedIds(String userId);
 }

--- a/smart-rent/src/main/java/com/smartrent/service/recentlyviewed/impl/RecentlyViewedServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/recentlyviewed/impl/RecentlyViewedServiceImpl.java
@@ -165,6 +165,31 @@ public class RecentlyViewedServiceImpl implements RecentlyViewedService {
         return result;
     }
 
+    @Override
+    public List<Long> getRecentlyViewedIds(String userId) {
+        String redisKey = buildKey(userId);
+
+        // ZREVRANGE returns the top MAX_LISTINGS listing IDs by score (most recent
+        // first). Spring Data returns an insertion-ordered LinkedHashSet, so the
+        // recency order is preserved. No DB hydration: callers that only need the
+        // IDs skip getDisplayingListingsByIds (the full-DTO build for up to 20
+        // listings) entirely.
+        Set<String> ids = redisTemplate.opsForZSet().reverseRange(redisKey, 0, MAX_LISTINGS - 1);
+        if (ids == null || ids.isEmpty()) {
+            return new ArrayList<>();
+        }
+
+        List<Long> result = new ArrayList<>(ids.size());
+        for (String id : ids) {
+            try {
+                result.add(Long.parseLong(id));
+            } catch (NumberFormatException e) {
+                log.warn("Skipping non-numeric recently-viewed entry '{}' for user {}", id, userId);
+            }
+        }
+        return result;
+    }
+
     /**
      * Validate timestamp to prevent invalid values
      * @param listing Listing to validate

--- a/smart-rent/src/main/java/com/smartrent/service/recommendation/impl/RecommendationServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/recommendation/impl/RecommendationServiceImpl.java
@@ -2,7 +2,6 @@ package com.smartrent.service.recommendation.impl;
 
 import com.smartrent.dto.request.AIRecommendationRequest;
 import com.smartrent.dto.response.ListingResponse;
-import com.smartrent.dto.response.RecentlyViewedItemResponse;
 import com.smartrent.dto.response.RecommendationItemDto;
 import com.smartrent.dto.response.RecommendationResponse;
 import com.smartrent.infra.connector.SmartRentAiConnector;
@@ -169,8 +168,7 @@ public class RecommendationServiceImpl implements RecommendationService {
                 userInteractions.add(new AIRecommendationRequest.InteractionEntryDto(userId, lId, 2.5));
                 seenIds.add(lId);
             }
-            for (RecentlyViewedItemResponse rv : recentlyViewedService.getRecentlyViewed(userId)) {
-                Long lId = rv.getListing().getListingId();
+            for (Long lId : recentlyViewedService.getRecentlyViewedIds(userId)) {
                 if (!seenIds.contains(lId)) {
                     userInteractions.add(new AIRecommendationRequest.InteractionEntryDto(userId, lId, 1.0));
                     seenIds.add(lId);
@@ -223,9 +221,17 @@ public class RecommendationServiceImpl implements RecommendationService {
         long tStart = System.nanoTime();
         Map<Long, Double> interactionWeightMap = new LinkedHashMap<>();
         List<SavedListing> savedListings = savedListingRepository.findByUserIdOrderByCreatedAtDesc(userId);
+        long tAfterSaved = System.nanoTime();
 
         List<Long> clickedListingIds = phoneClickDetailRepository.findListingIdsByUserId(userId);
-        List<RecentlyViewedItemResponse> viewedListings = recentlyViewedService.getRecentlyViewed(userId);
+        long tAfterClicks = System.nanoTime();
+
+        // IDs-only recency read (no full-DTO hydration): this path only needs the
+        // viewed listing IDs and their order below, so getRecentlyViewedIds skips
+        // the getDisplayingListingsByIds hydration of up to 20 listings that
+        // getRecentlyViewed() would run.
+        List<Long> viewedListingIds = recentlyViewedService.getRecentlyViewedIds(userId);
+        long tAfterViewed = System.nanoTime();
 
         for (SavedListing s : savedListings) {
             interactionWeightMap.merge(s.getId().getListingId(), 3.0, Math::max);
@@ -233,12 +239,12 @@ public class RecommendationServiceImpl implements RecommendationService {
         for (Long lId : clickedListingIds) {
             interactionWeightMap.merge(lId, 2.5, Math::max);
         }
-        for (RecentlyViewedItemResponse rv : viewedListings) {
-            interactionWeightMap.merge(rv.getListing().getListingId(), 1.0, Math::max);
+        for (Long lId : viewedListingIds) {
+            interactionWeightMap.merge(lId, 1.0, Math::max);
         }
 
         boolean hasEnoughInteractions = !savedListings.isEmpty() || !clickedListingIds.isEmpty()
-                || viewedListings.size() >= 3;
+                || viewedListingIds.size() >= 3;
         if (!hasEnoughInteractions) {
             return getColdStartFeed(topN);
         }
@@ -254,11 +260,8 @@ public class RecommendationServiceImpl implements RecommendationService {
         List<Listing> interactedListings = listingRepository.findWithAddressByListingIds(interactedListingIds);
 
         // Sort interactedListings so that the most recently viewed items come FIRST.
-        // Reuse the viewedListings already fetched above — re-calling getRecentlyViewed
-        // re-hits Redis AND re-runs batchMapListings (~4 DB queries + full DTO build).
-        List<Long> recencyOrder = viewedListings.stream()
-                .map(rv -> rv.getListing().getListingId())
-                .collect(Collectors.toList());
+        // viewedListingIds is already in recency order (most recent first) from Redis.
+        List<Long> recencyOrder = viewedListingIds;
 
         interactedListings.sort((l1, l2) -> {
             int idx1 = recencyOrder.indexOf(l1.getListingId());
@@ -274,6 +277,12 @@ public class RecommendationServiceImpl implements RecommendationService {
         List<AIRecommendationRequest.ListingFeatureDto> interactionFeatures = interactedListings.stream()
                 .map(this::toFeatureDto).collect(Collectors.toList());
         long tAfterInteractions = System.nanoTime();
+        log.info("[PerfTrace] personalized interactions breakdown userId={} | saved={}ms clicks={}ms recentlyViewed={}ms featureExtract={}ms",
+                userId,
+                (tAfterSaved - tStart) / 1_000_000,
+                (tAfterClicks - tAfterSaved) / 1_000_000,
+                (tAfterViewed - tAfterClicks) / 1_000_000,
+                (tAfterInteractions - tAfterViewed) / 1_000_000);
 
         // 3. Location profiling
         // 3.1 Find most frequent (preferred) locations
@@ -313,9 +322,7 @@ public class RecommendationServiceImpl implements RecommendationService {
             featureById.put(f.getListingId(), f);
         }
 
-        long diffLocViews = viewedListings.stream()
-                .map(rv -> rv.getListing() != null ? rv.getListing().getListingId() : null)
-                .filter(Objects::nonNull)
+        long diffLocViews = viewedListingIds.stream()
                 .distinct()
                 .filter(id -> isDifferentFromPreferred(featureById.get(id),
                         preferredProvinceCode, preferredDistrictId, preferredWardId, preferredWardCode))
@@ -345,9 +352,8 @@ public class RecommendationServiceImpl implements RecommendationService {
         // Fall back to the plain latest interaction when nothing differs (isShift
         // stays false in that case).
         Long latestListingId = null;
-        for (RecentlyViewedItemResponse rv : viewedListings) {
-            Long id = rv.getListing() != null ? rv.getListing().getListingId() : null;
-            if (id != null && isDifferentFromPreferred(featureById.get(id),
+        for (Long id : viewedListingIds) {
+            if (isDifferentFromPreferred(featureById.get(id),
                     preferredProvinceCode, preferredDistrictId, preferredWardId, preferredWardCode)) {
                 latestListingId = id;
                 break;
@@ -373,8 +379,8 @@ public class RecommendationServiceImpl implements RecommendationService {
             }
         }
         if (latestListingId == null) {
-            if (!viewedListings.isEmpty()) {
-                latestListingId = viewedListings.get(0).getListing().getListingId();
+            if (!viewedListingIds.isEmpty()) {
+                latestListingId = viewedListingIds.get(0);
             } else if (!savedListings.isEmpty()) {
                 latestListingId = savedListings.get(0).getId().getListingId();
             } else if (!clickedListingIds.isEmpty()) {

--- a/smart-rent/src/test/java/com/smartrent/service/recommendation/impl/RecommendationServiceImplTest.java
+++ b/smart-rent/src/test/java/com/smartrent/service/recommendation/impl/RecommendationServiceImplTest.java
@@ -83,7 +83,7 @@ public class RecommendationServiceImplTest {
                 .thenReturn(Collections.emptyList());
         when(phoneClickDetailRepository.findListingIdsByUserId("user1"))
                 .thenReturn(Collections.emptyList());
-        when(recentlyViewedService.getRecentlyViewed("user1"))
+        when(recentlyViewedService.getRecentlyViewedIds("user1"))
                 .thenReturn(Collections.emptyList());
 
         // For cold start


### PR DESCRIPTION
## Problem

Prod `[PerfTrace]` on the personalized feed:

```
interactions=5270ms candidateRetrieval=878ms cfGlobal+features=494ms feignAi=197ms total=6840ms
```

`candidateRetrieval` is already fixed (878ms, via V97). The new bottleneck is the **`interactions` phase = ~5.27s (77% of total)**.

## Root cause

The interaction block (`getPersonalizedFeed`, `tStart`→`tAfterInteractions`) called `recentlyViewedService.getRecentlyViewed(userId)`, which does a Redis `ZREVRANGE` (≤20 IDs) and then **`getDisplayingListingsByIds` — full `ListingResponse` hydration of up to 20 listings** (address/media/user, several DB queries). But the reco only ever uses the **viewed listing IDs + their recency order** (interaction weights, discovery-shift scan, recency sort). The full-DTO build is pure waste here.

## Change

- **New `RecentlyViewedService.getRecentlyViewedIds(userId)`** — ordered IDs (most recent first) straight from the Redis ZSET, no DB hydration.
- Use it in **both** `getPersonalizedFeed` (all 4 usages) and `getSimilarListings`.
- **Split-timing** `[PerfTrace]` inside the interactions block (`saved / clicks / recentlyViewed / featureExtract`) so the next prod trace attributes the residual cost precisely.

### Why both

Two hypotheses for the 5.27s that code can't distinguish: **(H2) the wasteful hydration** vs **(H1) Redis latency** (known Dokploy issue). This PR removes H2 outright *and* instruments the block, so one deploy either fixes it or the residual `recentlyViewed=…ms` isolates Redis (H1 → infra), not another guess.

## Behavior note

Viewed IDs are no longer filtered to *currently-displaying* listings — matching how saved/clicked interaction signals are already treated (unfiltered). These are historical behavior signals; downstream `findWithAddressByListingIds` tolerates IDs that no longer resolve. The result feed itself is still built from the separately display-filtered candidate set, unchanged.

## Verify

- `./gradlew compileJava compileTestJava` — exit 0
- `./gradlew test --tests "*RecommendationServiceImplTest"` — pass

After deploy, read one personalized trace: the new `interactions breakdown` line shows `recentlyViewed=…ms`. Expect the interaction phase to drop sharply; if `recentlyViewed` is still large, that's Redis latency, not hydration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
