### PR TITLE
refactor: extract shared JwtRecipientResolver for notification recipi…

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/config/WebSocketAuthChannelInterceptor.java
+++ b/smart-rent/src/main/java/com/smartrent/config/WebSocketAuthChannelInterceptor.java
@@ -1,6 +1,7 @@
 package com.smartrent.config;
 
 import com.smartrent.config.security.CustomJwtDecoder;
+import com.smartrent.util.JwtRecipientResolver;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.Message;
@@ -17,8 +18,8 @@ import java.security.Principal;
 
 /**
  * Authenticates the STOMP CONNECT frame and pins a {@link Principal} (the
- * recipientId — admin_id / user_id, matching NotificationController.resolveRecipientId)
- * to the WebSocket session. Notifications are then routed with
+ * recipientId resolved by {@link JwtRecipientResolver}) to the WebSocket
+ * session. Notifications are then routed with
  * {@code convertAndSendToUser(recipientId, "/queue/notifications", ...)} to that
  * one session's private user-destination.
  *
@@ -55,7 +56,7 @@ public class WebSocketAuthChannelInterceptor implements ChannelInterceptor {
 
         try {
             Jwt jwt = jwtDecoder.decode(authHeader.substring(7));
-            String recipientId = resolveRecipientId(jwt);
+            String recipientId = JwtRecipientResolver.resolveRecipientId(jwt);
             accessor.setUser(new StompPrincipal(recipientId));
             log.debug("STOMP CONNECT authenticated for principal {}", recipientId);
         } catch (MessagingException e) {
@@ -66,20 +67,6 @@ public class WebSocketAuthChannelInterceptor implements ChannelInterceptor {
         }
 
         return message;
-    }
-
-    /** Mirrors NotificationController.resolveRecipientId so the Principal name
-     *  equals the recipientId notifications are addressed to. */
-    private String resolveRecipientId(Jwt jwt) {
-        String adminId = jwt.getClaimAsString("admin_id");
-        if (adminId != null) {
-            return adminId;
-        }
-        String userId = jwt.getClaimAsString("user_id");
-        if (userId != null) {
-            return userId;
-        }
-        return jwt.getSubject();
     }
 
     private record StompPrincipal(String name) implements Principal {

--- a/smart-rent/src/main/java/com/smartrent/controller/NotificationController.java
+++ b/smart-rent/src/main/java/com/smartrent/controller/NotificationController.java
@@ -3,6 +3,7 @@ package com.smartrent.controller;
 import com.smartrent.dto.response.NotificationResponse;
 import com.smartrent.enums.RecipientType;
 import com.smartrent.service.notification.NotificationService;
+import com.smartrent.util.JwtRecipientResolver;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -32,8 +33,8 @@ public class NotificationController {
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "20") int size) {
 
-        String recipientId = resolveRecipientId(jwt);
-        RecipientType recipientType = resolveRecipientType(jwt);
+        String recipientId = JwtRecipientResolver.resolveRecipientId(jwt);
+        RecipientType recipientType = JwtRecipientResolver.resolveRecipientType(jwt);
         Pageable pageable = PageRequest.of(page, size);
 
         return ResponseEntity.ok(notificationService.getNotifications(recipientId, recipientType, pageable));
@@ -42,8 +43,8 @@ public class NotificationController {
     @Operation(summary = "Get unread notification count")
     @GetMapping("/unread-count")
     public ResponseEntity<Map<String, Long>> getUnreadCount(@AuthenticationPrincipal Jwt jwt) {
-        String recipientId = resolveRecipientId(jwt);
-        RecipientType recipientType = resolveRecipientType(jwt);
+        String recipientId = JwtRecipientResolver.resolveRecipientId(jwt);
+        RecipientType recipientType = JwtRecipientResolver.resolveRecipientType(jwt);
 
         long count = notificationService.getUnreadCount(recipientId, recipientType);
         return ResponseEntity.ok(Map.of("unreadCount", count));
@@ -55,8 +56,8 @@ public class NotificationController {
             @PathVariable Long id,
             @AuthenticationPrincipal Jwt jwt) {
 
-        String recipientId = resolveRecipientId(jwt);
-        RecipientType recipientType = resolveRecipientType(jwt);
+        String recipientId = JwtRecipientResolver.resolveRecipientId(jwt);
+        RecipientType recipientType = JwtRecipientResolver.resolveRecipientType(jwt);
         notificationService.markAsRead(id, recipientId, recipientType);
         return ResponseEntity.ok().build();
     }
@@ -64,28 +65,10 @@ public class NotificationController {
     @Operation(summary = "Mark all notifications as read")
     @PatchMapping("/read-all")
     public ResponseEntity<Void> markAllAsRead(@AuthenticationPrincipal Jwt jwt) {
-        String recipientId = resolveRecipientId(jwt);
-        RecipientType recipientType = resolveRecipientType(jwt);
+        String recipientId = JwtRecipientResolver.resolveRecipientId(jwt);
+        RecipientType recipientType = JwtRecipientResolver.resolveRecipientType(jwt);
 
         notificationService.markAllAsRead(recipientId, recipientType);
         return ResponseEntity.ok().build();
-    }
-
-    // ── Helpers ──
-
-    private String resolveRecipientId(Jwt jwt) {
-        // Try admin_id first, then user_id (matches existing JWT claim structure)
-        String adminId = jwt.getClaimAsString("admin_id");
-        if (adminId != null) return adminId;
-
-        String userId = jwt.getClaimAsString("user_id");
-        if (userId != null) return userId;
-
-        return jwt.getSubject();
-    }
-
-    private RecipientType resolveRecipientType(Jwt jwt) {
-        String adminId = jwt.getClaimAsString("admin_id");
-        return adminId != null ? RecipientType.ADMIN : RecipientType.USER;
     }
 }

--- a/smart-rent/src/main/java/com/smartrent/util/JwtRecipientResolver.java
+++ b/smart-rent/src/main/java/com/smartrent/util/JwtRecipientResolver.java
@@ -1,0 +1,37 @@
+package com.smartrent.util;
+
+import com.smartrent.enums.RecipientType;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+/**
+ * Single source of truth for deriving a notification recipientId/recipientType
+ * from a JWT. Used by both the REST notification endpoints and the WebSocket
+ * STOMP CONNECT authenticator so the Principal name pinned to a session always
+ * matches the recipientId notifications are addressed to via
+ * {@code convertAndSendToUser}. Keeping this logic in one place avoids the two
+ * call sites silently drifting apart.
+ */
+public final class JwtRecipientResolver {
+
+    private JwtRecipientResolver() {
+    }
+
+    public static String resolveRecipientId(Jwt jwt) {
+        String adminId = jwt.getClaimAsString("admin_id");
+        if (adminId != null) {
+            return adminId;
+        }
+
+        String userId = jwt.getClaimAsString("user_id");
+        if (userId != null) {
+            return userId;
+        }
+
+        return jwt.getSubject();
+    }
+
+    public static RecipientType resolveRecipientType(Jwt jwt) {
+        String adminId = jwt.getClaimAsString("admin_id");
+        return adminId != null ? RecipientType.ADMIN : RecipientType.USER;
+    }
+}


### PR DESCRIPTION
…ent logic

resolveRecipientId was duplicated identically in NotificationController and WebSocketAuthChannelInterceptor, kept in sync only by a comment. This exact class of drift (send-side and subscribe-side silently disagreeing) was the root cause of a prior bug where admin notifications connected but never arrived. Consolidating into one static helper removes the risk of the two copies diverging again.