### PR TITLE
fix: exclude pending-payment listings from the REJECTED status filter

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/infra/repository/specification/ListingSpecification.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/specification/ListingSpecification.java
@@ -945,12 +945,18 @@ public class ListingSpecification {
                 );
 
             case REJECTED ->
-                // verified = false AND isVerify = false AND isDraft = false AND postDate is not null
+                // verified = false AND isVerify = false AND isDraft = false AND postDate is not
+                // null AND transactionId is null. That last condition is required — without it
+                // this predicate is a strict subset match of PENDING_PAYMENT's own predicate
+                // (verified=false AND isVerify=false, plus transactionId is not null), so a
+                // listing awaiting payment satisfies REJECTED's conditions too and leaks into
+                // admin's "Đã Từ Chối" filter/status column.
                 criteriaBuilder.and(
                     criteriaBuilder.isFalse(root.get("verified")),
                     criteriaBuilder.isFalse(root.get("isVerify")),
                     criteriaBuilder.isFalse(root.get("isDraft")),
-                    criteriaBuilder.isNotNull(root.get("postDate"))
+                    criteriaBuilder.isNotNull(root.get("postDate")),
+                    criteriaBuilder.isNull(root.get("transactionId"))
                 );
 
             case VERIFIED ->


### PR DESCRIPTION
buildStatusPredicate's REJECTED case (verified=false AND isVerify=false AND isDraft=false AND postDate not null) is a strict subset of PENDING_PAYMENT's own predicate (verified=false AND isVerify=false AND transactionId not null) -- nothing excluded transactionId-set rows, so a listing still awaiting payment matched the REJECTED filter query too.

listingStatus=REJECTED is sent alongside moderationStatus whenever admin picks a rejected/suspended tab (see mapUIFiltersToAPI's moderationToListingStatus mirror on the FE), so this leaked pending-payment listings into that filtered view. The status column then correctly showed "Chờ thanh toán" for them (Listing.computeListingStatus checks PENDING_PAYMENT before moderationStatus) -- filter said rejected, badge said pending payment.

Add transactionId IS NULL to the REJECTED predicate, mirroring the condition that already distinguishes PENDING_PAYMENT.