### PR TITLE
fix: enforce posting-block guard on listing renewal

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/service/repost/impl/RepostServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/repost/impl/RepostServiceImpl.java
@@ -155,6 +155,9 @@ public class RepostServiceImpl implements RepostService {
     public RenewListingResponse renewListing(String userId, RenewListingRequest request) {
         log.info("Renewing listing {} for user {}", request.getListingId(), userId);
 
+        // Renewing extends visibility just like repost — block barred users
+        postingAccessGuard.ensureCanPost(userId);
+
         Listing listing = listingRepository.findById(request.getListingId())
                 .orElseThrow(() -> new RuntimeException("Listing not found: " + request.getListingId()));
 


### PR DESCRIPTION
renewListing() was the only re-listing entry point that skipped PostingAccessGuard — create, repost, and resubmit all already reject users an admin has blocked from posting, but a blocked user could still renew via the API even though the FE hides the button. Add the same ensureCanPost() check for consistency.