### PR TITLE
AI analysis queue: push on submit instead of polling (cron demoted to backstop)

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/config/ai/AiAnalysisStreamConfig.java
+++ b/smart-rent/src/main/java/com/smartrent/config/ai/AiAnalysisStreamConfig.java
@@ -1,0 +1,99 @@
+package com.smartrent.config.ai;
+
+import com.smartrent.service.ai.impl.AiAnalysisStreamConsumer;
+import com.smartrent.service.ai.impl.AiAnalysisWorker;
+import com.smartrent.service.ai.impl.RedisStreamAiAnalysisQueue;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.stream.Consumer;
+import org.springframework.data.redis.connection.stream.MapRecord;
+import org.springframework.data.redis.connection.stream.ReadOffset;
+import org.springframework.data.redis.connection.stream.StreamOffset;
+import org.springframework.data.redis.core.RedisCallback;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.stream.StreamMessageListenerContainer;
+import org.springframework.data.redis.stream.StreamMessageListenerContainer.StreamMessageListenerContainerOptions;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+
+/**
+ * Wires the AI-analysis queue: a Redis Streams consumer group that pre-computes a
+ * listing's AI analysis as soon as it is submitted, off the request thread.
+ *
+ * <p>This is the primary trigger — the scheduler in
+ * {@code AiListingAutoModerationScheduler} is only a reconciliation backstop.
+ *
+ * <p>Gated by {@code smartrent.ai.verification.queue.enabled} (default on) so
+ * test/CI contexts without Redis can disable the listener container, mirroring
+ * {@code notifications.async.enabled}.
+ */
+@Slf4j
+@Configuration
+@ConditionalOnProperty(
+    name = "smartrent.ai.verification.queue.enabled",
+    havingValue = "true",
+    matchIfMissing = true)
+public class AiAnalysisStreamConfig {
+
+    public static final String GROUP = "ai-analysis-workers";
+
+    @Value("${smartrent.ai.verification.queue.consumer-name:worker-1}")
+    private String consumerName;
+
+    @Bean
+    public AiAnalysisStreamConsumer aiAnalysisStreamConsumer(
+            AiAnalysisWorker worker, StringRedisTemplate redisTemplate) {
+        return new AiAnalysisStreamConsumer(worker, redisTemplate, GROUP);
+    }
+
+    @Bean(destroyMethod = "stop")
+    public StreamMessageListenerContainer<String, MapRecord<String, String, String>>
+            aiAnalysisStreamListenerContainer(
+                    RedisConnectionFactory connectionFactory,
+                    StringRedisTemplate redisTemplate,
+                    AiAnalysisStreamConsumer consumer) {
+
+        ensureConsumerGroup(redisTemplate);
+
+        StreamMessageListenerContainerOptions<String, MapRecord<String, String, String>> options =
+                StreamMessageListenerContainerOptions.builder()
+                        // An AI analysis is a slow, blocking I/O job (~30s). Give the container
+                        // its own bounded pool so several listings can be analysed at once
+                        // without a slow one stalling the others behind it.
+                        .pollTimeout(Duration.ofSeconds(1))
+                        .batchSize(1)
+                        .build();
+
+        StreamMessageListenerContainer<String, MapRecord<String, String, String>> container =
+                StreamMessageListenerContainer.create(connectionFactory, options);
+        container.receive(
+                Consumer.from(GROUP, consumerName),
+                StreamOffset.create(RedisStreamAiAnalysisQueue.STREAM_KEY, ReadOffset.lastConsumed()),
+                consumer);
+        container.start();
+        log.info(
+                "AI analysis stream consumer started: stream={}, group={}, consumer={}",
+                RedisStreamAiAnalysisQueue.STREAM_KEY, GROUP, consumerName);
+        return container;
+    }
+
+    /** Idempotently create the consumer group (MKSTREAM), ignoring BUSYGROUP. */
+    private void ensureConsumerGroup(StringRedisTemplate redisTemplate) {
+        try {
+            redisTemplate.execute((RedisCallback<String>) connection ->
+                    connection.streamCommands().xGroupCreate(
+                            RedisStreamAiAnalysisQueue.STREAM_KEY.getBytes(StandardCharsets.UTF_8),
+                            GROUP,
+                            ReadOffset.from("0"),
+                            true));
+            log.info("Created AI analysis consumer group {}", GROUP);
+        } catch (Exception e) {
+            log.debug("AI analysis consumer group {} already present: {}", GROUP, e.getMessage());
+        }
+    }
+}

--- a/smart-rent/src/main/java/com/smartrent/cronjob/AiListingAutoModerationScheduler.java
+++ b/smart-rent/src/main/java/com/smartrent/cronjob/AiListingAutoModerationScheduler.java
@@ -23,9 +23,21 @@ import java.util.concurrent.CompletableFuture;
 import java.util.stream.IntStream;
 
 /**
- * Pre-computes AI analysis for pending listings in the background, so the admin
- * review dialog can show the result instantly on open instead of running the AI
- * live and making the admin wait ~30s.
+ * <b>Reconciliation backstop</b> for AI pre-computation — not the primary trigger.
+ *
+ * <p>A listing is normally analysed within seconds of being submitted, pushed onto
+ * the Redis Streams queue by {@code ListingSubmittedAiEnqueuer}. This sweep exists
+ * for the listings that never made it onto that queue and would otherwise be
+ * analysed by nobody, leaving the admin staring at an empty dialog forever:
+ * <ul>
+ *   <li>Redis was down (or the enqueue threw) at submit time.</li>
+ *   <li>The consumer died mid-message and the entry aged out of the pending list.</li>
+ *   <li>The listing predates the queue, or was submitted while auto-verify was OFF
+ *       and the admin has since switched it back ON.</li>
+ * </ul>
+ *
+ * <p>Because the queue does the real work, this runs infrequently (30 min) on a
+ * small batch — it is a safety net, not a throughput mechanism.
  *
  * <p><b>Store-only.</b> This never approves or rejects a listing — it only stores
  * the AI's analysis on {@link ListingAiModeration}. Every listing still lands in
@@ -65,12 +77,12 @@ public class AiListingAutoModerationScheduler {
     private final AiVerificationSettingService aiVerificationSettingService;
 
     /**
-     * Number of listings pulled per tick. Lower it (e.g. 3-5) to drain a large
-     * one-time backlog without pinning the single AI worker's CPU — fewer
-     * concurrent CPU-bound duplicate checks, roughly the same throughput (the GIL
-     * serializes them anyway). Default 20.
+     * Number of listings pulled per sweep. Deliberately small: this only picks up
+     * stragglers the queue missed, and a large batch would pin the single AI
+     * worker's CPU with concurrent duplicate checks for no throughput gain (the
+     * GIL serializes them anyway). Raise it temporarily to drain a big backlog.
      */
-    @Value("${smartrent.ai.verification.scheduler.batch-size:20}")
+    @Value("${smartrent.ai.verification.scheduler.batch-size:10}")
     private int batchSize;
 
     /**
@@ -95,12 +107,14 @@ public class AiListingAutoModerationScheduler {
     }
 
     /**
-     * Run every 5 minutes to pre-compute + store the AI analysis for pending listings.
+     * Sweep every 30 minutes for listings the queue never analysed, and store their
+     * AI result. Finds nothing on a healthy system — the queue got there first.
      *
      * <p>Strategy:
      * <ol>
      *   <li>Load a page of pending listings in a single read transaction.</li>
-     *   <li>Batch-mark all as IN_PROGRESS in one query before dispatching.</li>
+     *   <li>Batch-mark all as IN_PROGRESS in one query before dispatching — this also
+     *       stops the queue consumer double-analysing anything picked up here.</li>
      *   <li>Call {@link AiModerationProcessorService#processSingleListing} for each listing
      *       via the Spring proxy so each item runs in its own {@code REQUIRES_NEW} transaction.
      *       Tasks run concurrently on {@link AiModerationExecutor#batchPool()} — a dedicated
@@ -108,25 +122,26 @@ public class AiListingAutoModerationScheduler {
      *       designed for CPU-bound work and limited to {@code cores - 1} threads.</li>
      * </ol>
      */
-    @Scheduled(fixedDelayString = "${smartrent.ai.verification.scheduler.delay:300000}")
+    @Scheduled(fixedDelayString = "${smartrent.ai.verification.scheduler.delay:1800000}")
     public void processPendingListings() {
         if (!aiVerificationSettingService.isAutoVerifyEnabled()) {
-            log.debug("AI auto-verify is DISABLED by admin — skipping background pre-computation.");
+            log.debug("AI auto-verify is DISABLED by admin — skipping reconciliation sweep.");
             return;
         }
-        log.info("Starting AI background pre-computation...");
+        log.debug("Starting AI reconciliation sweep...");
 
         try {
-            int size = batchSize > 0 ? batchSize : 20;
+            int size = batchSize > 0 ? batchSize : 10;
             Page<Listing> pendingListings = listingRepository.findListingsNeedingAiVerification(PageRequest.of(0, size));
             List<Listing> listings = pendingListings.getContent();
 
             if (listings.isEmpty()) {
-                log.info("No pending listings need AI pre-computation.");
+                log.debug("Reconciliation sweep found nothing — the queue kept up.");
                 return;
             }
 
-            log.info("Found {} listings to pre-compute", listings.size());
+            // Not empty means the queue missed these — worth surfacing at INFO.
+            log.info("Reconciliation sweep picked up {} listing(s) the queue missed", listings.size());
 
             // 1. Upsert moderation records, then batch-mark all as IN_PROGRESS in one query.
             List<ListingAiModeration> moderations = listings.stream().map(listing ->

--- a/smart-rent/src/main/java/com/smartrent/event/ListingSubmittedEvent.java
+++ b/smart-rent/src/main/java/com/smartrent/event/ListingSubmittedEvent.java
@@ -1,0 +1,13 @@
+package com.smartrent.event;
+
+/**
+ * Raised when a listing enters the review queue — on first submit, on resubmit
+ * after a revision request, and on update-and-resubmit.
+ *
+ * <p>Consumed after the transaction commits to enqueue the listing for AI
+ * pre-computation, so the admin review dialog has the analysis ready.
+ *
+ * @param listingId the listing that needs AI analysis
+ */
+public record ListingSubmittedEvent(Long listingId) {
+}

--- a/smart-rent/src/main/java/com/smartrent/service/ai/AiAnalysisQueue.java
+++ b/smart-rent/src/main/java/com/smartrent/service/ai/AiAnalysisQueue.java
@@ -1,0 +1,21 @@
+package com.smartrent.service.ai;
+
+/**
+ * Queue of listings waiting for their AI analysis to be pre-computed.
+ *
+ * <p>A listing is enqueued the moment it is submitted or resubmitted, so its AI
+ * analysis is ready within seconds instead of waiting for the next reconciliation
+ * sweep. The queue is the primary trigger; the scheduler is only a backstop for
+ * anything the queue missed (Redis down, message lost, listings that predate the
+ * queue).
+ */
+public interface AiAnalysisQueue {
+
+    /**
+     * Enqueue a listing for AI pre-computation.
+     *
+     * <p>Best-effort: a queue failure must never fail the caller's transaction —
+     * the reconciliation sweep will pick the listing up instead.
+     */
+    void enqueue(Long listingId);
+}

--- a/smart-rent/src/main/java/com/smartrent/service/ai/impl/AiAnalysisStreamConsumer.java
+++ b/smart-rent/src/main/java/com/smartrent/service/ai/impl/AiAnalysisStreamConsumer.java
@@ -1,0 +1,42 @@
+package com.smartrent.service.ai.impl;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.connection.stream.MapRecord;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.stream.StreamListener;
+
+/**
+ * Reads listing IDs delivered to the AI-analysis consumer group and runs the
+ * store-only pre-computation for each, acknowledging every message when done.
+ */
+@Slf4j
+public class AiAnalysisStreamConsumer
+        implements StreamListener<String, MapRecord<String, String, String>> {
+
+    private final AiAnalysisWorker worker;
+    private final StringRedisTemplate redisTemplate;
+    private final String group;
+
+    public AiAnalysisStreamConsumer(
+            AiAnalysisWorker worker, StringRedisTemplate redisTemplate, String group) {
+        this.worker = worker;
+        this.redisTemplate = redisTemplate;
+        this.group = group;
+    }
+
+    @Override
+    public void onMessage(MapRecord<String, String, String> message) {
+        try {
+            String raw = message.getValue().get("listingId");
+            worker.analyze(Long.valueOf(raw));
+        } catch (Exception e) {
+            // Acknowledge below regardless: processSingleListing already tracks its own
+            // retryCount, and the reconciliation sweep re-discovers anything left in
+            // PENDING. Leaving the message unacked would only poison the consumer group.
+            log.error("Failed to process queued AI analysis {}: {}", message.getId(), e.getMessage(), e);
+        } finally {
+            redisTemplate.opsForStream()
+                    .acknowledge(RedisStreamAiAnalysisQueue.STREAM_KEY, group, message.getId());
+        }
+    }
+}

--- a/smart-rent/src/main/java/com/smartrent/service/ai/impl/AiAnalysisWorker.java
+++ b/smart-rent/src/main/java/com/smartrent/service/ai/impl/AiAnalysisWorker.java
@@ -1,0 +1,105 @@
+package com.smartrent.service.ai.impl;
+
+import com.smartrent.enums.ModerationStatus;
+import com.smartrent.infra.repository.ListingAiModerationRepository;
+import com.smartrent.infra.repository.ListingRepository;
+import com.smartrent.infra.repository.entity.Listing;
+import com.smartrent.infra.repository.entity.ListingAiModeration;
+import com.smartrent.infra.repository.entity.enums.VerificationStatus;
+import com.smartrent.service.ai.AiModerationProcessorService;
+import com.smartrent.service.ai.AiVerificationSettingService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+/**
+ * Analyses one listing pulled off the AI analysis queue: claims it, then hands it
+ * to the store-only {@link AiModerationProcessorService}.
+ *
+ * <p>Applies the same gates as the reconciliation sweep's query
+ * ({@code findListingsNeedingAiVerification}) — the queue can deliver a listing
+ * that has since been drafted, approved by an admin, or taken over manually, and
+ * re-analysing it would be wasted AI spend.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AiAnalysisWorker {
+
+    private final ListingRepository listingRepository;
+    private final ListingAiModerationRepository listingAiModerationRepository;
+    private final AiModerationProcessorService aiModerationProcessorService;
+    private final AiVerificationSettingService aiVerificationSettingService;
+
+    /**
+     * Pre-compute and store the AI analysis for one listing.
+     *
+     * <p>Silently no-ops when the listing no longer needs analysis. Never approves
+     * or rejects — see {@link AiModerationProcessorService}.
+     */
+    public void analyze(Long listingId) {
+        if (!aiVerificationSettingService.isAutoVerifyEnabled()) {
+            log.debug("AI auto-verify disabled — dropping queued analysis for listing {}", listingId);
+            return;
+        }
+
+        // Fetch-joins address + amenities: processSingleListing reads them off this
+        // (detached) entity when building the duplicate-check request.
+        Listing listing = listingRepository.findByIdWithAmenities(listingId).orElse(null);
+        if (listing == null) {
+            log.warn("Queued listing {} no longer exists — skipping AI analysis", listingId);
+            return;
+        }
+        if (!needsAnalysis(listing)) {
+            log.debug("Listing {} no longer needs AI analysis (draft/shadow/resolved) — skipping", listingId);
+            return;
+        }
+
+        ListingAiModeration moderation = listingAiModerationRepository.findById(listingId)
+                .orElseGet(() -> ListingAiModeration.builder()
+                        .listingId(listingId)
+                        .retryCount(0)
+                        .manualOverride(false)
+                        .verificationStatus(VerificationStatus.PENDING)
+                        .build());
+
+        if (Boolean.TRUE.equals(moderation.getManualOverride())) {
+            log.debug("Listing {} was taken over by an admin — skipping AI analysis", listingId);
+            return;
+        }
+        if (moderation.getRetryCount() != null && moderation.getRetryCount() >= 3) {
+            log.debug("Listing {} exhausted AI retries — skipping", listingId);
+            return;
+        }
+        VerificationStatus status = moderation.getVerificationStatus();
+        if (status == VerificationStatus.IN_PROGRESS) {
+            log.debug("Listing {} is already being analysed — skipping duplicate delivery", listingId);
+            return;
+        }
+        // Anything already computed (VERIFIED/REJECTED/UNDER_REVIEW) is only re-run
+        // via a resubmit, which resets the record back to PENDING first.
+        if (status != null && status != VerificationStatus.PENDING) {
+            log.debug("Listing {} already has a stored AI result ({}) — skipping", listingId, status);
+            return;
+        }
+
+        // Claim it so a concurrent sweep doesn't pick up the same listing.
+        moderation.setVerificationStatus(VerificationStatus.IN_PROGRESS);
+        listingAiModerationRepository.save(moderation);
+
+        aiModerationProcessorService.processSingleListing(listing, moderation);
+    }
+
+    /** Mirrors the gatekeeping half of {@code findListingsNeedingAiVerification}. */
+    private boolean needsAnalysis(Listing listing) {
+        if (Boolean.TRUE.equals(listing.getIsDraft())) return false;
+        if (Boolean.TRUE.equals(listing.getIsShadow())) return false;
+        if (listing.getPostDate() == null) return false;
+        if (Boolean.TRUE.equals(listing.getVerified())) return false;
+
+        ModerationStatus ms = listing.getModerationStatus();
+        return ms == null
+                || ms == ModerationStatus.PENDING_REVIEW
+                || ms == ModerationStatus.RESUBMITTED;
+    }
+}

--- a/smart-rent/src/main/java/com/smartrent/service/ai/impl/ListingSubmittedAiEnqueuer.java
+++ b/smart-rent/src/main/java/com/smartrent/service/ai/impl/ListingSubmittedAiEnqueuer.java
@@ -1,0 +1,40 @@
+package com.smartrent.service.ai.impl;
+
+import com.smartrent.event.ListingSubmittedEvent;
+import com.smartrent.service.ai.AiAnalysisQueue;
+import com.smartrent.service.ai.AiVerificationSettingService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+/**
+ * Enqueues a submitted listing for AI pre-computation — but only while the admin's
+ * auto-verify setting is ON. With it OFF, nothing is pushed onto the queue at all,
+ * so no AI spend is incurred for listings submitted during that window; admins run
+ * the analysis by hand from the review dialog instead.
+ *
+ * <p>Fires on {@link TransactionPhase#AFTER_COMMIT} on purpose: enqueueing inside
+ * the transaction would hand the worker a listing ID that a later rollback makes
+ * nonexistent, and the worker (running in a different thread) could even race the
+ * commit and read a listing that isn't there yet.
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ListingSubmittedAiEnqueuer {
+
+    private final AiAnalysisQueue aiAnalysisQueue;
+    private final AiVerificationSettingService aiVerificationSettingService;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onListingSubmitted(ListingSubmittedEvent event) {
+        if (!aiVerificationSettingService.isAutoVerifyEnabled()) {
+            log.debug("AI auto-verify is OFF — not queueing listing {}", event.listingId());
+            return;
+        }
+        log.debug("Listing {} submitted — queueing AI analysis", event.listingId());
+        aiAnalysisQueue.enqueue(event.listingId());
+    }
+}

--- a/smart-rent/src/main/java/com/smartrent/service/ai/impl/RedisStreamAiAnalysisQueue.java
+++ b/smart-rent/src/main/java/com/smartrent/service/ai/impl/RedisStreamAiAnalysisQueue.java
@@ -1,0 +1,38 @@
+package com.smartrent.service.ai.impl;
+
+import com.smartrent.service.ai.AiAnalysisQueue;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+/**
+ * Redis Streams implementation of {@link AiAnalysisQueue}. Listing IDs are
+ * appended to a single stream and consumed by a worker via a consumer group —
+ * the same shape as the notification pipeline.
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class RedisStreamAiAnalysisQueue implements AiAnalysisQueue {
+
+    public static final String STREAM_KEY = "ai:listing:analysis";
+
+    private final StringRedisTemplate redisTemplate;
+
+    @Override
+    public void enqueue(Long listingId) {
+        if (listingId == null) return;
+        try {
+            redisTemplate.opsForStream().add(STREAM_KEY, Map.of("listingId", String.valueOf(listingId)));
+            log.debug("Enqueued listing {} for AI analysis", listingId);
+        } catch (Exception e) {
+            // Never fail the caller because the queue is down — the reconciliation
+            // sweep re-discovers anything that never made it onto the stream.
+            log.warn("Failed to enqueue listing {} for AI analysis (reconciliation sweep will retry): {}",
+                    listingId, e.getMessage());
+        }
+    }
+}

--- a/smart-rent/src/main/java/com/smartrent/service/listing/impl/ListingServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/listing/impl/ListingServiceImpl.java
@@ -58,6 +58,7 @@ import com.smartrent.service.listing.ListingService;
 import com.smartrent.service.listing.ListingQueryService;
 import com.smartrent.service.listing.PostingAccessGuard;
 import com.smartrent.service.listing.cache.ListingRequestCacheService;
+import com.smartrent.event.ListingSubmittedEvent;
 import com.smartrent.service.notification.NotificationService;
 import com.smartrent.util.TextNormalizer;
 // import com.smartrent.service.pricing.LocationPricingService;  // DISABLED: Not in use
@@ -138,6 +139,7 @@ public class ListingServiceImpl implements ListingService {
     com.smartrent.infra.repository.UserFollowRepository userFollowRepository;
     PostingAccessGuard postingAccessGuard;
     NotificationService notificationService;
+    org.springframework.context.ApplicationEventPublisher eventPublisher;
 
     @Override
     @Transactional
@@ -274,6 +276,11 @@ public class ListingServiceImpl implements ListingService {
         if ("DIAMOND".equalsIgnoreCase(vipType)) {
             createShadowListing(saved);
         }
+
+        // Queue the AI analysis so it is already computed by the time an admin opens
+        // the review dialog. Delivered after commit — media/amenities above are part
+        // of this transaction and the worker must not read the listing without them.
+        eventPublisher.publishEvent(new ListingSubmittedEvent(saved.getListingId()));
 
         return listingMapper.toCreationResponse(saved);
     }

--- a/smart-rent/src/main/java/com/smartrent/service/moderation/impl/ListingModerationServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/moderation/impl/ListingModerationServiceImpl.java
@@ -1,5 +1,6 @@
 package com.smartrent.service.moderation.impl;
 
+import com.smartrent.event.ListingSubmittedEvent;
 import com.smartrent.dto.request.ListingStatusChangeRequest;
 import com.smartrent.dto.request.ResolveReportRequest;
 import com.smartrent.dto.request.ResubmitListingRequest;
@@ -70,6 +71,7 @@ public class ListingModerationServiceImpl implements ListingModerationService {
     EmailService emailService;
     NotificationService notificationService;
     UserFollowService userFollowService;
+    org.springframework.context.ApplicationEventPublisher eventPublisher;
 
     @NonFinal
     @Value("${application.email.sender.email}")
@@ -368,6 +370,9 @@ public class ListingModerationServiceImpl implements ListingModerationService {
                     listingAiModerationRepository.save(moderation);
                     log.info("Created new AI moderation entry for resubmitted listing {}", listing.getListingId());
                 });
+        // Re-queue: the record above is back to PENDING, so the AI must re-analyse the
+        // revised content. Delivered after commit.
+        eventPublisher.publishEvent(new ListingSubmittedEvent(listing.getListingId()));
         // ---------------------------------
 
         // Advance any pending owner actions
@@ -505,6 +510,9 @@ public class ListingModerationServiceImpl implements ListingModerationService {
                     listingAiModerationRepository.save(moderation);
                     log.info("Created new AI moderation entry for updated listing {}", listing.getListingId());
                 });
+        // Re-queue: the record above is back to PENDING, so the AI must re-analyse the
+        // revised content. Delivered after commit.
+        eventPublisher.publishEvent(new ListingSubmittedEvent(listing.getListingId()));
         // ---------------------------------
 
         // Advance any pending owner actions

--- a/smart-rent/src/main/resources/application.yml
+++ b/smart-rent/src/main/resources/application.yml
@@ -529,17 +529,25 @@ otp:
 smartrent:
   ai:
     verification:
-      # Background job that pre-computes + STORES the AI analysis for pending
-      # listings, so the admin review dialog shows it instantly on open. It never
-      # approves/rejects — the admin always decides.
-      # `enabled` here is the infra kill switch; the admin-facing on/off toggle
-      # lives in the DB (system_settings.ai_auto_verify_enabled).
+      # AI analysis is pre-computed + STORED so the admin review dialog shows it
+      # instantly on open. It never approves/rejects — the admin always decides.
+      # The admin-facing on/off toggle lives in the DB
+      # (system_settings.ai_auto_verify_enabled); the switches below are infra
+      # kill switches only.
+      #
+      # PRIMARY trigger: a listing is pushed onto a Redis Stream the moment it is
+      # submitted/resubmitted, so its analysis is ready within seconds.
+      queue:
+        enabled: ${AI_QUEUE_ENABLED:true}
+        # Give each instance a distinct name when running >1 replica.
+        consumer-name: ${AI_QUEUE_CONSUMER_NAME:worker-1}
+      # BACKSTOP only: sweeps up listings the queue never analysed (Redis down at
+      # submit time, consumer died, listings that predate the queue). Finds nothing
+      # on a healthy system — hence the long delay and small batch.
       scheduler:
         enabled: ${AI_SCHEDULER_ENABLED:true}
-        delay: ${AI_SCHEDULER_DELAY_MS:300000}
-        # Listings processed per tick. Lower (e.g. 3-5) to drain a large one-time
-        # backlog without pinning the single AI worker's CPU. Default 20.
-        batch-size: ${AI_SCHEDULER_BATCH_SIZE:20}
+        delay: ${AI_SCHEDULER_DELAY_MS:1800000}
+        batch-size: ${AI_SCHEDULER_BATCH_SIZE:10}
       url: ${AI_VERIFICATION_URL:http://localhost:8000/ai/verify-listing}
       timeout-seconds: ${AI_VERIFICATION_TIMEOUT:90}
       max-retry-attempts: ${AI_VERIFICATION_MAX_RETRY:3}


### PR DESCRIPTION
The 5-minute sweep meant a listing submitted at 12:00:01 sat unanalysed until 12:05, and every tick paid for a full scan whether or not anything was pending. Push the work instead of polling for it.

- A listing is pushed onto a Redis Stream ("ai:listing:analysis") the moment it is submitted or resubmitted, and a consumer group analyses it within seconds. Reuses the Redis Streams pattern already in place for notifications, so no new broker is introduced.
- The push happens on AFTER_COMMIT, not inside the transaction: a worker on another thread would otherwise be handed a listing ID that a rollback makes nonexistent, or race the commit and read the listing without its media.
- Nothing is pushed while the admin's auto-verify setting is OFF, so no AI spend is incurred for listings submitted during that window.
- The cronjob stays, but demoted to a reconciliation backstop: 30 min, batch 10. It exists for listings the queue could never have delivered (Redis down at submit, consumer died mid-message, listings predating the queue) — without it those are analysed by nobody and the admin sees an empty dialog forever. On a healthy system it finds nothing.

Still store-only: the queue path goes through the same processSingleListing and never approves or rejects.