### PR TITLE
fix: classify admin JWTs as ADMIN recipients so their notifications load

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/service/authentication/impl/AdminAuthenticationServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/authentication/impl/AdminAuthenticationServiceImpl.java
@@ -141,6 +141,11 @@ public class AdminAuthenticationServiceImpl extends AuthenticationServiceImpl {
           .expirationTime(new Date(Instant.now().plus(duration, ChronoUnit.SECONDS).toEpochMilli()))
           .claim("rfId", otherId)
           .claim("scope", buildScope(admin))
+          // Top-level admin_id lets JwtRecipientResolver classify this token as an
+          // ADMIN recipient. Without it, admin notifications (stored with
+          // recipientType=ADMIN) never matched the REST list/unread/mark-read
+          // queries, which resolved the type from this claim and fell back to USER.
+          .claim("admin_id", admin.getAdminId())
           .claim("user", adminMapper.mapFromAdminEntityToJwtAdminClaimsDto(admin))
           .build();
     } catch (Exception e) {

--- a/smart-rent/src/main/java/com/smartrent/util/JwtRecipientResolver.java
+++ b/smart-rent/src/main/java/com/smartrent/util/JwtRecipientResolver.java
@@ -1,5 +1,6 @@
 package com.smartrent.util;
 
+import com.smartrent.config.Constants;
 import com.smartrent.enums.RecipientType;
 import org.springframework.security.oauth2.jwt.Jwt;
 
@@ -31,7 +32,20 @@ public final class JwtRecipientResolver {
     }
 
     public static RecipientType resolveRecipientType(Jwt jwt) {
-        String adminId = jwt.getClaimAsString("admin_id");
-        return adminId != null ? RecipientType.ADMIN : RecipientType.USER;
+        if (jwt.getClaimAsString("admin_id") != null) {
+            return RecipientType.ADMIN;
+        }
+
+        // Fallback for admin access tokens minted before the admin_id claim was
+        // added: a user token carries scope exactly "ROLE_USER", while an admin
+        // token carries its admin role scopes (ROLE_SA / ROLE_UA / ROLE_SPA).
+        // Anything that isn't the plain user scope is an admin.
+        String scope = jwt.getClaimAsString("scope");
+        if (scope != null && !scope.isBlank()
+                && !Constants.ROLE_USER.equals(scope.trim())) {
+            return RecipientType.ADMIN;
+        }
+
+        return RecipientType.USER;
     }
 }


### PR DESCRIPTION
JwtRecipientResolver.resolveRecipientType() keyed off a top-level admin_id claim, but the admin access token never carried one (adminId was only the subject + nested user claim). So every admin request resolved to recipientType=USER, while admin notifications are stored with recipientType=ADMIN — the REST list, unread-count and mark-as-read queries therefore never matched and the admin notification panel/badge were always empty. (Realtime push was unaffected: it routes on recipientId=subject only, which is why a live toast could arrive while the list stayed empty.)

- add a top-level admin_id claim to the admin access token so new tokens classify correctly and self-describe
- add a scope fallback in resolveRecipientType (user tokens carry scope "ROLE_USER"; admin tokens carry ROLE_SA/UA/SPA) so admins already logged in are fixed immediately without needing to re-login