### PR TITLE
fix: wrap notification list/unread-count in the standard ApiResponse …

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/controller/NotificationController.java
+++ b/smart-rent/src/main/java/com/smartrent/controller/NotificationController.java
@@ -1,6 +1,8 @@
 package com.smartrent.controller;
 
+import com.smartrent.dto.response.ApiResponse;
 import com.smartrent.dto.response.NotificationResponse;
+import com.smartrent.dto.response.PageResponse;
 import com.smartrent.enums.RecipientType;
 import com.smartrent.service.notification.NotificationService;
 import com.smartrent.util.JwtRecipientResolver;
@@ -28,7 +30,7 @@ public class NotificationController {
     @Operation(summary = "Get notifications",
             description = "Get paginated notification history for the authenticated user/admin")
     @GetMapping
-    public ResponseEntity<Page<NotificationResponse>> getNotifications(
+    public ApiResponse<PageResponse<NotificationResponse>> getNotifications(
             @AuthenticationPrincipal Jwt jwt,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "20") int size) {
@@ -37,17 +39,32 @@ public class NotificationController {
         RecipientType recipientType = JwtRecipientResolver.resolveRecipientType(jwt);
         Pageable pageable = PageRequest.of(page, size);
 
-        return ResponseEntity.ok(notificationService.getNotifications(recipientId, recipientType, pageable));
+        Page<NotificationResponse> notifications =
+                notificationService.getNotifications(recipientId, recipientType, pageable);
+
+        PageResponse<NotificationResponse> pageResponse = PageResponse.<NotificationResponse>builder()
+                .page(notifications.getNumber())
+                .size(notifications.getSize())
+                .totalElements(notifications.getTotalElements())
+                .totalPages(notifications.getTotalPages())
+                .data(notifications.getContent())
+                .build();
+
+        return ApiResponse.<PageResponse<NotificationResponse>>builder()
+                .data(pageResponse)
+                .build();
     }
 
     @Operation(summary = "Get unread notification count")
     @GetMapping("/unread-count")
-    public ResponseEntity<Map<String, Long>> getUnreadCount(@AuthenticationPrincipal Jwt jwt) {
+    public ApiResponse<Map<String, Long>> getUnreadCount(@AuthenticationPrincipal Jwt jwt) {
         String recipientId = JwtRecipientResolver.resolveRecipientId(jwt);
         RecipientType recipientType = JwtRecipientResolver.resolveRecipientType(jwt);
 
         long count = notificationService.getUnreadCount(recipientId, recipientType);
-        return ResponseEntity.ok(Map.of("unreadCount", count));
+        return ApiResponse.<Map<String, Long>>builder()
+                .data(Map.of("unreadCount", count))
+                .build();
     }
 
     @Operation(summary = "Mark a notification as read")


### PR DESCRIPTION
…envelope

GET /v1/notifications and /v1/notifications/unread-count returned a raw Page/Map body instead of the app's {code, message, data} envelope every other paginated admin endpoint uses (see AdminListingReportController). The frontend's axios layer stamps success:true on any 2xx response regardless of body shape, so useNotifications' `res.success && res.data` check silently passed with `data` undefined and never populated the list - admin saw an empty notification bell/page even though the API had data. Wrap both in ApiResponse, and the list in PageResponse to match the {data, page, size, totalElements, totalPages} shape the frontend already expects.