### PR TITLE
fix: harden trigger_type against unknown OwnerActionTriggerType values

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/infra/repository/entity/ListingOwnerAction.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/entity/ListingOwnerAction.java
@@ -3,6 +3,8 @@ package com.smartrent.infra.repository.entity;
 import com.smartrent.enums.OwnerActionStatus;
 import com.smartrent.enums.OwnerActionTriggerType;
 import com.smartrent.enums.OwnerActionType;
+import com.smartrent.infra.repository.entity.converter.OwnerActionStatusConverter;
+import com.smartrent.infra.repository.entity.converter.OwnerActionTriggerTypeConverter;
 import com.smartrent.infra.repository.entity.converter.OwnerActionTypeConverter;
 import jakarta.persistence.*;
 import lombok.*;
@@ -38,7 +40,7 @@ public class ListingOwnerAction {
     @Column(name = "listing_id", nullable = false)
     Long listingId;
 
-    @Enumerated(EnumType.STRING)
+    @Convert(converter = OwnerActionTriggerTypeConverter.class)
     @Column(name = "trigger_type", nullable = false, length = 30)
     OwnerActionTriggerType triggerType;
 
@@ -50,7 +52,7 @@ public class ListingOwnerAction {
     OwnerActionType requiredAction;
 
     @Builder.Default
-    @Enumerated(EnumType.STRING)
+    @Convert(converter = OwnerActionStatusConverter.class)
     @Column(name = "status", nullable = false, length = 30)
     OwnerActionStatus status = OwnerActionStatus.PENDING_OWNER;
 

--- a/smart-rent/src/main/java/com/smartrent/infra/repository/entity/converter/OwnerActionTriggerTypeConverter.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/entity/converter/OwnerActionTriggerTypeConverter.java
@@ -1,0 +1,38 @@
+package com.smartrent.infra.repository.entity.converter;
+
+import com.smartrent.enums.OwnerActionTriggerType;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Same rationale as {@link OwnerActionTypeConverter}: a legacy/manual DB write can leave
+ * {@code trigger_type} holding a value that isn't a current {@link OwnerActionTriggerType}
+ * constant (e.g. {@code USER_REPORT}, which was never a declared value here). Without this
+ * converter, Hibernate's default enum mapping throws {@link IllegalArgumentException} while
+ * hydrating the row, which crashes every bulk read of owner actions — including
+ * GET /v1/listings/my-listings, where one poisoned row blanks out an owner's entire listing
+ * list. Fall back to REPORT_RESOLVED instead of throwing.
+ */
+@Slf4j
+@Converter
+public class OwnerActionTriggerTypeConverter implements AttributeConverter<OwnerActionTriggerType, String> {
+
+    @Override
+    public String convertToDatabaseColumn(OwnerActionTriggerType attribute) {
+        return attribute == null ? null : attribute.name();
+    }
+
+    @Override
+    public OwnerActionTriggerType convertToEntityAttribute(String dbData) {
+        if (dbData == null) {
+            return null;
+        }
+        try {
+            return OwnerActionTriggerType.valueOf(dbData);
+        } catch (IllegalArgumentException e) {
+            log.error("Unknown trigger_type value '{}' found in DB; defaulting to REPORT_RESOLVED", dbData);
+            return OwnerActionTriggerType.REPORT_RESOLVED;
+        }
+    }
+}


### PR DESCRIPTION
GET /v1/listings/my-listings crashed with "No enum constant OwnerActionTriggerType.USER_REPORT" because a legacy row stored a trigger_type value that isn't a declared enum constant, and the column was still mapped with a plain @Enumerated(EnumType.STRING). Add OwnerActionTriggerTypeConverter (same fallback pattern as OwnerActionTypeConverter) and wire it in, and also wire the already-written but unused OwnerActionStatusConverter onto status to close the same gap there.