### PR TITLE
fix: expose pendingOwnerAction signal on admin listing responses

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/dto/response/AdminListingSummary.java
+++ b/smart-rent/src/main/java/com/smartrent/dto/response/AdminListingSummary.java
@@ -97,6 +97,11 @@ public class AdminListingSummary {
             "ordinary admin suspend, which the owner can resubmit from")
     Boolean permanentlyRemoved;
 
+    @Schema(description = "True when moderationStatus=SUSPENDED came from rejecting the listing in the review " +
+            "queue (creates an owner action requiring the owner to fix and resubmit). False/absent when it came " +
+            "from temporarily hiding the listing during report review instead — no owner action is created for that.")
+    Boolean hasPendingOwnerAction;
+
     @Getter
     @Setter
     @Builder

--- a/smart-rent/src/main/java/com/smartrent/dto/response/ListingResponseWithAdmin.java
+++ b/smart-rent/src/main/java/com/smartrent/dto/response/ListingResponseWithAdmin.java
@@ -130,6 +130,11 @@ public class ListingResponseWithAdmin {
             "ordinary admin suspend, which the owner can resubmit from")
     Boolean permanentlyRemoved;
 
+    @Schema(description = "Pending owner action (if any) — present when moderationStatus=SUSPENDED came from " +
+            "rejecting the listing in the review queue, absent when it came from temporarily hiding the listing " +
+            "during report review instead")
+    OwnerActionResponse pendingOwnerAction;
+
     @Schema(description = "Property information summary")
     PropertyInfo propertyInfo;
 

--- a/smart-rent/src/main/java/com/smartrent/service/listing/impl/ListingServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/listing/impl/ListingServiceImpl.java
@@ -771,7 +771,10 @@ public class ListingServiceImpl implements ListingService {
                 ? userMapper.mapFromUserEntityToUserCreationResponse(userEntity)
                 : null;
 
-        return listingMapper.toResponseWithAdmin(listing, user, verifyingAdmin, verificationStatus, verificationNotes);
+        ListingResponseWithAdmin response =
+                listingMapper.toResponseWithAdmin(listing, user, verifyingAdmin, verificationStatus, verificationNotes);
+        response.setPendingOwnerAction(listingModerationService.getOwnerPendingAction(id));
+        return response;
     }
 
     /**
@@ -2072,6 +2075,13 @@ public class ListingServiceImpl implements ListingService {
                             LinkedHashMap::new,
                             Collectors.mapping(Media::getUrl, Collectors.toList())));
 
+            // ---- Batch-load pending owner actions — 1 query ----
+            // Lets the admin FE tell "rejected in review queue" apart from
+            // "temporarily hidden via report review" even though both share
+            // moderationStatus=SUSPENDED (see AdminListingSummary#hasPendingOwnerAction).
+            Map<Long, com.smartrent.dto.response.OwnerActionResponse> pendingActionsByListingId =
+                    listingModerationService.getOwnerPendingActions(listingIds);
+
             // ---- Map to slim AdminListingSummary DTOs ----
             // (No amenity/address fetch — list view does not need them.)
             listings = content.stream()
@@ -2086,7 +2096,11 @@ public class ListingServiceImpl implements ListingService {
                         }
                         com.smartrent.infra.repository.entity.User owner = userMap.get(listing.getUserId());
                         List<String> images = imagesByListingId.getOrDefault(listing.getListingId(), Collections.emptyList());
-                        return listingMapper.toAdminSummary(listing, owner, verificationStatus, images);
+                        com.smartrent.dto.response.AdminListingSummary summary =
+                                listingMapper.toAdminSummary(listing, owner, verificationStatus, images);
+                        summary.setHasPendingOwnerAction(
+                                pendingActionsByListingId.containsKey(listing.getListingId()));
+                        return summary;
                     })
                     .collect(Collectors.toList());
         } else {


### PR DESCRIPTION
Admin FE currently can't tell apart two different admin actions that both leave moderationStatus=SUSPENDED: rejecting a listing in the review queue (always creates a ListingOwnerAction) and temporarily hiding a listing under report review (never does). Without this signal the admin table shows both as a generic "suspended" badge even though one is a hard rejection and the other is a reversible, no-action-needed hide — the seller-facing app already disambiguates the same states via pendingOwnerAction (see ListingResponseForOwner).

- AdminListingSummary gets a slim `hasPendingOwnerAction` boolean, batch-loaded in getAllListingsForAdmin via the existing getOwnerPendingActions(listingIds) batch method (no N+1)
- ListingResponseWithAdmin gets the full `pendingOwnerAction` object, set in getListingByIdWithAdmin via getOwnerPendingAction(id)