### PR TITLE
fix: queue AI analysis from every path that sends a listing to review

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/service/listing/impl/ListingServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/listing/impl/ListingServiceImpl.java
@@ -140,6 +140,7 @@ public class ListingServiceImpl implements ListingService {
     PostingAccessGuard postingAccessGuard;
     NotificationService notificationService;
     org.springframework.context.ApplicationEventPublisher eventPublisher;
+    com.smartrent.infra.repository.ListingAiModerationRepository listingAiModerationRepository;
 
     @Override
     @Transactional
@@ -277,12 +278,27 @@ public class ListingServiceImpl implements ListingService {
             createShadowListing(saved);
         }
 
-        // Queue the AI analysis so it is already computed by the time an admin opens
-        // the review dialog. Delivered after commit — media/amenities above are part
-        // of this transaction and the worker must not read the listing without them.
-        eventPublisher.publishEvent(new ListingSubmittedEvent(saved.getListingId()));
+        queueAiAnalysis(saved);
 
         return listingMapper.toCreationResponse(saved);
+    }
+
+    /**
+     * Queue a listing for AI pre-computation, so the analysis is already stored by the
+     * time an admin opens the review dialog.
+     *
+     * <p>Call this from <b>every</b> path that puts a listing into the review queue —
+     * first submit, paid submit, VIP, edit-of-an-approved-listing, repost. The
+     * reconciliation sweep that used to catch a missed call site is off, so a path
+     * that forgets this simply never gets analysed.
+     *
+     * <p>Delivered after commit (see {@code ListingSubmittedAiEnqueuer}): media and
+     * amenities are linked in the same transaction, and the worker must not read the
+     * listing before they are visible.
+     */
+    private void queueAiAnalysis(Listing listing) {
+        if (listing == null || listing.getListingId() == null) return;
+        eventPublisher.publishEvent(new ListingSubmittedEvent(listing.getListingId()));
     }
 
     /**
@@ -421,6 +437,8 @@ public class ListingServiceImpl implements ListingService {
                 if ("DIAMOND".equalsIgnoreCase(request.getVipType())) {
                     createShadowListing(saved);
                 }
+
+                queueAiAnalysis(saved);
 
                 return listingMapper.toCreationResponse(saved);
             }
@@ -755,16 +773,38 @@ public class ListingServiceImpl implements ListingService {
         }
 
         // An approved listing edited by the owner must go back through review
-        if (existing.getModerationStatus() == ModerationStatus.APPROVED) {
+        boolean sentBackToReview = existing.getModerationStatus() == ModerationStatus.APPROVED;
+        if (sentBackToReview) {
             existing.setVerified(false);
             existing.setIsVerify(true);
             existing.setModerationStatus(ModerationStatus.PENDING_REVIEW);
+            // The stored AI analysis describes the *pre-edit* content. Reset the record so
+            // the worker re-analyses instead of skipping it as already-computed — otherwise
+            // the review dialog would show a stale verdict for content that has changed.
+            resetAiModerationForReanalysis(existing.getListingId());
         }
 
         Listing saved = listingRepository.save(existing);
+        if (sentBackToReview) {
+            queueAiAnalysis(saved);
+        }
         com.smartrent.dto.response.UserCreationResponse user = buildUserResponse(saved.getUserId());
         com.smartrent.dto.response.AddressResponse addressResponse = buildAddressResponse(saved.getAddress());
         return listingMapper.toResponse(saved, user, addressResponse);
+    }
+
+    /**
+     * Put a listing's AI moderation record back to PENDING so the queue worker will
+     * re-analyse it. Used when the content changed under an existing analysis.
+     */
+    private void resetAiModerationForReanalysis(Long listingId) {
+        listingAiModerationRepository.findById(listingId).ifPresent(moderation -> {
+            moderation.setVerificationStatus(
+                    com.smartrent.infra.repository.entity.enums.VerificationStatus.PENDING);
+            moderation.setRetryCount(0);
+            moderation.setManualOverride(false);
+            listingAiModerationRepository.save(moderation);
+        });
     }
 
     @Override
@@ -1147,6 +1187,8 @@ public class ListingServiceImpl implements ListingService {
             // (so a failed payment wouldn't lose it). Payment succeeded - delete it.
             deleteSourceDraftIfPresent(request);
 
+            queueAiAnalysis(saved);
+
             return listingMapper.toCreationResponse(saved);
 
         } catch (Exception e) {
@@ -1203,6 +1245,8 @@ public class ListingServiceImpl implements ListingService {
 
             // Remove from cache
             listingRequestCacheService.removeVipListingRequest(transactionId);
+
+            queueAiAnalysis(savedVipListing);
 
             return listingMapper.toCreationResponse(savedVipListing);
 

--- a/smart-rent/src/main/java/com/smartrent/service/repost/impl/RepostServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/repost/impl/RepostServiceImpl.java
@@ -11,6 +11,7 @@ import com.smartrent.dto.response.RepostResponse;
 import com.smartrent.enums.BenefitType;
 import com.smartrent.enums.ListingStatus;
 import com.smartrent.enums.ModerationStatus;
+import com.smartrent.event.ListingSubmittedEvent;
 import com.smartrent.enums.PaymentProvider;
 import com.smartrent.infra.repository.ListingRepository;
 import com.smartrent.infra.repository.TransactionRepository;
@@ -52,6 +53,7 @@ public class RepostServiceImpl implements RepostService {
     TransactionService transactionService;
     PaymentService paymentService;
     com.smartrent.service.listing.PostingAccessGuard postingAccessGuard;
+    org.springframework.context.ApplicationEventPublisher eventPublisher;
 
     @Override
     @Transactional
@@ -274,6 +276,11 @@ public class RepostServiceImpl implements RepostService {
         listing.setIsVerify(true);
         listing.setModerationStatus(ModerationStatus.PENDING_REVIEW);
         listingRepository.save(listing);
+
+        // Back in the review queue, so the admin dialog needs an AI analysis to show.
+        // The content is unchanged, so a listing that already has one is skipped by the
+        // worker (no repeat AI spend); one that never got analysed picks it up here.
+        eventPublisher.publishEvent(new ListingSubmittedEvent(listing.getListingId()));
 
         log.info("Successfully reactivated listing {} via {} — new expiry {}",
                 listing.getListingId(), source, newExpiry);


### PR DESCRIPTION
Only createListing enqueued. Five other paths put a listing into the review queue and none of them did, so those listings were never analysed and the admin opened the dialog to an empty AI panel:

- createVipListing
- createNormalListingFromCache  (the post-payment path — most normal listings!)
- createVipListingFromCache     (post-payment VIP)
- updateListing                 (owner edits an approved listing -> back to review)
- RepostServiceImpl.reactivateListing

Route them all through a single queueAiAnalysis() helper so the next path that is added has one obvious thing to call.

updateListing additionally resets the AI moderation record to PENDING: the stored analysis describes the pre-edit content, and without the reset the worker skips the listing as already-computed and the dialog shows a stale verdict for content that has changed.

Repost deliberately does not reset — the content is unchanged, so a listing that already has an analysis is skipped by the worker (no repeat AI spend) while one that never got analysed picks it up.

Note: the reconciliation sweep would have caught every one of these automatically. It is currently disabled (AI_SCHEDULER_ENABLED=false), which is why the gap was silent rather than self-healing.