### PR TITLE
refactor: give rejected/hidden/removed listings distinct moderation s…

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/dto/request/ListingFilterRequest.java
+++ b/smart-rent/src/main/java/com/smartrent/dto/request/ListingFilterRequest.java
@@ -64,15 +64,8 @@ public class ListingFilterRequest {
 
     @Schema(description = "Filter by moderation status (admin only)",
             example = "PENDING_REVIEW",
-            allowableValues = {"PENDING_REVIEW", "APPROVED", "REJECTED", "REVISION_REQUIRED", "RESUBMITTED", "SUSPENDED"})
+            allowableValues = {"PENDING_REVIEW", "APPROVED", "REJECTED", "REVISION_REQUIRED", "RESUBMITTED", "SUSPENDED", "REMOVED"})
     String moderationStatus;
-
-    @Schema(description = "Admin only. Only meaningful alongside moderationStatus=SUSPENDED, which is shared by "
-            + "two unrelated admin actions: rejecting a listing in the review queue (always creates a pending "
-            + "owner action) and temporarily hiding a listing under report review (never does). true narrows to "
-            + "the reject case, false narrows to the hide case; omit to match both.",
-            example = "true")
-    Boolean hasPendingOwnerAction;
 
     // ============ LOCATION FILTERS ============
     @Schema(description = """

--- a/smart-rent/src/main/java/com/smartrent/dto/response/AdminListingSummary.java
+++ b/smart-rent/src/main/java/com/smartrent/dto/response/AdminListingSummary.java
@@ -92,15 +92,9 @@ public class AdminListingSummary {
     @Schema(description = "Human-readable reason for last moderation action")
     String lastModerationReasonText;
 
-    @Schema(description = "True if this listing was permanently removed for a confirmed report violation " +
-            "(moderationStatus=SUSPENDED but the owner can never resubmit it) — distinguishes this from an " +
-            "ordinary admin suspend, which the owner can resubmit from")
+    @Schema(description = "True if this listing was permanently removed for a confirmed report violation. " +
+            "Redundant with moderationStatus=REMOVED now; kept for backward compatibility.")
     Boolean permanentlyRemoved;
-
-    @Schema(description = "True when moderationStatus=SUSPENDED came from rejecting the listing in the review " +
-            "queue (creates an owner action requiring the owner to fix and resubmit). False/absent when it came " +
-            "from temporarily hiding the listing during report review instead — no owner action is created for that.")
-    Boolean hasPendingOwnerAction;
 
     @Getter
     @Setter

--- a/smart-rent/src/main/java/com/smartrent/dto/response/ListingResponseWithAdmin.java
+++ b/smart-rent/src/main/java/com/smartrent/dto/response/ListingResponseWithAdmin.java
@@ -125,15 +125,9 @@ public class ListingResponseWithAdmin {
     @Schema(description = "Human-readable reason for last moderation action")
     String lastModerationReasonText;
 
-    @Schema(description = "True if this listing was permanently removed for a confirmed report violation " +
-            "(moderationStatus=SUSPENDED but the owner can never resubmit it) — distinguishes this from an " +
-            "ordinary admin suspend, which the owner can resubmit from")
+    @Schema(description = "True if this listing was permanently removed for a confirmed report violation. " +
+            "Redundant with moderationStatus=REMOVED now; kept for backward compatibility.")
     Boolean permanentlyRemoved;
-
-    @Schema(description = "Pending owner action (if any) — present when moderationStatus=SUSPENDED came from " +
-            "rejecting the listing in the review queue, absent when it came from temporarily hiding the listing " +
-            "during report review instead")
-    OwnerActionResponse pendingOwnerAction;
 
     @Schema(description = "Property information summary")
     PropertyInfo propertyInfo;

--- a/smart-rent/src/main/java/com/smartrent/enums/ModerationStatus.java
+++ b/smart-rent/src/main/java/com/smartrent/enums/ModerationStatus.java
@@ -7,8 +7,15 @@ package com.smartrent.enums;
 public enum ModerationStatus {
     PENDING_REVIEW,
     APPROVED,
+    // Admin rejected the listing in the review queue. Terminal from the owner's
+    // side (distinct from REVISION_REQUIRED, which invites a fix + resubmit).
     REJECTED,
     REVISION_REQUIRED,
     RESUBMITTED,
-    SUSPENDED
+    // Temporarily hidden while a report against the listing is under review.
+    // Reversible by the admin (unhide) — the owner is not expected to act.
+    SUSPENDED,
+    // Permanently removed for a confirmed report violation. Terminal, never
+    // resubmittable. Was previously encoded as SUSPENDED + permanentlyRemoved=true.
+    REMOVED
 }

--- a/smart-rent/src/main/java/com/smartrent/infra/repository/entity/Listing.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/entity/Listing.java
@@ -559,6 +559,10 @@ public class Listing {
                     return com.smartrent.enums.ListingStatus.REJECTED;
                 case REJECTED:
                     return com.smartrent.enums.ListingStatus.REJECTED;
+                case REMOVED:
+                    // Permanently removed — not publicly visible; grouped under the
+                    // REJECTED listing status like the other non-live moderation states.
+                    return com.smartrent.enums.ListingStatus.REJECTED;
                 case APPROVED:
                     if (this.expired != null && this.expired) {
                         return com.smartrent.enums.ListingStatus.EXPIRED;

--- a/smart-rent/src/main/java/com/smartrent/infra/repository/specification/ListingSpecification.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/specification/ListingSpecification.java
@@ -183,27 +183,6 @@ public class ListingSpecification {
                 }
             }
 
-            // hasPendingOwnerAction — only meaningful alongside moderationStatus=SUSPENDED,
-            // which is shared by rejecting a listing in the review queue (creates a pending
-            // owner action) and temporarily hiding it under report review (doesn't). Lets the
-            // admin table filter "Đã từ chối" apart from "Bị tạm ngưng" instead of showing both
-            // under one SUSPENDED bucket (see AdminListingSummary#hasPendingOwnerAction).
-            if (filter.getHasPendingOwnerAction() != null) {
-                Subquery<Long> ownerActionSubquery = query.subquery(Long.class);
-                var ownerActionRoot = ownerActionSubquery.from(
-                        com.smartrent.infra.repository.entity.ListingOwnerAction.class);
-                ownerActionSubquery.select(ownerActionRoot.get("listingId"))
-                        .where(criteriaBuilder.and(
-                                criteriaBuilder.equal(ownerActionRoot.get("listingId"), root.get("listingId")),
-                                criteriaBuilder.equal(ownerActionRoot.get("status"),
-                                        com.smartrent.enums.OwnerActionStatus.PENDING_OWNER)
-                        ));
-
-                predicates.add(Boolean.TRUE.equals(filter.getHasPendingOwnerAction())
-                        ? criteriaBuilder.exists(ownerActionSubquery)
-                        : criteriaBuilder.not(criteriaBuilder.exists(ownerActionSubquery)));
-            }
-
             // ============ LOCATION FILTERS ============
             // Category filter
             if (filter.getCategoryId() != null) {

--- a/smart-rent/src/main/java/com/smartrent/service/listing/ListingQueryService.java
+++ b/smart-rent/src/main/java/com/smartrent/service/listing/ListingQueryService.java
@@ -87,7 +87,6 @@ public class ListingQueryService {
         if (!Boolean.TRUE.equals(filter.getIsAdminRequest())) return false;
         if (!"PENDING_REVIEW".equals(filter.getModerationStatus())) return false;
         if (!"IN_REVIEW".equals(filter.getListingStatus())) return false;
-        if (filter.getHasPendingOwnerAction() != null) return false;
         String sortBy = filter.getSortBy();
         if (sortBy != null && !sortBy.isEmpty() && !"NEWEST".equals(sortBy) && !"DEFAULT".equals(sortBy)) return false;
 

--- a/smart-rent/src/main/java/com/smartrent/service/listing/impl/ListingServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/listing/impl/ListingServiceImpl.java
@@ -647,8 +647,13 @@ public class ListingServiceImpl implements ListingService {
             throw new DomainException(DomainCode.NOT_LISTING_OWNER);
         }
 
-        // Block updates on SUSPENDED listings
-        if (existing.getModerationStatus() == ModerationStatus.SUSPENDED) {
+        // Block generic edits on listings that are hidden, rejected, or removed.
+        // REVISION_REQUIRED is intentionally NOT blocked — that state exists precisely
+        // so the owner can fix and resubmit.
+        ModerationStatus modStatus = existing.getModerationStatus();
+        if (modStatus == ModerationStatus.SUSPENDED
+                || modStatus == ModerationStatus.REJECTED
+                || modStatus == ModerationStatus.REMOVED) {
             throw new DomainException(DomainCode.UPDATE_NOT_ALLOWED);
         }
         // Update fields from request (null-safe for partial update)
@@ -771,10 +776,7 @@ public class ListingServiceImpl implements ListingService {
                 ? userMapper.mapFromUserEntityToUserCreationResponse(userEntity)
                 : null;
 
-        ListingResponseWithAdmin response =
-                listingMapper.toResponseWithAdmin(listing, user, verifyingAdmin, verificationStatus, verificationNotes);
-        response.setPendingOwnerAction(listingModerationService.getOwnerPendingAction(id));
-        return response;
+        return listingMapper.toResponseWithAdmin(listing, user, verifyingAdmin, verificationStatus, verificationNotes);
     }
 
     /**
@@ -2075,15 +2077,10 @@ public class ListingServiceImpl implements ListingService {
                             LinkedHashMap::new,
                             Collectors.mapping(Media::getUrl, Collectors.toList())));
 
-            // ---- Batch-load pending owner actions — 1 query ----
-            // Lets the admin FE tell "rejected in review queue" apart from
-            // "temporarily hidden via report review" even though both share
-            // moderationStatus=SUSPENDED (see AdminListingSummary#hasPendingOwnerAction).
-            Map<Long, com.smartrent.dto.response.OwnerActionResponse> pendingActionsByListingId =
-                    listingModerationService.getOwnerPendingActions(listingIds);
-
             // ---- Map to slim AdminListingSummary DTOs ----
             // (No amenity/address fetch — list view does not need them.)
+            // The moderationStatus itself (REJECTED / SUSPENDED / REMOVED) now carries
+            // the distinction the admin table needs — no owner-action lookup required.
             listings = content.stream()
                     .map(listing -> {
                         String verificationStatus;
@@ -2096,11 +2093,7 @@ public class ListingServiceImpl implements ListingService {
                         }
                         com.smartrent.infra.repository.entity.User owner = userMap.get(listing.getUserId());
                         List<String> images = imagesByListingId.getOrDefault(listing.getListingId(), Collections.emptyList());
-                        com.smartrent.dto.response.AdminListingSummary summary =
-                                listingMapper.toAdminSummary(listing, owner, verificationStatus, images);
-                        summary.setHasPendingOwnerAction(
-                                pendingActionsByListingId.containsKey(listing.getListingId()));
-                        return summary;
+                        return listingMapper.toAdminSummary(listing, owner, verificationStatus, images);
                     })
                     .collect(Collectors.toList());
         } else {

--- a/smart-rent/src/main/java/com/smartrent/service/moderation/impl/ListingModerationServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/moderation/impl/ListingModerationServiceImpl.java
@@ -100,7 +100,7 @@ public class ListingModerationServiceImpl implements ListingModerationService {
 
         switch (decision) {
             case "APPROVE" -> handleApprove(listing, adminId);
-            case "REJECT" -> handleRejectOrRevision(listing, request, adminId, ModerationStatus.SUSPENDED, ModerationAction.REJECT);
+            case "REJECT" -> handleRejectOrRevision(listing, request, adminId, ModerationStatus.REJECTED, ModerationAction.REJECT);
             case "REQUEST_REVISION" -> handleRejectOrRevision(listing, request, adminId, ModerationStatus.REVISION_REQUIRED, ModerationAction.REQUEST_REVISION);
             case "SUSPEND" -> handleRejectOrRevision(listing, request, adminId, ModerationStatus.SUSPENDED, ModerationAction.SUSPEND);
             default -> throw new DomainException(DomainCode.MODERATION_INVALID_DECISION);
@@ -264,9 +264,11 @@ public class ListingModerationServiceImpl implements ListingModerationService {
 
         ModerationStatus previousStatus = listing.getModerationStatus();
 
-        listing.setModerationStatus(ModerationStatus.SUSPENDED);
+        listing.setModerationStatus(ModerationStatus.REMOVED);
         listing.setVerified(false);
         listing.setIsVerify(false);
+        // Keep the permanentlyRemoved column set too: the REMOVED status now carries
+        // this meaning, but the resubmit guard and older reads still consult the flag.
         listing.setPermanentlyRemoved(true);
         listing.setLastModeratedBy(adminId);
         listing.setLastModeratedAt(LocalDateTime.now());
@@ -275,7 +277,7 @@ public class ListingModerationServiceImpl implements ListingModerationService {
 
         // Audit event
         createModerationEvent(listingId, ModerationSource.REPORT_RESOLUTION,
-                previousStatus, ModerationStatus.SUSPENDED,
+                previousStatus, ModerationStatus.REMOVED,
                 ModerationAction.SUSPEND, adminId, null,
                 null, request.getAdminNotes(), reportId);
 

--- a/smart-rent/src/main/resources/db/migration/V111__Split_suspended_moderation_status.sql
+++ b/smart-rent/src/main/resources/db/migration/V111__Split_suspended_moderation_status.sql
@@ -1,0 +1,32 @@
+-- Split the overloaded moderation_status='SUSPENDED' into three distinct states.
+--
+-- SUSPENDED used to encode three unrelated outcomes, disambiguated only by the
+-- permanently_removed flag and the presence of a listing_owner_actions row:
+--   1. Admin rejected the listing in the review queue  -> now REJECTED
+--   2. Admin temporarily hid it while a report is open  -> stays SUSPENDED
+--   3. Report resolution permanently removed it          -> now REMOVED
+--
+-- Order matters: REMOVED is claimed first (permanently_removed wins), then the
+-- reject case (identified by a LISTING_REJECTED owner action — matched on the
+-- action's existence, not its current status, so already-actioned rejects are
+-- still reclassified), and whatever SUSPENDED remains is a genuine report hide.
+
+-- 3) Permanently removed via report resolution.
+UPDATE listings
+SET moderation_status = 'REMOVED'
+WHERE moderation_status = 'SUSPENDED'
+  AND permanently_removed = TRUE;
+
+-- 1) Rejected in the review queue (created a LISTING_REJECTED owner action).
+UPDATE listings l
+SET l.moderation_status = 'REJECTED'
+WHERE l.moderation_status = 'SUSPENDED'
+  AND l.permanently_removed = FALSE
+  AND EXISTS (
+      SELECT 1
+      FROM listing_owner_actions oa
+      WHERE oa.listing_id = l.listing_id
+        AND oa.trigger_type = 'LISTING_REJECTED'
+  );
+
+-- 2) Everything still SUSPENDED is a genuine "temporarily hidden under report" case.


### PR DESCRIPTION
…tatuses

moderationStatus=SUSPENDED was overloaded to mean three unrelated things, disambiguated downstream by the permanently_removed flag and the presence of a listing_owner_actions row. That forced every consumer (2 frontends + this service) to re-derive intent from side-channel flags, and the admin filter for "rejected" could not be expressed cleanly. Replace the overload with distinct statuses:

- admin REJECT in the review queue -> REJECTED (was SUSPENDED; REJECTED already existed as an enum value, only AI auto-reject used it)
- admin hide during report review  -> SUSPENDED (unchanged action, but the value now means ONLY "temporarily hidden")
- report resolution removal        -> REMOVED (new enum value; still sets
  permanently_removed=true for backward-compat reads)

Consequences:
- Listing.computeListingStatus maps REMOVED -> REJECTED like the other non-live states, so the public getListingById gate already 404s it (verified via isPubliclyVisible)
- updateListing now blocks SUSPENDED/REJECTED/REMOVED (REVISION_REQUIRED stays editable — that's the fix-and-resubmit state)
- deleted the whole hasPendingOwnerAction machinery that only existed to split SUSPENDED: the ListingSpecification EXISTS subquery, the ListingFilterRequest param, the ListingQueryService fast-path guard, and the AdminListingSummary / ListingResponseWithAdmin response fields — the status value carries the distinction now
- V111 migration reclassifies existing SUSPENDED rows: permanently_removed -> REMOVED, has a LISTING_REJECTED owner action -> REJECTED, rest stay SUSPENDED (genuine report hides)
- SUSPENDED is kept in the enum (ListingModerationEvent audit rows persist it, and it's still a live status), so no audit hydration breaks