### PR TITLE
fix: notify admins when a new listing enters the moderation queue

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/enums/NotificationType.java
+++ b/smart-rent/src/main/java/com/smartrent/enums/NotificationType.java
@@ -16,6 +16,7 @@ public enum NotificationType {
     LISTING_RESUBMITTED,
     LISTING_PENDING_REVIEW,          // owner notified when listing is routed to manual review (e.g. duplicate detected)
     LISTING_DUPLICATE_DETECTED,      // admins notified when AI flags a listing as duplicate/suspicious
+    NEW_LISTING_PENDING_REVIEW,      // admins notified when a newly submitted listing enters the moderation queue
 
     // Broker-related
     BROKER_REGISTRATION_RECEIVED,   // admins are notified when a user submits registration

--- a/smart-rent/src/main/java/com/smartrent/service/listing/impl/ListingServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/listing/impl/ListingServiceImpl.java
@@ -27,6 +27,7 @@ import com.smartrent.dto.response.ProvinceListingStatsResponse;
 import com.smartrent.enums.BenefitType;
 import com.smartrent.enums.ListingStatus;
 import com.smartrent.enums.ModerationStatus;
+import com.smartrent.enums.NotificationType;
 import com.smartrent.enums.PostSource;
 import com.smartrent.infra.exception.AppException;
 import com.smartrent.infra.exception.DomainException;
@@ -57,6 +58,7 @@ import com.smartrent.service.listing.ListingService;
 import com.smartrent.service.listing.ListingQueryService;
 import com.smartrent.service.listing.PostingAccessGuard;
 import com.smartrent.service.listing.cache.ListingRequestCacheService;
+import com.smartrent.service.notification.NotificationService;
 import com.smartrent.util.TextNormalizer;
 // import com.smartrent.service.pricing.LocationPricingService;  // DISABLED: Not in use
 import com.smartrent.service.quota.QuotaService;
@@ -135,6 +137,7 @@ public class ListingServiceImpl implements ListingService {
     com.smartrent.service.moderation.ListingModerationService listingModerationService;
     com.smartrent.infra.repository.UserFollowRepository userFollowRepository;
     PostingAccessGuard postingAccessGuard;
+    NotificationService notificationService;
 
     @Override
     @Transactional
@@ -253,6 +256,7 @@ public class ListingServiceImpl implements ListingService {
         Listing saved = listingRepository.save(listing);
         log.info("Listing created successfully with quota - id: {}, vipType: {}, benefitIds: {}",
                 saved.getListingId(), vipType, request.getBenefitIds());
+        notifyAdminsNewListingPendingReview(saved);
 
         // Link media to listing if provided (within same transaction)
         if (request.getMediaIds() != null && !request.getMediaIds().isEmpty()) {
@@ -569,6 +573,25 @@ public class ListingServiceImpl implements ListingService {
 
         listingRepository.save(shadowListing);
         log.info("Shadow listing created successfully");
+    }
+
+    /**
+     * Realtime notification: tell all admins a newly submitted listing entered
+     * the moderation queue (covers quota/package postings and paid/SePay
+     * postings alike). Best-effort — a notification failure must not fail
+     * listing creation.
+     */
+    private void notifyAdminsNewListingPendingReview(Listing listing) {
+        try {
+            notificationService.sendToAllAdmins(
+                    NotificationType.NEW_LISTING_PENDING_REVIEW,
+                    "Có tin đăng mới chờ duyệt",
+                    "Tin đăng \"" + listing.getTitle() + "\" đang chờ được xem xét.",
+                    listing.getListingId(), "LISTING");
+        } catch (Exception e) {
+            log.warn("Failed to send new-listing admin notification for listing {}: {}",
+                    listing.getListingId(), e.getMessage());
+        }
     }
 
     @Override
@@ -1098,6 +1121,7 @@ public class ListingServiceImpl implements ListingService {
             Listing saved = listingRepository.save(listing);
             log.info("NORMAL listing created successfully with id: {} for transaction: {}",
                     saved.getListingId(), transactionId);
+            notifyAdminsNewListingPendingReview(saved);
 
             // Link media if provided
             if (request.getMediaIds() != null && !request.getMediaIds().isEmpty()) {
@@ -1153,6 +1177,7 @@ public class ListingServiceImpl implements ListingService {
             Listing savedVipListing = listingRepository.save(vipListing);
             log.info("VIP listing created with id: {} for transaction: {}",
                     savedVipListing.getListingId(), transactionId);
+            notifyAdminsNewListingPendingReview(savedVipListing);
 
             // Link media if provided
             if (request.getMediaIds() != null && !request.getMediaIds().isEmpty()) {


### PR DESCRIPTION
Submitting a listing for review - via membership/package quota or via paid/SePay checkout - never sent admins any notification or websocket event, so the admin content/posts page had nothing to react to and only ever refreshed on manual filter changes. Add NEW_LISTING_PENDING_REVIEW and fire it to all admins from the three places a listing actually gets persisted into PENDING_REVIEW (quota flow, and normal/VIP creation after payment confirmation).