### PR TITLE
feat: add hasPendingOwnerAction filter to distinguish rejected vs hid…

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/dto/request/ListingFilterRequest.java
+++ b/smart-rent/src/main/java/com/smartrent/dto/request/ListingFilterRequest.java
@@ -67,6 +67,13 @@ public class ListingFilterRequest {
             allowableValues = {"PENDING_REVIEW", "APPROVED", "REJECTED", "REVISION_REQUIRED", "RESUBMITTED", "SUSPENDED"})
     String moderationStatus;
 
+    @Schema(description = "Admin only. Only meaningful alongside moderationStatus=SUSPENDED, which is shared by "
+            + "two unrelated admin actions: rejecting a listing in the review queue (always creates a pending "
+            + "owner action) and temporarily hiding a listing under report review (never does). true narrows to "
+            + "the reject case, false narrows to the hide case; omit to match both.",
+            example = "true")
+    Boolean hasPendingOwnerAction;
+
     // ============ LOCATION FILTERS ============
     @Schema(description = """
             Province ID (OLD structure - 63 provinces).

--- a/smart-rent/src/main/java/com/smartrent/infra/repository/specification/ListingSpecification.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/specification/ListingSpecification.java
@@ -183,6 +183,27 @@ public class ListingSpecification {
                 }
             }
 
+            // hasPendingOwnerAction — only meaningful alongside moderationStatus=SUSPENDED,
+            // which is shared by rejecting a listing in the review queue (creates a pending
+            // owner action) and temporarily hiding it under report review (doesn't). Lets the
+            // admin table filter "Đã từ chối" apart from "Bị tạm ngưng" instead of showing both
+            // under one SUSPENDED bucket (see AdminListingSummary#hasPendingOwnerAction).
+            if (filter.getHasPendingOwnerAction() != null) {
+                Subquery<Long> ownerActionSubquery = query.subquery(Long.class);
+                var ownerActionRoot = ownerActionSubquery.from(
+                        com.smartrent.infra.repository.entity.ListingOwnerAction.class);
+                ownerActionSubquery.select(ownerActionRoot.get("listingId"))
+                        .where(criteriaBuilder.and(
+                                criteriaBuilder.equal(ownerActionRoot.get("listingId"), root.get("listingId")),
+                                criteriaBuilder.equal(ownerActionRoot.get("status"),
+                                        com.smartrent.enums.OwnerActionStatus.PENDING_OWNER)
+                        ));
+
+                predicates.add(Boolean.TRUE.equals(filter.getHasPendingOwnerAction())
+                        ? criteriaBuilder.exists(ownerActionSubquery)
+                        : criteriaBuilder.not(criteriaBuilder.exists(ownerActionSubquery)));
+            }
+
             // ============ LOCATION FILTERS ============
             // Category filter
             if (filter.getCategoryId() != null) {

--- a/smart-rent/src/main/java/com/smartrent/service/listing/ListingQueryService.java
+++ b/smart-rent/src/main/java/com/smartrent/service/listing/ListingQueryService.java
@@ -87,6 +87,7 @@ public class ListingQueryService {
         if (!Boolean.TRUE.equals(filter.getIsAdminRequest())) return false;
         if (!"PENDING_REVIEW".equals(filter.getModerationStatus())) return false;
         if (!"IN_REVIEW".equals(filter.getListingStatus())) return false;
+        if (filter.getHasPendingOwnerAction() != null) return false;
         String sortBy = filter.getSortBy();
         if (sortBy != null && !sortBy.isEmpty() && !"NEWEST".equals(sortBy) && !"DEFAULT".equals(sortBy)) return false;
 


### PR DESCRIPTION
…den listings

The admin moderationStatus=SUSPENDED filter option returns both listings rejected in the review queue and listings temporarily hidden via report review, since both share that same status value. There was no way to query for just one or the other.

- ListingFilterRequest gets an optional hasPendingOwnerAction boolean, only meaningful alongside moderationStatus=SUSPENDED
- ListingSpecification adds an EXISTS/NOT EXISTS subquery against listing_owner_actions (status=PENDING_OWNER) — same table the seller-facing pendingOwnerAction field already reads from
- isAdminPendingReviewQueueShape's fast-path guard now also requires hasPendingOwnerAction=null, so a filter combination that includes it can't silently skip the new predicate