### PR TITLE
perf(db): drop redundant indexes (V110) + fix owner-analytics N+1

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/infra/repository/ListingRepository.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/ListingRepository.java
@@ -21,6 +21,15 @@ public interface ListingRepository extends JpaRepository<Listing, Long>, JpaSpec
     List<Listing> findByListingIdIn(Collection<Long> listingIds);
 
     /**
+     * Lightweight {@code [listingId, title]} projection for a batch of ids —
+     * used by owner analytics to resolve titles for a page of aggregate rows in
+     * ONE query instead of a {@code findById} per row (N+1). Avoids loading the
+     * full Listing entity (notably the longtext description).
+     */
+    @Query("SELECT l.listingId, l.title FROM listings l WHERE l.listingId IN :listingIds")
+    List<Object[]> findIdAndTitleByListingIdIn(@Param("listingIds") Collection<Long> listingIds);
+
+    /**
      * Fetch listings by id restricted to those currently publicly displayed
      * (same visibility filter as {@link #findPublicListings}). Used so that
      * features like "recently viewed" never surface listings that have since

--- a/smart-rent/src/main/java/com/smartrent/infra/repository/entity/Address.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/entity/Address.java
@@ -15,14 +15,12 @@ import java.util.List;
  * Matches database schema from V7 migration
  */
 @Entity(name = "addresses")
-@Table(name = "addresses",
-        indexes = {
-                @Index(name = "idx_addresses_legacy_loc", columnList = "legacy_province_id, legacy_district_id, legacy_ward_id"),
-                @Index(name = "idx_addresses_new_loc", columnList = "new_province_code, new_ward_code"),
-                @Index(name = "idx_addresses_geo", columnList = "latitude, longitude"),
-                @Index(name = "idx_addresses_legacy_ward", columnList = "legacy_ward_id"),
-                @Index(name = "idx_addresses_legacy_district", columnList = "legacy_district_id")
-        })
+// Address indexes live in Flyway migrations (idx_legacy_location / idx_new_location /
+// idx_addresses_lat_lng / idx_legacy_ward / idx_legacy_district from V59/V81, etc.).
+// The duplicate @Index copies here were removed after V110 dropped them on prod —
+// each was an exact duplicate of a migration index. Keeping them would let
+// ddl-auto=update reintroduce the bloat.
+@Table(name = "addresses")
 @Getter
 @Setter
 @Builder

--- a/smart-rent/src/main/java/com/smartrent/infra/repository/entity/Media.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/entity/Media.java
@@ -20,13 +20,13 @@ import java.time.LocalDateTime;
 @Entity(name = "media")
 @Table(name = "media",
         indexes = {
-                @Index(name = "idx_listing_id", columnList = "listing_id"),
+                // idx_listing_id + idx_media_listing_status dropped in V110 —
+                // both are prefixes of idx_media_listing_status_sort (migration).
                 @Index(name = "idx_user_id", columnList = "user_id"),
                 @Index(name = "idx_media_type", columnList = "media_type"),
                 @Index(name = "idx_status", columnList = "status"),
                 @Index(name = "idx_listing_sort", columnList = "listing_id, sort_order"),
-                @Index(name = "idx_storage_key", columnList = "storage_key"),
-                @Index(name = "idx_media_listing_status", columnList = "listing_id, status")
+                @Index(name = "idx_storage_key", columnList = "storage_key")
         })
 @Getter
 @Setter

--- a/smart-rent/src/main/java/com/smartrent/infra/repository/entity/PhoneClickDetail.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/entity/PhoneClickDetail.java
@@ -19,8 +19,8 @@ import java.time.LocalDateTime;
 @Entity(name = "phone_clicks")
 @Table(name = "phone_clicks",
         indexes = {
-                @Index(name = "idx_listing_id", columnList = "listing_id"),
-                @Index(name = "idx_user_id", columnList = "user_id"),
+                // idx_listing_id (⊂ idx_listing_user) + idx_user_id
+                // (⊂ idx_phone_clicks_user_listing) dropped in V110.
                 @Index(name = "idx_listing_user", columnList = "listing_id, user_id"),
                 @Index(name = "idx_phone_clicks_user_listing", columnList = "user_id, listing_id"),
                 @Index(name = "idx_clicked_at", columnList = "clicked_at")

--- a/smart-rent/src/main/java/com/smartrent/infra/repository/entity/PricingHistory.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/entity/PricingHistory.java
@@ -14,7 +14,7 @@ import java.time.LocalDateTime;
 @Entity(name = "pricing_histories")
 @Table(name = "pricing_histories",
         indexes = {
-                @Index(name = "idx_listing_id", columnList = "listing_id"),
+                // idx_listing_id dropped in V110 — prefix of idx_listing_date.
                 @Index(name = "idx_listing_date", columnList = "listing_id, changed_at"),
                 @Index(name = "idx_changed_at", columnList = "changed_at"),
                 @Index(name = "idx_is_current", columnList = "is_current"),

--- a/smart-rent/src/main/java/com/smartrent/infra/repository/entity/View.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/entity/View.java
@@ -15,7 +15,7 @@ import java.time.LocalDateTime;
 @Entity(name = "views")
 @Table(name = "views",
         indexes = {
-                @Index(name = "idx_listing_id", columnList = "listing_id"),
+                // idx_listing_id dropped in V110 — prefix of idx_listing_time.
                 @Index(name = "idx_listing_time", columnList = "listing_id, viewed_at"),
                 @Index(name = "idx_user_id", columnList = "user_id"),
                 @Index(name = "idx_ip_time", columnList = "ip_address, viewed_at")

--- a/smart-rent/src/main/java/com/smartrent/service/analytics/impl/AnalyticsServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/analytics/impl/AnalyticsServiceImpl.java
@@ -96,16 +96,17 @@ public class AnalyticsServiceImpl implements AnalyticsService {
             page = phoneClickDetailRepository.countClicksPerListingForOwnerPaged(ownerId, pageable);
         }
 
-        List<ListingClickSummary> summaries = page.getContent().stream()
+        List<Object[]> rows = page.getContent();
+        // Batch-resolve titles for the page in ONE query (was findById per row → N+1).
+        Map<Long, String> titleById = resolveListingTitles(rows);
+
+        List<ListingClickSummary> summaries = rows.stream()
                 .map(row -> {
                     Long listingId = ((Number) row[0]).longValue();
                     Long count = ((Number) row[1]).longValue();
-                    String title = listingRepository.findById(listingId)
-                            .map(Listing::getTitle)
-                            .orElse("Unknown");
                     return ListingClickSummary.builder()
                             .listingId(listingId)
-                            .listingTitle(title)
+                            .listingTitle(titleById.getOrDefault(listingId, "Unknown"))
                             .totalClicks(count)
                             .build();
                 })
@@ -171,16 +172,16 @@ public class AnalyticsServiceImpl implements AnalyticsService {
         // ALL of the owner's listings, not just the current page.
         long totalSavesAcrossAll = savedListingRepository.countTotalSavesForOwner(ownerId);
 
-        List<ListingSaveSummary> summaries = page.getContent().stream()
+        List<Object[]> rows = page.getContent();
+        Map<Long, String> titleById = resolveListingTitles(rows);
+
+        List<ListingSaveSummary> summaries = rows.stream()
                 .map(row -> {
                     Long lid = ((Number) row[0]).longValue();
                     Long count = ((Number) row[1]).longValue();
-                    String title = listingRepository.findById(lid)
-                            .map(Listing::getTitle)
-                            .orElse("Unknown");
                     return ListingSaveSummary.builder()
                             .listingId(lid)
-                            .listingTitle(title)
+                            .listingTitle(titleById.getOrDefault(lid, "Unknown"))
                             .totalSaves(count)
                             .build();
                 })
@@ -197,6 +198,24 @@ public class AnalyticsServiceImpl implements AnalyticsService {
     }
 
     // ─── Private helpers ───
+
+    /**
+     * Batch-resolve listing titles for a page of {@code [listingId, count]}
+     * aggregate rows in a single query, replacing a per-row
+     * {@code listingRepository.findById} (N+1). Ids missing from the result
+     * fall back to "Unknown" at the call site via {@code getOrDefault}.
+     */
+    private Map<Long, String> resolveListingTitles(List<Object[]> rows) {
+        List<Long> ids = rows.stream()
+                .map(r -> ((Number) r[0]).longValue())
+                .distinct()
+                .collect(Collectors.toList());
+        if (ids.isEmpty()) {
+            return Map.of();
+        }
+        return listingRepository.findIdAndTitleByListingIdIn(ids).stream()
+                .collect(Collectors.toMap(r -> ((Number) r[0]).longValue(), r -> (String) r[1]));
+    }
 
     private List<DailyClickCount> buildClicksOverTime(Long listingId) {
         List<Object[]> rawData = phoneClickDetailRepository.countClicksGroupedByDate(listingId);

--- a/smart-rent/src/main/resources/db/migration/V110__Drop_redundant_indexes.sql
+++ b/smart-rent/src/main/resources/db/migration/V110__Drop_redundant_indexes.sql
@@ -1,0 +1,120 @@
+-- Migration V110: drop redundant / duplicate secondary indexes.
+-- ============================================================================
+-- A 2026-07-12 index audit found the listings table alone carrying 47 indexes
+-- (~484 MB incl. clustered; secondary index_length 298 MB > 181 MB of data),
+-- with the same bloat pattern on addresses / phone_clicks / views / media /
+-- pricing_histories / users. Two kinds of dead weight:
+--
+--   1. EXACT DUPLICATES — two indexes on identical column lists. One is pure
+--      redundancy (created historically by Hibernate ddl-auto under an entity
+--      @Index name, then re-added by a later Flyway migration under a different
+--      name — or vice versa).
+--   2. PREFIX-REDUNDANT — a single-column index whose column is already the
+--      leading column of a wider composite, so the composite serves every query
+--      the single-column index could (including FK lookups — each dropped index
+--      below still has a same-leading-column composite to back its FK).
+--
+-- Dropping them speeds up writes (fewer indexes to maintain on the write-heavy
+-- views / phone_clicks / listings tables), frees ~115 MB, and shrinks the
+-- optimizer's plan search. No read path regresses — every dropped index is
+-- covered by a surviving index (noted per line).
+--
+-- These were already dropped directly on prod during the audit; this migration
+-- makes the change reproducible (fresh Flyway builds) and idempotent — each
+-- DROP is guarded on information_schema, so it is a no-op where the index is
+-- already gone. The matching duplicate @Index annotations were removed from the
+-- Address / Media / View / PricingHistory / PhoneClickDetail entities in the
+-- same change so ddl-auto=update can't reintroduce them.
+--
+-- Idempotent guarded-DROP style matches V94–V109 (inline PREPARE, no DELIMITER
+-- so Flyway's statement splitter handles it).
+-- ============================================================================
+
+-- listings (dup of idx_listings_parent / idx_listings_pushed_at /
+--            idx_listings_user_draft_updated respectively)
+SET @cnt = (SELECT COUNT(*) FROM information_schema.statistics WHERE table_schema = DATABASE() AND table_name = 'listings' AND index_name = 'idx_parent_listing');
+SET @ddl = IF(@cnt > 0, 'ALTER TABLE listings DROP INDEX idx_parent_listing', 'SELECT 1');
+PREPARE s FROM @ddl; EXECUTE s; DEALLOCATE PREPARE s;
+
+SET @cnt = (SELECT COUNT(*) FROM information_schema.statistics WHERE table_schema = DATABASE() AND table_name = 'listings' AND index_name = 'idx_pushed_at');
+SET @ddl = IF(@cnt > 0, 'ALTER TABLE listings DROP INDEX idx_pushed_at', 'SELECT 1');
+PREPARE s FROM @ddl; EXECUTE s; DEALLOCATE PREPARE s;
+
+SET @cnt = (SELECT COUNT(*) FROM information_schema.statistics WHERE table_schema = DATABASE() AND table_name = 'listings' AND index_name = 'idx_listings_user_drafts');
+SET @ddl = IF(@cnt > 0, 'ALTER TABLE listings DROP INDEX idx_listings_user_drafts', 'SELECT 1');
+PREPARE s FROM @ddl; EXECUTE s; DEALLOCATE PREPARE s;
+
+-- addresses (dups of idx_addresses_lat_lng / idx_legacy_location /
+--            idx_legacy_district / idx_legacy_ward / idx_new_location; and the
+--            single idx_legacy_province / idx_new_province are prefixes of
+--            idx_legacy_location / idx_new_location)
+SET @cnt = (SELECT COUNT(*) FROM information_schema.statistics WHERE table_schema = DATABASE() AND table_name = 'addresses' AND index_name = 'idx_addresses_geo');
+SET @ddl = IF(@cnt > 0, 'ALTER TABLE addresses DROP INDEX idx_addresses_geo', 'SELECT 1');
+PREPARE s FROM @ddl; EXECUTE s; DEALLOCATE PREPARE s;
+
+SET @cnt = (SELECT COUNT(*) FROM information_schema.statistics WHERE table_schema = DATABASE() AND table_name = 'addresses' AND index_name = 'idx_addresses_legacy_loc');
+SET @ddl = IF(@cnt > 0, 'ALTER TABLE addresses DROP INDEX idx_addresses_legacy_loc', 'SELECT 1');
+PREPARE s FROM @ddl; EXECUTE s; DEALLOCATE PREPARE s;
+
+SET @cnt = (SELECT COUNT(*) FROM information_schema.statistics WHERE table_schema = DATABASE() AND table_name = 'addresses' AND index_name = 'idx_addresses_legacy_district');
+SET @ddl = IF(@cnt > 0, 'ALTER TABLE addresses DROP INDEX idx_addresses_legacy_district', 'SELECT 1');
+PREPARE s FROM @ddl; EXECUTE s; DEALLOCATE PREPARE s;
+
+SET @cnt = (SELECT COUNT(*) FROM information_schema.statistics WHERE table_schema = DATABASE() AND table_name = 'addresses' AND index_name = 'idx_addresses_legacy_ward');
+SET @ddl = IF(@cnt > 0, 'ALTER TABLE addresses DROP INDEX idx_addresses_legacy_ward', 'SELECT 1');
+PREPARE s FROM @ddl; EXECUTE s; DEALLOCATE PREPARE s;
+
+SET @cnt = (SELECT COUNT(*) FROM information_schema.statistics WHERE table_schema = DATABASE() AND table_name = 'addresses' AND index_name = 'idx_addresses_new_loc');
+SET @ddl = IF(@cnt > 0, 'ALTER TABLE addresses DROP INDEX idx_addresses_new_loc', 'SELECT 1');
+PREPARE s FROM @ddl; EXECUTE s; DEALLOCATE PREPARE s;
+
+SET @cnt = (SELECT COUNT(*) FROM information_schema.statistics WHERE table_schema = DATABASE() AND table_name = 'addresses' AND index_name = 'idx_legacy_province');
+SET @ddl = IF(@cnt > 0, 'ALTER TABLE addresses DROP INDEX idx_legacy_province', 'SELECT 1');
+PREPARE s FROM @ddl; EXECUTE s; DEALLOCATE PREPARE s;
+
+SET @cnt = (SELECT COUNT(*) FROM information_schema.statistics WHERE table_schema = DATABASE() AND table_name = 'addresses' AND index_name = 'idx_new_province');
+SET @ddl = IF(@cnt > 0, 'ALTER TABLE addresses DROP INDEX idx_new_province', 'SELECT 1');
+PREPARE s FROM @ddl; EXECUTE s; DEALLOCATE PREPARE s;
+
+-- users (dup of the unique uk_users_phone on the same (phone_code, phone_number))
+SET @cnt = (SELECT COUNT(*) FROM information_schema.statistics WHERE table_schema = DATABASE() AND table_name = 'users' AND index_name = 'idx_users_phone');
+SET @ddl = IF(@cnt > 0, 'ALTER TABLE users DROP INDEX idx_users_phone', 'SELECT 1');
+PREPARE s FROM @ddl; EXECUTE s; DEALLOCATE PREPARE s;
+
+-- phone_clicks (idx_listing_id ⊂ idx_listing_clicked_at / idx_listing_user;
+--               idx_user_id ⊂ idx_phone_clicks_user_listing)
+SET @cnt = (SELECT COUNT(*) FROM information_schema.statistics WHERE table_schema = DATABASE() AND table_name = 'phone_clicks' AND index_name = 'idx_listing_id');
+SET @ddl = IF(@cnt > 0, 'ALTER TABLE phone_clicks DROP INDEX idx_listing_id', 'SELECT 1');
+PREPARE s FROM @ddl; EXECUTE s; DEALLOCATE PREPARE s;
+
+SET @cnt = (SELECT COUNT(*) FROM information_schema.statistics WHERE table_schema = DATABASE() AND table_name = 'phone_clicks' AND index_name = 'idx_user_id');
+SET @ddl = IF(@cnt > 0, 'ALTER TABLE phone_clicks DROP INDEX idx_user_id', 'SELECT 1');
+PREPARE s FROM @ddl; EXECUTE s; DEALLOCATE PREPARE s;
+
+-- views (idx_listing_id ⊂ idx_listing_time)
+SET @cnt = (SELECT COUNT(*) FROM information_schema.statistics WHERE table_schema = DATABASE() AND table_name = 'views' AND index_name = 'idx_listing_id');
+SET @ddl = IF(@cnt > 0, 'ALTER TABLE views DROP INDEX idx_listing_id', 'SELECT 1');
+PREPARE s FROM @ddl; EXECUTE s; DEALLOCATE PREPARE s;
+
+-- media (idx_listing_id ⊂ idx_listing_sort / idx_media_listing_status_sort;
+--        idx_media_listing_status ⊂ idx_media_listing_status_sort)
+SET @cnt = (SELECT COUNT(*) FROM information_schema.statistics WHERE table_schema = DATABASE() AND table_name = 'media' AND index_name = 'idx_listing_id');
+SET @ddl = IF(@cnt > 0, 'ALTER TABLE media DROP INDEX idx_listing_id', 'SELECT 1');
+PREPARE s FROM @ddl; EXECUTE s; DEALLOCATE PREPARE s;
+
+SET @cnt = (SELECT COUNT(*) FROM information_schema.statistics WHERE table_schema = DATABASE() AND table_name = 'media' AND index_name = 'idx_media_listing_status');
+SET @ddl = IF(@cnt > 0, 'ALTER TABLE media DROP INDEX idx_media_listing_status', 'SELECT 1');
+PREPARE s FROM @ddl; EXECUTE s; DEALLOCATE PREPARE s;
+
+-- pricing_histories (idx_listing_id ⊂ idx_listing_date;
+--                    idx_pricing_history_filter ⊂ idx_pricing_listing_current_type)
+SET @cnt = (SELECT COUNT(*) FROM information_schema.statistics WHERE table_schema = DATABASE() AND table_name = 'pricing_histories' AND index_name = 'idx_listing_id');
+SET @ddl = IF(@cnt > 0, 'ALTER TABLE pricing_histories DROP INDEX idx_listing_id', 'SELECT 1');
+PREPARE s FROM @ddl; EXECUTE s; DEALLOCATE PREPARE s;
+
+SET @cnt = (SELECT COUNT(*) FROM information_schema.statistics WHERE table_schema = DATABASE() AND table_name = 'pricing_histories' AND index_name = 'idx_pricing_history_filter');
+SET @ddl = IF(@cnt > 0, 'ALTER TABLE pricing_histories DROP INDEX idx_pricing_history_filter', 'SELECT 1');
+PREPARE s FROM @ddl; EXECUTE s; DEALLOCATE PREPARE s;
+
+-- Refresh optimizer statistics on the affected tables.
+ANALYZE TABLE listings, addresses, phone_clicks, views, media, pricing_histories, users;


### PR DESCRIPTION
## Summary
Two independent DB-performance fixes surfaced by a full production index/consistency audit.

### 1. Drop 18 redundant / duplicate indexes (`V110`)
The `listings` table alone carried **47 indexes** (~484 MB incl. clustered; **298 MB secondary > 181 MB data**), with the same bloat on `addresses`, `phone_clicks`, `views`, `media`, `pricing_histories`, `users`. The 18 dropped are either **exact duplicates** (same column list under two names — one from historical `ddl-auto`, one from a later migration) or **single-column indexes that are a leading prefix of an existing composite**. Every dropped index still has a same-leading-column composite backing its FK, so **no read path or FK regresses**.

- `V110__Drop_redundant_indexes.sql` — idempotent (guarded on `information_schema`), `ANALYZE`s the affected tables.
- Removed the matching duplicate `@Index` annotations from `Address` / `Media` / `View` / `PricingHistory` / `PhoneClickDetail` so `ddl-auto=update` can't reintroduce them.
- Effect: **~115 MB freed** + fewer indexes to maintain on the write-heavy `views` / `phone_clicks` tables.

> Note: these drops were already applied directly on prod during the audit (online `ALGORITHM=INPLACE, LOCK=NONE`); this migration **codifies** them so a fresh Flyway build matches prod and no-ops where already dropped.

### 2. Fix N+1 in owner analytics
`getOwnerListingsAnalytics` and `getOwnerSavedListingsAnalytics` resolved each page row's title with a `findById` inside `.map()` (one round-trip per row). Now a shared `resolveListingTitles(rows)` helper batches the lookup via a new `ListingRepository.findIdAndTitleByListingIdIn` id+title projection — **one query per page instead of N** (e.g. 21 → 2 for a 20-row page) and no longer loads the full `Listing` entity (longtext description).

## Not included (deliberately)
`computeProvinceStats` was **left as-is**: unlike category stats (a simple `category_id` GROUP BY), province cards count through `ListingSpecification`'s `addresses` INNER JOIN with `(legacyProvinceId OR newProvinceCode)`, and a single listing can be counted in two overlapping cards — a lone GROUP BY can't reproduce those per-card counts without risking homepage≠listing-page drift. It is `@Cacheable` (cold-cache only) + index-backed.

## Verification
- `./gradlew compileJava` → **BUILD SUCCESSFUL**.
- Every dropped index confirmed covered by a surviving composite (see per-line comments in `V110`).