### PR TITLE
feat(ai-moderation): admin on-demand duplicate check endpoint

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/controller/AiListingVerificationController.java
+++ b/smart-rent/src/main/java/com/smartrent/controller/AiListingVerificationController.java
@@ -3,6 +3,7 @@ package com.smartrent.controller;
 import com.smartrent.dto.request.AiListingVerificationRequest;
 import com.smartrent.dto.response.AiListingVerificationResponse;
 import com.smartrent.dto.response.ApiResponse;
+import com.smartrent.dto.response.DuplicateCheckResponse;
 import com.smartrent.service.ai.AiListingVerificationService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -195,6 +196,30 @@ public class AiListingVerificationController {
 
         return ResponseEntity.ok(ApiResponse.<AiListingVerificationResponse>builder()
                 .message("Listing verification completed successfully")
+                .data(response)
+                .build());
+    }
+
+    @PostMapping("/{listingId}/check-duplicate")
+    @Operation(
+        summary = "Check an existing listing for duplicates using AI",
+        description = "Runs the AI duplicate-detection pipeline (candidate retrieval + TF-IDF/fuzzy "
+                + "scoring + LLM & perceptual-hash image confirmation) for an existing listing by ID. "
+                + "Stateless: persists nothing. Returns the decision (PASS/SUSPICIOUS/DUPLICATE), the "
+                + "highest similarity score, and the matched listings for the admin to review manually.",
+        parameters = {
+            @Parameter(name = "listingId", description = "The ID of the listing to check", required = true, example = "123")
+        }
+    )
+    public ResponseEntity<ApiResponse<DuplicateCheckResponse>> checkDuplicate(
+            @PathVariable Long listingId) {
+
+        log.info("Received AI duplicate check request for listing ID: {}", listingId);
+
+        DuplicateCheckResponse response = aiListingVerificationService.checkDuplicateById(listingId);
+
+        return ResponseEntity.ok(ApiResponse.<DuplicateCheckResponse>builder()
+                .message("Duplicate check completed successfully")
                 .data(response)
                 .build());
     }

--- a/smart-rent/src/main/java/com/smartrent/service/ai/AiListingVerificationService.java
+++ b/smart-rent/src/main/java/com/smartrent/service/ai/AiListingVerificationService.java
@@ -2,6 +2,7 @@ package com.smartrent.service.ai;
 
 import com.smartrent.dto.request.AiListingVerificationRequest;
 import com.smartrent.dto.response.AiListingVerificationResponse;
+import com.smartrent.dto.response.DuplicateCheckResponse;
 import com.smartrent.infra.repository.entity.Listing;
 
 /**
@@ -35,8 +36,20 @@ public interface AiListingVerificationService {
     AiListingVerificationRequest buildVerificationRequest(Long listingId);
 
     /**
+     * Run a duplicate-listing check for an existing listing by ID. Builds the
+     * duplicate-check request from the stored listing (title/description/price/
+     * area/images + resolved location + product type) and calls the AI service.
+     * Stateless — returns the structured duplicate result for the admin to use
+     * during manual review; persists nothing.
+     *
+     * @param listingId The listing ID
+     * @return The duplicate-check result (decision, highest score, matches)
+     */
+    DuplicateCheckResponse checkDuplicateById(Long listingId);
+
+    /**
      * Check if the AI verification service is available
-     * 
+     *
      * @return true if the service is available, false otherwise
      */
     boolean isServiceAvailable();

--- a/smart-rent/src/main/java/com/smartrent/service/ai/impl/AiListingVerificationServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/ai/impl/AiListingVerificationServiceImpl.java
@@ -1,9 +1,12 @@
 package com.smartrent.service.ai.impl;
 
 import com.smartrent.dto.request.AiListingVerificationRequest;
+import com.smartrent.dto.request.DuplicateCheckRequest;
 import com.smartrent.dto.response.AiListingVerificationResponse;
+import com.smartrent.dto.response.DuplicateCheckResponse;
 import com.smartrent.infra.exception.AppException;
 import com.smartrent.infra.exception.model.DomainCode;
+import com.smartrent.infra.repository.entity.Address;
 import com.smartrent.infra.repository.entity.Listing;
 import com.smartrent.mapper.AiListingMapper;
 import com.smartrent.service.ai.AiListingVerificationService;
@@ -236,6 +239,37 @@ public class AiListingVerificationServiceImpl implements AiListingVerificationSe
         }
         
         return request;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public DuplicateCheckResponse checkDuplicateById(Long listingId) {
+        AiListingVerificationRequest request = buildVerificationRequest(listingId);
+        Listing listing = listingRepository.findByIdWithAmenities(listingId)
+            .orElseThrow(() -> new IllegalArgumentException("Listing not found with id: " + listingId));
+
+        // Same mapping the auto-moderation cronjob uses (runDuplicateCheck): reuse
+        // the fields already gathered for verification and enrich with structured
+        // location + product type so the AI can retrieve candidates.
+        DuplicateCheckRequest.DuplicateCheckRequestBuilder builder = DuplicateCheckRequest.builder()
+            .listingId(listing.getListingId())
+            .title(request.getTitle())
+            .description(request.getDescription())
+            .price(request.getPrice() != null ? request.getPrice().doubleValue() : null)
+            .area(request.getArea())
+            .address(request.getAddress())
+            .productType(listing.getProductType() != null ? listing.getProductType().name() : null)
+            .imageUrls(request.getImages());
+
+        Address addr = listing.getAddress();
+        if (addr != null) {
+            String provinceCode = addr.getNewProvinceCode() != null
+                ? addr.getNewProvinceCode()
+                : (addr.getLegacyProvinceId() != null ? String.valueOf(addr.getLegacyProvinceId()) : null);
+            builder.provinceCode(provinceCode).districtId(addr.getLegacyDistrictId());
+        }
+
+        return smartRentAiConnector.checkDuplicate(builder.build());
     }
 
     @Override


### PR DESCRIPTION
Exposes the AI duplicate-detection pipeline for admin manual review, mirroring the stateless on-demand `/verify` endpoint. Pairs with the admin-FE PR (Shungisme/smartrent-fe: feat/admin-duplicate-check-ui).

## What changed
- **`AiListingVerificationController`**: `POST /v1/ai/listings/{listingId}/check-duplicate`.
- **`AiListingVerificationService.checkDuplicateById()`**: builds the `DuplicateCheckRequest` from the stored listing (same mapping as the auto-moderation cronjob's `runDuplicateCheck` — title/description/price/area/images + resolved province/district + product type) and calls the AI connector. Stateless — persists nothing; returns decision (PASS/SUSPICIOUS/DUPLICATE) + highest score + matches.

## Notes
- Builds on the merged duplicate-detection work (connector `checkDuplicate`, `DuplicateCheckResponse`).
- Compiles: `gradlew compileJava` exit 0. Manually tested end-to-end by the author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)