### PR TITLE
fix: set postDate on VIP listings so a rejected one stays filterable

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/service/listing/impl/ListingServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/listing/impl/ListingServiceImpl.java
@@ -517,6 +517,12 @@ public class ListingServiceImpl implements ListingService {
                 // IN_REVIEW and must carry PENDING_REVIEW so it shows on the seller's
                 // IN_REVIEW tab and enters the admin moderation queue.
                 .moderationStatus(ModerationStatus.PENDING_REVIEW)
+                // Mirror ListingMapperImpl.toEntity:42 — without postDate, a VIP
+                // listing that's later rejected fails buildStatusPredicate(REJECTED)'s
+                // "postDate IS NOT NULL" check (computeListingStatus doesn't check it,
+                // so the listing still shows unfiltered — it just vanishes from any
+                // REJECTED filter/search).
+                .postDate(java.time.LocalDateTime.now())
                 .expired(false)
                 .build();
     }
@@ -555,6 +561,10 @@ public class ListingServiceImpl implements ListingService {
                 .parentListingId(premiumListing.getListingId())
                 .postSource(premiumListing.getPostSource()) // Same source as parent
                 .transactionId(premiumListing.getTransactionId()) // Same transaction as parent
+                // Mirror the parent's postDate (see buildListingFromVipRequest) — a null
+                // postDate makes buildStatusPredicate(REJECTED) never match this row.
+                .postDate(premiumListing.getPostDate() != null
+                        ? premiumListing.getPostDate() : java.time.LocalDateTime.now())
                 .build();
 
         listingRepository.save(shadowListing);

--- a/smart-rent/src/main/resources/db/migration/V112__Backfill_null_post_date.sql
+++ b/smart-rent/src/main/resources/db/migration/V112__Backfill_null_post_date.sql
@@ -1,0 +1,13 @@
+-- buildListingFromVipRequest (VIP listing creation, including SePay-paid VIP
+-- listings) never set post_date, unlike the mapper path used for NORMAL
+-- listings. computeListingStatus() doesn't check post_date for the
+-- moderation-status branch, so these rows still displayed fine — but
+-- buildStatusPredicate(REJECTED) requires post_date IS NOT NULL, so a VIP
+-- listing that got rejected silently vanished from any REJECTED filter/search
+-- while still showing up in the unfiltered list. Backfill existing rows with
+-- their creation time, the closest available approximation of when they were
+-- actually posted.
+UPDATE listings
+SET post_date = created_at
+WHERE post_date IS NULL
+  AND created_at IS NOT NULL;


### PR DESCRIPTION
buildListingFromVipRequest (VIP listing creation — including SePay-paid VIP listings) never set postDate, unlike ListingMapperImpl.toEntity used for NORMAL listings. computeListingStatus() doesn't check postDate on the moderationStatus branch, so a null postDate never affected the status shown in an unfiltered list. But buildStatusPredicate(REJECTED) requires postDate IS NOT NULL — so a VIP listing that got rejected silently vanished from any REJECTED filter/search on both seller and admin, while still showing up in the plain listing list. createShadowListing (built from the same VIP request) had the identical gap.

- buildListingFromVipRequest: postDate = now()
- createShadowListing: mirror the parent's postDate
- V112 migration backfills existing NULL post_date rows to created_at, so already-rejected VIP listings become filterable without re-creating them