### PR TITLE
feat(ai-moderation): stored moderation result for admin replay

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/controller/AiListingVerificationController.java
+++ b/smart-rent/src/main/java/com/smartrent/controller/AiListingVerificationController.java
@@ -4,6 +4,7 @@ import com.smartrent.dto.request.AiListingVerificationRequest;
 import com.smartrent.dto.response.AiListingVerificationResponse;
 import com.smartrent.dto.response.ApiResponse;
 import com.smartrent.dto.response.DuplicateCheckResponse;
+import com.smartrent.dto.response.StoredAiModerationResponse;
 import com.smartrent.service.ai.AiListingVerificationService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -196,6 +197,30 @@ public class AiListingVerificationController {
 
         return ResponseEntity.ok(ApiResponse.<AiListingVerificationResponse>builder()
                 .message("Listing verification completed successfully")
+                .data(response)
+                .build());
+    }
+
+    @GetMapping("/{listingId}/moderation-result")
+    @Operation(
+        summary = "Get the stored AI moderation result for a listing",
+        description = "Returns the AI analysis (verification + duplicate check) the auto-moderation "
+                + "cronjob already persisted for a listing, so the admin review UI can show it without "
+                + "re-running the AI. Returns data=null when no stored result exists.",
+        parameters = {
+            @Parameter(name = "listingId", description = "The ID of the listing", required = true, example = "123")
+        }
+    )
+    public ResponseEntity<ApiResponse<StoredAiModerationResponse>> getStoredModerationResult(
+            @PathVariable Long listingId) {
+
+        StoredAiModerationResponse response =
+                aiListingVerificationService.getStoredModerationResult(listingId);
+
+        return ResponseEntity.ok(ApiResponse.<StoredAiModerationResponse>builder()
+                .message(response != null
+                        ? "Stored moderation result retrieved successfully"
+                        : "No stored moderation result for this listing")
                 .data(response)
                 .build());
     }

--- a/smart-rent/src/main/java/com/smartrent/dto/response/StoredAiModerationResponse.java
+++ b/smart-rent/src/main/java/com/smartrent/dto/response/StoredAiModerationResponse.java
@@ -1,0 +1,50 @@
+package com.smartrent.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.FieldDefaults;
+
+import java.time.LocalDateTime;
+
+/**
+ * The AI moderation result stored by the auto-moderation cronjob, replayed for
+ * admins so the review UI can show the analysis without re-running it.
+ *
+ * <p>{@code verification} and {@code duplicateCheck} are deserialized from the
+ * {@code listing_ai_moderation.ai_reason} JSON (written as
+ * {@code {verification, duplicateCheck}}) and re-serialized with their own
+ * field annotations — verification stays snake_case, duplicateCheck camelCase —
+ * so the admin frontend consumes them with the exact types the on-demand
+ * /verify and /check-duplicate endpoints already return.
+ */
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@FieldDefaults(level = AccessLevel.PRIVATE)
+@JsonIgnoreProperties(ignoreUnknown = true)
+@Schema(description = "Stored AI moderation result (verification + duplicate check) for a listing")
+public class StoredAiModerationResponse {
+
+    @Schema(description = "Stored AI verification analysis (null if not present)")
+    AiListingVerificationResponse verification;
+
+    @Schema(description = "Stored AI duplicate-check result (null if not present)")
+    DuplicateCheckResponse duplicateCheck;
+
+    @Schema(description = "Overall AI score persisted on the moderation record")
+    Double aiScore;
+
+    @Schema(description = "Moderation verification status (VERIFIED, REJECTED, UNDER_REVIEW, PENDING, ...)")
+    String verificationStatus;
+
+    @Schema(description = "When the moderation record was last updated (i.e. when the AI analyzed it)")
+    LocalDateTime analyzedAt;
+}

--- a/smart-rent/src/main/java/com/smartrent/service/ai/AiListingVerificationService.java
+++ b/smart-rent/src/main/java/com/smartrent/service/ai/AiListingVerificationService.java
@@ -3,6 +3,7 @@ package com.smartrent.service.ai;
 import com.smartrent.dto.request.AiListingVerificationRequest;
 import com.smartrent.dto.response.AiListingVerificationResponse;
 import com.smartrent.dto.response.DuplicateCheckResponse;
+import com.smartrent.dto.response.StoredAiModerationResponse;
 import com.smartrent.infra.repository.entity.Listing;
 
 /**
@@ -46,6 +47,18 @@ public interface AiListingVerificationService {
      * @return The duplicate-check result (decision, highest score, matches)
      */
     DuplicateCheckResponse checkDuplicateById(Long listingId);
+
+    /**
+     * Return the AI moderation result the auto-moderation cronjob already stored
+     * for a listing (parsed from {@code listing_ai_moderation.ai_reason}), so the
+     * admin review UI can display it without re-running the AI. Returns
+     * {@code null} when no moderation record / stored result exists or it cannot
+     * be parsed.
+     *
+     * @param listingId The listing ID
+     * @return The stored verification + duplicate result, or {@code null}
+     */
+    StoredAiModerationResponse getStoredModerationResult(Long listingId);
 
     /**
      * Check if the AI verification service is available

--- a/smart-rent/src/main/java/com/smartrent/service/ai/impl/AiListingVerificationServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/ai/impl/AiListingVerificationServiceImpl.java
@@ -2,12 +2,16 @@ package com.smartrent.service.ai.impl;
 
 import com.smartrent.dto.request.AiListingVerificationRequest;
 import com.smartrent.dto.request.DuplicateCheckRequest;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.smartrent.dto.response.AiListingVerificationResponse;
 import com.smartrent.dto.response.DuplicateCheckResponse;
+import com.smartrent.dto.response.StoredAiModerationResponse;
 import com.smartrent.infra.exception.AppException;
 import com.smartrent.infra.exception.model.DomainCode;
+import com.smartrent.infra.repository.ListingAiModerationRepository;
 import com.smartrent.infra.repository.entity.Address;
 import com.smartrent.infra.repository.entity.Listing;
+import com.smartrent.infra.repository.entity.ListingAiModeration;
 import com.smartrent.mapper.AiListingMapper;
 import com.smartrent.service.ai.AiListingVerificationService;
 import lombok.RequiredArgsConstructor;
@@ -33,6 +37,8 @@ public class AiListingVerificationServiceImpl implements AiListingVerificationSe
     private final com.smartrent.infra.connector.SmartRentAiConnector smartRentAiConnector;
     private final AiListingMapper aiListingMapper;
     private final ListingRepository listingRepository;
+    private final ListingAiModerationRepository listingAiModerationRepository;
+    private final ObjectMapper objectMapper;
 
 
     @Override
@@ -270,6 +276,33 @@ public class AiListingVerificationServiceImpl implements AiListingVerificationSe
         }
 
         return smartRentAiConnector.checkDuplicate(builder.build());
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public StoredAiModerationResponse getStoredModerationResult(Long listingId) {
+        ListingAiModeration moderation =
+            listingAiModerationRepository.findById(listingId).orElse(null);
+        if (moderation == null
+                || moderation.getAiReason() == null
+                || moderation.getAiReason().isBlank()) {
+            return null;
+        }
+        try {
+            // ai_reason is {verification, duplicateCheck}; verification re-serializes
+            // snake_case and duplicateCheck camelCase — matching the FE types.
+            StoredAiModerationResponse stored = objectMapper.readValue(
+                moderation.getAiReason(), StoredAiModerationResponse.class);
+            stored.setAiScore(moderation.getAiScore());
+            stored.setVerificationStatus(moderation.getVerificationStatus() != null
+                ? moderation.getVerificationStatus().name() : null);
+            stored.setAnalyzedAt(moderation.getUpdatedAt());
+            return stored;
+        } catch (Exception e) {
+            log.warn("Failed to parse stored aiReason for listing {}: {}",
+                listingId, e.getMessage());
+            return null;
+        }
     }
 
     @Override


### PR DESCRIPTION
Re-lands the stored-moderation-result endpoint. (It was pushed onto the already-merged #417 branch earlier, so it never reached main — this is the proper standalone PR.)

## What changed
- `GET /v1/ai/listings/{listingId}/moderation-result`: reads `listing_ai_moderation.ai_reason` (`{verification, duplicateCheck}`) and returns it plus `verificationStatus` + `analyzedAt`. `data=null` when nothing is stored. Best-effort (parse failure → null).
- `StoredAiModerationResponse`: verification re-serializes snake_case, duplicateCheck camelCase — matching the on-demand `/verify` and `/check-duplicate` shapes, so the admin FE reuses the same types with no mapping.

Lets the admin review UI show the AI analysis instantly instead of re-running it (re-spending Gemini tokens) on every open. Pairs with the admin-FE PR.

## Notes
- Builds on the merged `checkDuplicateById` work (#417). `gradlew compileJava` exit 0.