### PR TITLE
feat(duplicate-detection): listingId self-exclusion, imageSimilarity, symmetric notif

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/cronjob/AiListingAutoModerationScheduler.java
+++ b/smart-rent/src/main/java/com/smartrent/cronjob/AiListingAutoModerationScheduler.java
@@ -49,17 +49,27 @@ public class AiListingAutoModerationScheduler {
      */
     private final AtomicBoolean aiAutoModerationEnabled;
 
+    /**
+     * Number of listings pulled per scheduler tick. Lower it (e.g. 3-5) to drain a
+     * large one-time backlog without pinning the single AI worker's CPU — fewer
+     * concurrent CPU-bound duplicate checks, roughly the same throughput (the GIL
+     * serializes them anyway). Default 20 preserves the original behavior.
+     */
+    private final int batchSize;
+
     public AiListingAutoModerationScheduler(
             ListingRepository listingRepository,
             ListingAiModerationRepository listingAiModerationRepository,
             AiModerationProcessorService aiModerationProcessorService,
             AiModerationExecutor aiModerationExecutor,
-            @Value("${smartrent.ai.verification.scheduler.enabled:true}") boolean initiallyEnabled) {
+            @Value("${smartrent.ai.verification.scheduler.enabled:true}") boolean initiallyEnabled,
+            @Value("${smartrent.ai.verification.scheduler.batch-size:20}") int batchSize) {
         this.listingRepository = listingRepository;
         this.listingAiModerationRepository = listingAiModerationRepository;
         this.aiModerationProcessorService = aiModerationProcessorService;
         this.aiModerationExecutor = aiModerationExecutor;
         this.aiAutoModerationEnabled = new AtomicBoolean(initiallyEnabled);
+        this.batchSize = batchSize > 0 ? batchSize : 20;
     }
 
     /** Called by the admin API to enable AI auto-moderation. */
@@ -123,7 +133,7 @@ public class AiListingAutoModerationScheduler {
         log.info("Starting AI Auto Moderation Scheduler...");
 
         try {
-            Page<Listing> pendingListings = listingRepository.findListingsNeedingAiVerification(PageRequest.of(0, 20));
+            Page<Listing> pendingListings = listingRepository.findListingsNeedingAiVerification(PageRequest.of(0, batchSize));
             List<Listing> listings = pendingListings.getContent();
 
             if (listings.isEmpty()) {

--- a/smart-rent/src/main/java/com/smartrent/dto/request/DuplicateCheckRequest.java
+++ b/smart-rent/src/main/java/com/smartrent/dto/request/DuplicateCheckRequest.java
@@ -12,6 +12,7 @@ import java.util.List;
 @AllArgsConstructor
 @FieldDefaults(level = AccessLevel.PRIVATE)
 public class DuplicateCheckRequest {
+    Long listingId;
     String title;
     String description;
     Double price;

--- a/smart-rent/src/main/java/com/smartrent/dto/response/DuplicateCheckResponse.java
+++ b/smart-rent/src/main/java/com/smartrent/dto/response/DuplicateCheckResponse.java
@@ -31,6 +31,7 @@ public class DuplicateCheckResponse {
         double descriptionSimilarity;
         double addressSimilarity;
         double priceSimilarity;
+        double imageSimilarity;
         Double llmScore;
         String llmReason;
     }

--- a/smart-rent/src/main/java/com/smartrent/service/ai/impl/AiModerationProcessorServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/ai/impl/AiModerationProcessorServiceImpl.java
@@ -147,12 +147,17 @@ public class AiModerationProcessorServiceImpl implements AiModerationProcessorSe
             log.info("Finished processing listing ID: {}, verificationStatus: {}, moderationStatus: {}",
                     listing.getListingId(), moderation.getVerificationStatus(), listing.getModerationStatus());
 
-            boolean downgradedByDuplicate = duplicateResult != null
-                    && ("DUPLICATE".equals(duplicateResult.getDecision()) || "SUSPICIOUS".equals(duplicateResult.getDecision()))
-                    && "APPROVED".equals(suggestedStatus);
+            boolean flaggedDuplicate = duplicateResult != null
+                    && ("DUPLICATE".equals(duplicateResult.getDecision())
+                        || "SUSPICIOUS".equals(duplicateResult.getDecision()));
+            // Notify whenever the listing is flagged as a duplicate AND is not
+            // rejected — covers both a downgraded APPROVE and a listing already
+            // heading to manual review (NEEDS_REVIEW), which previously got no
+            // duplicate-specific alert to either owner or admins.
+            boolean duplicateNeedsReview = flaggedDuplicate && !"REJECTED".equals(suggestedStatus);
 
-            sendOwnerNotification(listing, suggestedStatus, downgradedByDuplicate);
-            if (downgradedByDuplicate) {
+            sendOwnerNotification(listing, suggestedStatus, duplicateNeedsReview);
+            if (duplicateNeedsReview) {
                 sendAdminDuplicateNotification(listing, duplicateResult);
             }
 
@@ -164,13 +169,13 @@ public class AiModerationProcessorServiceImpl implements AiModerationProcessorSe
         }
     }
 
-    private void sendOwnerNotification(Listing listing, String suggestedStatus, boolean downgradedByDuplicate) {
+    private void sendOwnerNotification(Listing listing, String suggestedStatus, boolean duplicateNeedsReview) {
         if (listing.getUserId() == null) return;
 
         NotificationType notifType;
         String notifMessage;
 
-        if (downgradedByDuplicate) {
+        if (duplicateNeedsReview) {
             notifType = NotificationType.LISTING_PENDING_REVIEW;
             notifMessage = "Tin đăng \"" + listing.getTitle() + "\" của bạn đang được xem xét thủ công do hệ thống phát hiện nội dung tương tự với tin đăng khác.";
         } else if ("APPROVED".equals(suggestedStatus)) {
@@ -221,6 +226,7 @@ public class AiModerationProcessorServiceImpl implements AiModerationProcessorSe
     private DuplicateCheckResponse runDuplicateCheck(Listing listing, AiListingVerificationRequest request) {
         try {
             DuplicateCheckRequest.DuplicateCheckRequestBuilder builder = DuplicateCheckRequest.builder()
+                    .listingId(listing.getListingId())
                     .title(request.getTitle())
                     .description(request.getDescription())
                     .price(request.getPrice() != null ? request.getPrice().doubleValue() : null)

--- a/smart-rent/src/main/resources/application.yml
+++ b/smart-rent/src/main/resources/application.yml
@@ -533,6 +533,9 @@ smartrent:
       scheduler:
         enabled: ${AI_SCHEDULER_ENABLED:true}
         delay: ${AI_SCHEDULER_DELAY_MS:300000}
+        # Listings processed per tick. Lower (e.g. 3-5) to drain a large one-time
+        # backlog without pinning the single AI worker's CPU. Default 20.
+        batch-size: ${AI_SCHEDULER_BATCH_SIZE:20}
       url: ${AI_VERIFICATION_URL:http://localhost:8000/ai/verify-listing}
       timeout-seconds: ${AI_VERIFICATION_TIMEOUT:90}
       max-retry-attempts: ${AI_VERIFICATION_MAX_RETRY:3}


### PR DESCRIPTION
Backend side of the duplicate-detection pHash + recall work. The AI repo (Vuhuydiet/smartrent-ai#76) carries the detection pipeline; this PR is the contract + moderation-wiring changes it needs.

## What changed
- **`DuplicateCheckRequest`:** add `listingId` so the AI can exclude the listing from its own candidate set (defensive against self-match on re-moderation of an already-approved listing).
- **`DuplicateCheckResponse.SuspiciousMatch`:** add `imageSimilarity` (pHash signal); `runDuplicateCheck` now passes `listingId`.
- **`AiModerationProcessorServiceImpl`:** notify admins **and** the owner whenever a listing is flagged `DUPLICATE`/`SUSPICIOUS` and not rejected — not only when a would-be APPROVE was downgraded. Previously a `NEEDS_REVIEW` + `DUPLICATE` listing got no duplicate-specific alert to either party (info was buried in `aiReason` JSON only).

## Notes
- Behavior unchanged when the AI returns no duplicate flag. Duplicate check remains best-effort (AI failure → treated as PASS, never blocks moderation).
- Deploy the AI PR **first** (this backend swallows the AI call as PASS until the new endpoint fields exist).
- Compiles: `gradlew compileJava` exit 0.