### PR TITLE
AI background pre-compute (store-only): review dialog opens with results ready

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/controller/AiListingVerificationController.java
+++ b/smart-rent/src/main/java/com/smartrent/controller/AiListingVerificationController.java
@@ -205,9 +205,10 @@ public class AiListingVerificationController {
     @GetMapping("/{listingId}/moderation-result")
     @Operation(
         summary = "Get the stored AI moderation result for a listing",
-        description = "Returns a previously persisted AI analysis (verification + duplicate check) "
-                + "for a listing, if one exists, so the admin review UI can show it without "
-                + "re-running the AI. Returns data=null when no stored result exists.",
+        description = "Returns the AI analysis (verification + duplicate check) the background "
+                + "pre-computation job already stored for a listing, so the admin review dialog can "
+                + "show it instantly without re-running the AI. Returns data=null when nothing has "
+                + "been computed yet (the admin can then run it manually).",
         parameters = {
             @Parameter(name = "listingId", description = "The ID of the listing", required = true, example = "123")
         }
@@ -359,9 +360,10 @@ public class AiListingVerificationController {
     @SecurityRequirement(name = "Bearer Authentication")
     @Operation(
         summary = "Get AI auto-verify setting (Admin only)",
-        description = "Returns whether AI auto-verify is currently enabled. When enabled, the post "
-                + "review dialog automatically runs AI analysis as soon as it opens instead of "
-                + "requiring the admin to click the manual Verify button.",
+        description = "Returns whether AI auto-verify is currently enabled. When enabled, a background "
+                + "job pre-computes and stores the AI analysis for pending listings, so the review "
+                + "dialog shows the result the instant it opens instead of the admin clicking Verify "
+                + "and waiting. It never approves/rejects — the admin always decides.",
         parameters = {
             @Parameter(name = "X-Admin-Id", description = "Admin ID", required = true)
         }
@@ -384,11 +386,13 @@ public class AiListingVerificationController {
     @Operation(
         summary = "Toggle AI auto-verify on/off (Admin only)",
         description = """
-            Enables or disables AI auto-verify. The flag is persisted in the database so it
-            survives server restarts.
+            Enables or disables background AI pre-computation. The flag is persisted in the
+            database so it survives server restarts, and is re-read on every scheduler tick.
 
-            - **enabled=true** → the post review dialog auto-runs AI analysis as soon as it opens.
-            - **enabled=false** → admins must click the manual Verify button in the dialog.
+            - **enabled=true** → a background job analyses pending listings and stores the result,
+              so the review dialog shows it instantly on open (no waiting).
+            - **enabled=false** → nothing runs in the background; admins click the manual Verify
+              button in the dialog to run the AI on demand.
 
             This does NOT auto-approve or auto-reject listings — the AI result stays advisory and
             the admin still makes the final decision from the dialog.
@@ -404,7 +408,7 @@ public class AiListingVerificationController {
         aiVerificationSettingService.setAutoVerifyEnabled(enabled, adminId);
         log.info("Admin {} {} AI auto-verify", adminId, enabled ? "ENABLED" : "DISABLED");
         String message = enabled
-                ? "AI auto-verify has been enabled. The review dialog will auto-run AI analysis on open."
+                ? "AI auto-verify has been enabled. Pending listings will be analysed in the background so results are ready when the review dialog opens."
                 : "AI auto-verify has been disabled. Admins will need to click Verify manually.";
         return ResponseEntity.ok(ApiResponse.builder()
                 .message(message)

--- a/smart-rent/src/main/java/com/smartrent/cronjob/AiListingAutoModerationScheduler.java
+++ b/smart-rent/src/main/java/com/smartrent/cronjob/AiListingAutoModerationScheduler.java
@@ -1,0 +1,165 @@
+package com.smartrent.cronjob;
+
+import com.smartrent.infra.repository.ListingAiModerationRepository;
+import com.smartrent.infra.repository.ListingRepository;
+import com.smartrent.infra.repository.entity.Listing;
+import com.smartrent.infra.repository.entity.ListingAiModeration;
+import com.smartrent.service.ai.AiModerationExecutor;
+import com.smartrent.service.ai.AiModerationProcessorService;
+import com.smartrent.service.ai.AiVerificationSettingService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.IntStream;
+
+/**
+ * Pre-computes AI analysis for pending listings in the background, so the admin
+ * review dialog can show the result instantly on open instead of running the AI
+ * live and making the admin wait ~30s.
+ *
+ * <p><b>Store-only.</b> This never approves or rejects a listing — it only stores
+ * the AI's analysis on {@link ListingAiModeration}. Every listing still lands in
+ * the admin's review queue and the admin makes the final call in the dialog.
+ *
+ * <p>Two independent switches gate it:
+ * <ul>
+ *   <li>{@code smartrent.ai.verification.scheduler.enabled} — infra-level kill switch
+ *       (env/config, e.g. to keep it off in tests or local dev).</li>
+ *   <li>The {@code ai_auto_verify_enabled} setting in the DB — the admin-facing
+ *       toggle, read fresh on every tick so it takes effect immediately and
+ *       survives restarts. See {@link AiVerificationSettingService}.</li>
+ * </ul>
+ */
+@Component
+@Slf4j
+@RequiredArgsConstructor
+@ConditionalOnProperty(
+    name = "smartrent.ai.verification.scheduler.enabled",
+    havingValue = "true",
+    matchIfMissing = true
+)
+public class AiListingAutoModerationScheduler {
+
+    private final ListingRepository listingRepository;
+    private final ListingAiModerationRepository listingAiModerationRepository;
+
+    /**
+     * Injected as a Spring proxy bean so that @Transactional(REQUIRES_NEW)
+     * in processSingleListing is correctly intercepted by AOP.
+     */
+    private final AiModerationProcessorService aiModerationProcessorService;
+
+    private final AiModerationExecutor aiModerationExecutor;
+
+    /** DB-backed admin toggle — read on every tick, so no restart is needed. */
+    private final AiVerificationSettingService aiVerificationSettingService;
+
+    /**
+     * Number of listings pulled per tick. Lower it (e.g. 3-5) to drain a large
+     * one-time backlog without pinning the single AI worker's CPU — fewer
+     * concurrent CPU-bound duplicate checks, roughly the same throughput (the GIL
+     * serializes them anyway). Default 20.
+     */
+    @Value("${smartrent.ai.verification.scheduler.batch-size:20}")
+    private int batchSize;
+
+    /**
+     * Run every hour to recover any listings stuck in IN_PROGRESS state.
+     * This acts as a self-healing mechanism in case the server crashes during processing.
+     */
+    @Scheduled(fixedDelayString = "3600000") // 1 hour
+    @Transactional
+    public void recoverStuckInProgressListings() {
+        log.info("Starting Self-Healing Job for stuck IN_PROGRESS listings...");
+        try {
+            LocalDateTime thresholdTime = LocalDateTime.now().minusMinutes(30);
+            int recoveredCount = listingAiModerationRepository.resetStuckInProgressListings(thresholdTime);
+            if (recoveredCount > 0) {
+                log.info("Self-Healing Job successfully recovered {} listings stuck in IN_PROGRESS state.", recoveredCount);
+            } else {
+                log.debug("No stuck listings found.");
+            }
+        } catch (Exception e) {
+            log.error("Error during Self-Healing Job for stuck IN_PROGRESS listings", e);
+        }
+    }
+
+    /**
+     * Run every 5 minutes to pre-compute + store the AI analysis for pending listings.
+     *
+     * <p>Strategy:
+     * <ol>
+     *   <li>Load a page of pending listings in a single read transaction.</li>
+     *   <li>Batch-mark all as IN_PROGRESS in one query before dispatching.</li>
+     *   <li>Call {@link AiModerationProcessorService#processSingleListing} for each listing
+     *       via the Spring proxy so each item runs in its own {@code REQUIRES_NEW} transaction.
+     *       Tasks run concurrently on {@link AiModerationExecutor#batchPool()} — a dedicated
+     *       I/O pool sized for the batch — instead of the shared ForkJoinPool which is
+     *       designed for CPU-bound work and limited to {@code cores - 1} threads.</li>
+     * </ol>
+     */
+    @Scheduled(fixedDelayString = "${smartrent.ai.verification.scheduler.delay:300000}")
+    public void processPendingListings() {
+        if (!aiVerificationSettingService.isAutoVerifyEnabled()) {
+            log.debug("AI auto-verify is DISABLED by admin — skipping background pre-computation.");
+            return;
+        }
+        log.info("Starting AI background pre-computation...");
+
+        try {
+            int size = batchSize > 0 ? batchSize : 20;
+            Page<Listing> pendingListings = listingRepository.findListingsNeedingAiVerification(PageRequest.of(0, size));
+            List<Listing> listings = pendingListings.getContent();
+
+            if (listings.isEmpty()) {
+                log.info("No pending listings need AI pre-computation.");
+                return;
+            }
+
+            log.info("Found {} listings to pre-compute", listings.size());
+
+            // 1. Upsert moderation records, then batch-mark all as IN_PROGRESS in one query.
+            List<ListingAiModeration> moderations = listings.stream().map(listing ->
+                listingAiModerationRepository.findById(listing.getListingId())
+                    .orElseGet(() -> ListingAiModeration.builder()
+                        .listingId(listing.getListingId())
+                        .retryCount(0)
+                        .manualOverride(false)
+                        .build())
+            ).toList();
+            listingAiModerationRepository.saveAll(moderations);
+
+            List<Long> listingIds = listings.stream().map(Listing::getListingId).toList();
+            listingAiModerationRepository.markListingsAsInProgress(listingIds);
+
+            // 2. Process listings concurrently on the dedicated I/O thread pool.
+            //    Each call goes through the Spring AOP proxy on aiModerationProcessorService,
+            //    so @Transactional(REQUIRES_NEW) is correctly applied per listing.
+            List<CompletableFuture<Void>> futures = IntStream.range(0, listings.size())
+                .mapToObj(i -> CompletableFuture.runAsync(() -> {
+                    try {
+                        aiModerationProcessorService.processSingleListing(listings.get(i), moderations.get(i));
+                    } catch (Exception e) {
+                        log.error("Failed to pre-compute listing ID: {} in parallel batch",
+                            listings.get(i).getListingId(), e);
+                    }
+                }, aiModerationExecutor.batchPool()))
+                .toList();
+
+            CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
+
+        } catch (Exception e) {
+            log.error("Error in AI background pre-computation", e);
+        }
+    }
+}

--- a/smart-rent/src/main/java/com/smartrent/infra/repository/ListingAiModerationRepository.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/ListingAiModerationRepository.java
@@ -2,8 +2,34 @@ package com.smartrent.infra.repository;
 
 import com.smartrent.infra.repository.entity.ListingAiModeration;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Repository
 public interface ListingAiModerationRepository extends JpaRepository<ListingAiModeration, Long> {
+
+    @Transactional
+    @Modifying
+    @Query("""
+        UPDATE listing_ai_moderation lam
+        SET lam.verificationStatus = 'IN_PROGRESS'
+        WHERE lam.listingId IN :listingIds
+        AND (lam.verificationStatus = 'PENDING' OR lam.verificationStatus IS NULL)
+    """)
+    int markListingsAsInProgress(@Param("listingIds") List<Long> listingIds);
+
+    @Transactional
+    @Modifying
+    @Query("""
+        UPDATE listing_ai_moderation lam
+        SET lam.verificationStatus = 'PENDING'
+        WHERE lam.verificationStatus = 'IN_PROGRESS'
+        AND lam.updatedAt < :thresholdTime
+    """)
+    int resetStuckInProgressListings(@Param("thresholdTime") java.time.LocalDateTime thresholdTime);
 }

--- a/smart-rent/src/main/java/com/smartrent/infra/repository/ListingRepository.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/ListingRepository.java
@@ -90,6 +90,58 @@ public interface ListingRepository extends JpaRepository<Listing, Long>, JpaSpec
      */
     Optional<Listing> findByTransactionId(String transactionId);
 
+    /**
+     * Find listings that need AI pre-computation for the review dialog.
+     *
+     * <p>The background job runs the AI on these and STORES the result on
+     * {@code ListingAiModeration} so the admin sees it instantly on open — it
+     * does NOT change the listing's own status (no auto-approve/reject).
+     *
+     * <p>Inclusion rules — a listing is picked up when it passes the gatekeeping
+     * filters AND its AI processing state allows a (re)try:
+     * <ul>
+     *   <li>{@code lam IS NULL} → new listing, never processed → include</li>
+     *   <li>{@code lam.verificationStatus = PENDING} AND retryCount < 3 → needs processing → include</li>
+     *   <li>{@code l.moderationStatus = RESUBMITTED} AND retryCount < 3 → owner resubmitted after
+     *       revision → re-compute even if the previous {@code lam} ended in REJECTED/VERIFIED</li>
+     * </ul>
+     *
+     * <p>Exclusion rules:
+     * <ul>
+     *   <li>{@code lam.verificationStatus = IN_PROGRESS} → currently being processed → exclude (avoids double-dispatch)</li>
+     *   <li>{@code lam.verificationStatus IN (VERIFIED, REJECTED, UNDER_REVIEW)} AND not RESUBMITTED → already computed → exclude</li>
+     *   <li>{@code retryCount >= 3} → gave up → exclude</li>
+     *   <li>{@code l.moderationStatus IN (APPROVED, REJECTED, SUSPENDED, REVISION_REQUIRED)} → already resolved by admin → exclude</li>
+     *   <li>{@code l.verified = true} → already approved → exclude</li>
+     *   <li>{@code lam.manualOverride = true} → human took over → exclude</li>
+     * </ul>
+     */
+    @Query("""
+        SELECT l FROM listings l
+        LEFT JOIN listing_ai_moderation lam ON lam.listingId = l.listingId
+        WHERE (
+                lam IS NULL
+                OR (
+                    lam.manualOverride = false
+                    AND lam.retryCount < 3
+                    AND lam.verificationStatus <> 'IN_PROGRESS'
+                    AND (
+                        lam.verificationStatus = 'PENDING'
+                        OR l.moderationStatus = com.smartrent.enums.ModerationStatus.RESUBMITTED
+                    )
+                )
+            )
+        AND l.isDraft = false
+        AND l.isShadow = false
+        AND l.postDate IS NOT NULL
+        AND (l.verified IS NULL OR l.verified = false)
+        AND (l.moderationStatus IS NULL
+             OR l.moderationStatus = com.smartrent.enums.ModerationStatus.PENDING_REVIEW
+             OR l.moderationStatus = com.smartrent.enums.ModerationStatus.RESUBMITTED)
+        ORDER BY l.vipTypeSortOrder ASC, l.createdAt DESC
+    """)
+    Page<Listing> findListingsNeedingAiVerification(Pageable pageable);
+
     @Query("SELECT DISTINCT l FROM listings l LEFT JOIN FETCH l.address LEFT JOIN FETCH l.amenities WHERE l.listingId = :id")
     Optional<Listing> findByIdWithAmenities(@Param("id") Long id);
 

--- a/smart-rent/src/main/java/com/smartrent/service/ai/AiModerationExecutor.java
+++ b/smart-rent/src/main/java/com/smartrent/service/ai/AiModerationExecutor.java
@@ -1,0 +1,86 @@
+package com.smartrent.service.ai;
+
+import jakarta.annotation.PreDestroy;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Dedicated thread pools for AI-driven listing moderation.
+ *
+ * <p>Two isolated pools prevent the deadlock that would occur if the batch-level
+ * parallelism and the per-listing fan-out shared a single pool:
+ *
+ * <ul>
+ *   <li>{@link #batchPool()} — runs one task per listing in the scheduler batch (up to 20
+ *       concurrent listings).  Each task blocks while waiting for the AI service to respond,
+ *       so the pool is sized for I/O concurrency rather than CPU cores.</li>
+ *   <li>{@link #taskPool()} — runs the verify + duplicate-check fan-out within each listing
+ *       (2 tasks per listing). Kept separate to avoid the deadlock that would arise if
+ *       batch-pool threads blocked waiting for sub-tasks queued on the same pool.</li>
+ * </ul>
+ *
+ * <p>{@link ThreadPoolExecutor.CallerRunsPolicy} provides graceful back-pressure: when a pool
+ * is saturated the calling thread executes the task directly, preventing queue overflow and
+ * maintaining forward progress without throwing {@link java.util.concurrent.RejectedExecutionException}.
+ * Daemon threads ensure neither pool blocks JVM shutdown.
+ */
+@Slf4j
+@Component
+public class AiModerationExecutor {
+
+    private final ThreadPoolExecutor batchPool = new ThreadPoolExecutor(
+            20, 20,
+            60L, TimeUnit.SECONDS,
+            new ArrayBlockingQueue<>(40),
+            r -> {
+                Thread t = new Thread(r, "ai-mod-batch");
+                t.setDaemon(true);
+                return t;
+            },
+            new ThreadPoolExecutor.CallerRunsPolicy());
+
+    private final ThreadPoolExecutor taskPool = new ThreadPoolExecutor(
+            16, 32,
+            60L, TimeUnit.SECONDS,
+            new ArrayBlockingQueue<>(128),
+            r -> {
+                Thread t = new Thread(r, "ai-mod-task");
+                t.setDaemon(true);
+                return t;
+            },
+            new ThreadPoolExecutor.CallerRunsPolicy());
+
+    /** For parallel processing of multiple listings in the scheduler batch. */
+    public Executor batchPool() {
+        return batchPool;
+    }
+
+    /** For parallel verify + duplicate-check fan-out within a single listing. */
+    public Executor taskPool() {
+        return taskPool;
+    }
+
+    @PreDestroy
+    void shutdown() {
+        shutdownPool(batchPool, "ai-mod-batch");
+        shutdownPool(taskPool, "ai-mod-task");
+    }
+
+    private void shutdownPool(ThreadPoolExecutor pool, String name) {
+        pool.shutdown();
+        try {
+            if (!pool.awaitTermination(10, TimeUnit.SECONDS)) {
+                pool.shutdownNow();
+                log.warn("Thread pool '{}' did not terminate gracefully.", name);
+            }
+        } catch (InterruptedException e) {
+            pool.shutdownNow();
+            Thread.currentThread().interrupt();
+        }
+    }
+}

--- a/smart-rent/src/main/java/com/smartrent/service/ai/AiModerationProcessorService.java
+++ b/smart-rent/src/main/java/com/smartrent/service/ai/AiModerationProcessorService.java
@@ -1,0 +1,26 @@
+package com.smartrent.service.ai;
+
+import com.smartrent.infra.repository.entity.Listing;
+import com.smartrent.infra.repository.entity.ListingAiModeration;
+
+/**
+ * Pre-computes AI analysis for listings in the background and stores it, so the
+ * admin review dialog can display the result the moment it opens instead of
+ * running the AI live and making the admin wait.
+ *
+ * <p>Store-only: it never approves or rejects a listing. The admin always makes
+ * the final decision.
+ *
+ * <p>Separated from the scheduler so {@code @Transactional(REQUIRES_NEW)} is
+ * properly applied via Spring's AOP proxy (self-invocation bypass fix).
+ */
+public interface AiModerationProcessorService {
+
+    /**
+     * Run the AI on a single listing and store the result, in its own transaction.
+     *
+     * @param listing    The listing to analyse.
+     * @param moderation The associated AI moderation record (already IN_PROGRESS).
+     */
+    void processSingleListing(Listing listing, ListingAiModeration moderation);
+}

--- a/smart-rent/src/main/java/com/smartrent/service/ai/impl/AiModerationProcessorServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/ai/impl/AiModerationProcessorServiceImpl.java
@@ -1,0 +1,193 @@
+package com.smartrent.service.ai.impl;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.smartrent.dto.request.AiListingVerificationRequest;
+import com.smartrent.dto.request.DuplicateCheckRequest;
+import com.smartrent.dto.response.AiListingVerificationResponse;
+import com.smartrent.dto.response.DuplicateCheckResponse;
+import com.smartrent.enums.NotificationType;
+import com.smartrent.infra.connector.SmartRentAiConnector;
+import com.smartrent.infra.repository.ListingAiModerationRepository;
+import com.smartrent.infra.repository.entity.Address;
+import com.smartrent.infra.repository.entity.Listing;
+import com.smartrent.infra.repository.entity.ListingAiModeration;
+import com.smartrent.infra.repository.entity.enums.VerificationStatus;
+import com.smartrent.service.ai.AiListingVerificationService;
+import com.smartrent.service.ai.AiModerationExecutor;
+import com.smartrent.service.ai.AiModerationProcessorService;
+import com.smartrent.service.notification.NotificationService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AiModerationProcessorServiceImpl implements AiModerationProcessorService {
+
+    private final ListingAiModerationRepository listingAiModerationRepository;
+    private final AiListingVerificationService aiVerificationService;
+    private final NotificationService notificationService;
+    private final SmartRentAiConnector smartRentAiConnector;
+    private final ObjectMapper objectMapper;
+    private final AiModerationExecutor aiModerationExecutor;
+
+    /**
+     * Pre-computes the AI analysis for a single listing and STORES it, in its own
+     * independent transaction.
+     *
+     * <p><b>Store-only by design.</b> This never changes the listing's own state —
+     * it does not touch {@code verified}, {@code isVerify} or {@code moderationStatus},
+     * and it never approves or rejects. Its only job is to have the AI result ready
+     * on {@link ListingAiModeration} so the admin review dialog can show it the
+     * instant it opens, instead of making the admin wait ~30s for a live run. The
+     * final approve/reject decision stays entirely with the admin, via
+     * {@code PUT /v1/admin/listings/{id}/status}.
+     *
+     * <p>{@code moderation.verificationStatus} is set from the AI's suggestion, but
+     * purely as an <i>opinion/processed marker</i> on the moderation record — it is
+     * what stops the listing from being re-analysed on the next tick, and what the
+     * dialog displays as "AI suggests …". It is not the listing's status.
+     *
+     * <p>Using {@code REQUIRES_NEW} ensures that:
+     * <ul>
+     *   <li>Each listing's result is committed immediately, even if another listing fails.</li>
+     *   <li>A failure in one listing does not roll back the others in the parallel batch.</li>
+     * </ul>
+     *
+     * <p>This method MUST live in a separate Spring bean (not the scheduler itself) so that
+     * Spring's AOP proxy intercepts the call and applies the transaction correctly.
+     * Calling a {@code @Transactional} method on {@code this} from within the same bean
+     * bypasses the proxy and silently loses transaction isolation.
+     */
+    @Override
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void processSingleListing(Listing listing, ListingAiModeration moderation) {
+        try {
+            log.info("Pre-computing AI analysis for listing ID: {}", listing.getListingId());
+
+            AiListingVerificationRequest request =
+                    aiVerificationService.buildVerificationRequest(listing.getListingId());
+
+            // Verify and duplicate-check are independent — run them concurrently.
+            CompletableFuture<AiListingVerificationResponse> verifyFuture =
+                    CompletableFuture.supplyAsync(
+                            () -> aiVerificationService.verifyListing(request),
+                            aiModerationExecutor.taskPool());
+            CompletableFuture<DuplicateCheckResponse> duplicateFuture =
+                    CompletableFuture.supplyAsync(
+                            () -> runDuplicateCheck(listing, request),
+                            aiModerationExecutor.taskPool());
+
+            AiListingVerificationResponse response = verifyFuture.join();
+            DuplicateCheckResponse duplicateResult = duplicateFuture.join();
+
+            moderation.setAiScore(response.getScore());
+
+            String suggestedStatus = response.getSuggestedStatus();
+            log.info("AI suggested status for listing ID {}: {} (advisory only — not applied)",
+                    listing.getListingId(), suggestedStatus);
+
+            // Record the AI's opinion on the moderation row only. The listing itself is
+            // left untouched — it stays in the admin's review queue either way.
+            if ("APPROVED".equals(suggestedStatus)) {
+                moderation.setVerificationStatus(VerificationStatus.VERIFIED);
+            } else if ("REJECTED".equals(suggestedStatus)) {
+                moderation.setVerificationStatus(VerificationStatus.REJECTED);
+            } else {
+                moderation.setVerificationStatus(VerificationStatus.UNDER_REVIEW);
+            }
+
+            try {
+                // Persist verification + duplicate result together so the review dialog can
+                // show image/video issues, violations, and any duplicate matches in one place.
+                Map<String, Object> aiReason = new LinkedHashMap<>();
+                aiReason.put("verification", response);
+                aiReason.put("duplicateCheck", duplicateResult);
+                moderation.setAiReason(objectMapper.writeValueAsString(aiReason));
+            } catch (JsonProcessingException e) {
+                log.warn("Failed to serialize AI moderation result for listing ID: {}", listing.getListingId(), e);
+            }
+
+            listingAiModerationRepository.save(moderation);
+
+            log.info("Stored AI analysis for listing ID: {} (aiSuggestion: {}) — awaiting admin review",
+                    listing.getListingId(), moderation.getVerificationStatus());
+
+            // Duplicates are the one thing worth proactively alerting admins about, since
+            // the listing would otherwise look unremarkable in the review queue.
+            if (duplicateResult != null
+                    && ("DUPLICATE".equals(duplicateResult.getDecision())
+                        || "SUSPICIOUS".equals(duplicateResult.getDecision()))) {
+                log.info("Listing ID {} flagged as {} (score={}) — notifying admins.",
+                        listing.getListingId(), duplicateResult.getDecision(), duplicateResult.getHighestScore());
+                sendAdminDuplicateNotification(listing, duplicateResult);
+            }
+
+        } catch (Exception e) {
+            log.error("Failed to pre-compute AI analysis for listing ID: {}", listing.getListingId(), e);
+            moderation.setRetryCount(moderation.getRetryCount() + 1);
+            moderation.setVerificationStatus(VerificationStatus.PENDING); // revert for retry
+            listingAiModerationRepository.save(moderation);
+        }
+    }
+
+    private void sendAdminDuplicateNotification(Listing listing, DuplicateCheckResponse duplicateResult) {
+        String message = "Tin đăng \"" + listing.getTitle() + "\" (ID: " + listing.getListingId()
+                + ") bị phát hiện " + duplicateResult.getDecision()
+                + " (score=" + String.format("%.2f", duplicateResult.getHighestScore()) + "). Cần xem xét thủ công.";
+        try {
+            notificationService.sendToAllAdmins(
+                    NotificationType.LISTING_DUPLICATE_DETECTED,
+                    "Phát hiện tin đăng trùng lặp",
+                    message,
+                    listing.getListingId(), "LISTING");
+        } catch (Exception e) {
+            log.warn("Failed to send duplicate detection admin notification for listing {}: {}", listing.getListingId(), e.getMessage());
+        }
+    }
+
+    /**
+     * Calls the AI duplicate-detection endpoint for a listing. Reuses the fields
+     * already gathered for verification and enriches them with structured
+     * location (province/district) so the AI can retrieve candidates.
+     *
+     * <p>Best-effort by design: any failure (AI down, timeout, validation) is
+     * swallowed and returns {@code null} (treated as PASS) so duplicate detection
+     * can never block the pre-computation pipeline.
+     */
+    private DuplicateCheckResponse runDuplicateCheck(Listing listing, AiListingVerificationRequest request) {
+        try {
+            DuplicateCheckRequest.DuplicateCheckRequestBuilder builder = DuplicateCheckRequest.builder()
+                    .listingId(listing.getListingId())
+                    .title(request.getTitle())
+                    .description(request.getDescription())
+                    .price(request.getPrice() != null ? request.getPrice().doubleValue() : null)
+                    .area(request.getArea())
+                    .address(request.getAddress())
+                    .productType(listing.getProductType() != null ? listing.getProductType().name() : null)
+                    .imageUrls(request.getImages());
+
+            Address addr = listing.getAddress();
+            if (addr != null) {
+                String provinceCode = addr.getNewProvinceCode() != null
+                        ? addr.getNewProvinceCode()
+                        : (addr.getLegacyProvinceId() != null ? String.valueOf(addr.getLegacyProvinceId()) : null);
+                builder.provinceCode(provinceCode).districtId(addr.getLegacyDistrictId());
+            }
+
+            return smartRentAiConnector.checkDuplicate(builder.build());
+        } catch (Exception e) {
+            log.warn("Duplicate check failed for listing ID {} (treating as PASS): {}",
+                    listing.getListingId(), e.getMessage());
+            return null;
+        }
+    }
+}

--- a/smart-rent/src/main/resources/application.yml
+++ b/smart-rent/src/main/resources/application.yml
@@ -529,6 +529,17 @@ otp:
 smartrent:
   ai:
     verification:
+      # Background job that pre-computes + STORES the AI analysis for pending
+      # listings, so the admin review dialog shows it instantly on open. It never
+      # approves/rejects — the admin always decides.
+      # `enabled` here is the infra kill switch; the admin-facing on/off toggle
+      # lives in the DB (system_settings.ai_auto_verify_enabled).
+      scheduler:
+        enabled: ${AI_SCHEDULER_ENABLED:true}
+        delay: ${AI_SCHEDULER_DELAY_MS:300000}
+        # Listings processed per tick. Lower (e.g. 3-5) to drain a large one-time
+        # backlog without pinning the single AI worker's CPU. Default 20.
+        batch-size: ${AI_SCHEDULER_BATCH_SIZE:20}
       url: ${AI_VERIFICATION_URL:http://localhost:8000/ai/verify-listing}
       timeout-seconds: ${AI_VERIFICATION_TIMEOUT:90}
       max-retry-attempts: ${AI_VERIFICATION_MAX_RETRY:3}


### PR DESCRIPTION
## Bối cảnh
PR #422 xoá hẳn cronjob AI để bỏ "trust AI 100%" — nhưng xoá luôn cả phần **tính trước & lưu** kết quả AI. Hậu quả: endpoint stored-result luôn trả `null`, admin phải bấm Verify và **đợi ~30s** mỗi lần xem xét tin.

## Thay đổi
Dựng lại job nền, nhưng **store-only**:
- Gọi AI (verify + duplicate) và **lưu** kết quả vào `ListingAiModeration` → dialog xem xét hiện kết quả **ngay khi mở**, không phải đợi.
- **KHÔNG bao giờ duyệt/từ chối**: không `listing.setVerified` / `setIsVerify` / `setModerationStatus`, không gửi noti auto-approve/reject cho owner. Mọi tin vẫn vào hàng đợi admin; quyết định cuối vẫn qua `PUT /v1/admin/listings/{id}/status`. `moderation.verificationStatus` giờ chỉ ghi **ý kiến** của AI (kiêm cờ đã-xử-lý), không phải trạng thái của listing.
- Gate bởi flag DB `system_settings.ai_auto_verify_enabled` (đọc lại mỗi tick → đổi là ăn ngay, sống qua restart) + kill switch hạ tầng `smartrent.ai.verification.scheduler.enabled`. `AtomicBoolean` reset-khi-restart đã bỏ hẳn.
- Chỉ giữ noti báo admin khi phát hiện **trùng lặp**, vì tin trùng nhìn bề ngoài không có gì bất thường trong hàng đợi.

FE đi kèm: smartrent-fe PR `feat/ai-auto-verify-dialog`.

## Test plan
- [x] `./gradlew compileJava` pass
- [x] Grep xác nhận job nền không đụng `listing.setVerified/setIsVerify/setModerationStatus`; nơi duy nhất set APPROVED/REJECTED là `handleApprove/handleReject(adminId)` (admin bấm)
- [ ] Bật flag → job nền chạy, `ai_reason` được ghi, mở dialog thấy kết quả ngay
- [ ] Tắt flag → job nền skip, dialog trống, bấm Verify chạy thủ công
- [ ] Xác nhận không tin nào bị tự đổi sang APPROVED/REJECTED
