### PR TITLE
fix: keep paid-then-rejected listings classified and filterable as RE…

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/infra/repository/entity/Listing.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/entity/Listing.java
@@ -539,10 +539,17 @@ public class Listing {
             return com.smartrent.enums.ListingStatus.EXPIRED;
         }
 
-        // 2. PENDING_PAYMENT - Has transaction but not completed
+        // 2. PENDING_PAYMENT - transaction started but not completed, AND the
+        // listing has not been moderated to a decided state yet. A listing that
+        // was paid and later rejected/suspended/removed still carries its
+        // transactionId, so without the moderationStatus guard it would read as
+        // "pending payment" and mask the real rejection (the moderation outcome in
+        // 2.5 must win). A genuinely unpaid listing sits at PENDING_REVIEW/null.
         if (this.transactionId != null && !this.transactionId.isEmpty() &&
             (this.verified == null || !this.verified) &&
-            (this.isVerify == null || !this.isVerify)) {
+            (this.isVerify == null || !this.isVerify) &&
+            (this.moderationStatus == null
+                || this.moderationStatus == com.smartrent.enums.ModerationStatus.PENDING_REVIEW)) {
             return com.smartrent.enums.ListingStatus.PENDING_PAYMENT;
         }
 

--- a/smart-rent/src/main/java/com/smartrent/infra/repository/specification/ListingSpecification.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/specification/ListingSpecification.java
@@ -924,18 +924,27 @@ public class ListingSpecification {
                 );
 
             case REJECTED ->
-                // verified = false AND isVerify = false AND isDraft = false AND postDate is not
-                // null AND transactionId is null. That last condition is required — without it
-                // this predicate is a strict subset match of PENDING_PAYMENT's own predicate
-                // (verified=false AND isVerify=false, plus transactionId is not null), so a
-                // listing awaiting payment satisfies REJECTED's conditions too and leaks into
-                // admin's "Đã Từ Chối" filter/status column.
+                // verified=false AND isVerify=false AND isDraft=false AND postDate not null,
+                // EXCLUDING only genuine pending-payment listings. This must mirror
+                // Listing.computeListingStatus() exactly: a listing that was paid and then
+                // rejected/suspended keeps its transactionId but is REJECTED, not
+                // PENDING_PAYMENT — so a blanket "transactionId is null" wrongly dropped
+                // paid-then-rejected listings out of the "Đã Từ Chối" filter. Pending-payment
+                // is only "has a transaction AND not yet moderated to a decided state"
+                // (moderationStatus null or PENDING_REVIEW); exclude exactly that.
                 criteriaBuilder.and(
                     criteriaBuilder.isFalse(root.get("verified")),
                     criteriaBuilder.isFalse(root.get("isVerify")),
                     criteriaBuilder.isFalse(root.get("isDraft")),
                     criteriaBuilder.isNotNull(root.get("postDate")),
-                    criteriaBuilder.isNull(root.get("transactionId"))
+                    criteriaBuilder.not(criteriaBuilder.and(
+                        criteriaBuilder.isNotNull(root.get("transactionId")),
+                        criteriaBuilder.or(
+                            criteriaBuilder.isNull(root.get("moderationStatus")),
+                            criteriaBuilder.equal(root.get("moderationStatus"),
+                                com.smartrent.enums.ModerationStatus.PENDING_REVIEW)
+                        )
+                    ))
                 );
 
             case VERIFIED ->


### PR DESCRIPTION
…JECTED

A listing paid for via a transaction keeps its transactionId forever. When such a listing was later rejected/suspended, two places still treated it as "pending payment":

1. Listing.computeListingStatus() checked PENDING_PAYMENT (transactionId set + not verified + not in review) BEFORE the moderationStatus block, so a paid-then-rejected listing computed to PENDING_PAYMENT and the status badge showed "Chờ thanh toán" instead of "Bị từ chối".
2. buildStatusPredicate(REJECTED) required transactionId IS NULL (added to stop genuine pending-payment listings leaking into the REJECTED filter), which also dropped paid-then-rejected listings — so the seller "Đã từ chối" tab and the admin rejected filter showed nothing while the listing still appeared under "Tất cả".

Both now treat PENDING_PAYMENT as "has a transaction AND is not yet moderated to a decided state" (moderationStatus null or PENDING_REVIEW). A decided moderation outcome (REJECTED/SUSPENDED/REMOVED/REVISION_REQUIRED) wins over the stale transactionId, so paid-then-rejected listings read as REJECTED and stay in the rejected filters. Genuine unpaid listings (moderationStatus null/PENDING_REVIEW) are still excluded from REJECTED.