### PR TITLE
feat(admin): match owner email in listings ownerSearch, index contact…

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/controller/ListingAdminController.java
+++ b/smart-rent/src/main/java/com/smartrent/controller/ListingAdminController.java
@@ -157,7 +157,7 @@ public class ListingAdminController {
                     ),
                     @ExampleObject(
                         name = "Find listings by owner",
-                        summary = "Match owner name or phone (firstName / lastName / contactPhoneNumber / phoneNumber)",
+                        summary = "Match owner name, phone, or email (firstName / lastName / contactPhoneNumber / phoneNumber / email)",
                         value = """
                             {
                               "page": 1,

--- a/smart-rent/src/main/java/com/smartrent/dto/request/ListingFilterRequest.java
+++ b/smart-rent/src/main/java/com/smartrent/dto/request/ListingFilterRequest.java
@@ -272,8 +272,8 @@ public class ListingFilterRequest {
     String title;
 
     @Schema(description = """
-            Admin-only search across owner first name, last name, and phone numbers
-            (matches contactPhoneNumber OR phoneNumber). Case-insensitive substring match.
+            Admin-only search across owner first name, last name, phone numbers, and email
+            (matches contactPhoneNumber OR phoneNumber OR email). Case-insensitive substring match.
             Useful for finding all listings posted by a given user from the admin list.
             """, example = "0367919024")
     String ownerSearch;

--- a/smart-rent/src/main/java/com/smartrent/infra/repository/entity/User.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/entity/User.java
@@ -29,7 +29,8 @@ import java.time.LocalDateTime;
                 @UniqueConstraint(name = "uk_users_phone", columnNames = { "phone_code", "phone_number" })
         },
         indexes = {
-                @Index(name = "idx_users_broker_status", columnList = "is_broker, broker_verification_status")
+                @Index(name = "idx_users_broker_status", columnList = "is_broker, broker_verification_status"),
+                @Index(name = "idx_users_contact_phone_number", columnList = "contact_phone_number")
         })
 @Getter
 @Setter

--- a/smart-rent/src/main/java/com/smartrent/infra/repository/specification/ListingSpecification.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/specification/ListingSpecification.java
@@ -724,8 +724,8 @@ public class ListingSpecification {
                     criteriaBuilder.lower(root.get("title")), titleNeedle));
             }
 
-            // ============ ADMIN: OWNER NAME / PHONE SEARCH ============
-            // Matches owner firstName, lastName, contactPhoneNumber, or phoneNumber (case-insensitive contains).
+            // ============ ADMIN: OWNER NAME / PHONE / EMAIL SEARCH ============
+            // Matches owner firstName, lastName, contactPhoneNumber, phoneNumber, or email (case-insensitive contains).
             if (filter.getOwnerSearch() != null && !filter.getOwnerSearch().trim().isEmpty()) {
                 String ownerNeedle = "%" + filter.getOwnerSearch().trim().toLowerCase() + "%";
                 Subquery<String> ownerSubquery = query.subquery(String.class);
@@ -741,7 +741,9 @@ public class ListingSpecification {
                                         criteriaBuilder.like(
                                                 criteriaBuilder.lower(ownerRoot.get("contactPhoneNumber")), ownerNeedle),
                                         criteriaBuilder.like(
-                                                criteriaBuilder.lower(ownerRoot.get("phoneNumber")), ownerNeedle)
+                                                criteriaBuilder.lower(ownerRoot.get("phoneNumber")), ownerNeedle),
+                                        criteriaBuilder.like(
+                                                criteriaBuilder.lower(ownerRoot.get("email")), ownerNeedle)
                                 )
                         ));
                 predicates.add(root.get("userId").in(ownerSubquery));

--- a/smart-rent/src/main/resources/db/migration/V113__Add_users_contact_phone_number_index.sql
+++ b/smart-rent/src/main/resources/db/migration/V113__Add_users_contact_phone_number_index.sql
@@ -1,0 +1,21 @@
+-- Index the owner "chủ tin" phone/email lookup used by the admin content/posts
+-- filter (POST /v1/listings/admin/list -> ownerSearch, ListingSpecification).
+--
+-- ownerSearch now matches firstName / lastName / contactPhoneNumber /
+-- phoneNumber / email (email added alongside this migration). email already
+-- has idx_users_email (V1) and the legacy phone_number column already has
+-- idx_users_phone_number (V107). contact_phone_number — the field admins
+-- actually search on for a user's current contact number — had no index.
+-- Uses the conditional pattern (check INFORMATION_SCHEMA first) since MySQL
+-- CREATE INDEX has no IF NOT EXISTS, matching V107's style.
+
+SET @index_exists = (SELECT COUNT(*) FROM information_schema.STATISTICS
+    WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = 'users'
+    AND INDEX_NAME = 'idx_users_contact_phone_number');
+SET @sql = IF(@index_exists = 0,
+    'CREATE INDEX idx_users_contact_phone_number ON users (contact_phone_number)',
+    'SELECT ''Index idx_users_contact_phone_number already exists'' AS message');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;


### PR DESCRIPTION
…_phone_number

Admin content/posts filter searched owner name/phone but not email; extend the ownerSearch OR clause to also match users.email. Add the missing index on users.contact_phone_number (the field actually searched) — email and legacy phone_number were already indexed (V1, V107), and moderation-status filtering already has dedicated indexes (V101/V102/V109).