### PR TITLE
fix: queue AI analysis from every submit path, run analyses concurrently

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/config/ai/AiAnalysisStreamConfig.java
+++ b/smart-rent/src/main/java/com/smartrent/config/ai/AiAnalysisStreamConfig.java
@@ -20,6 +20,9 @@ import org.springframework.data.redis.stream.StreamMessageListenerContainer.Stre
 
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Wires the AI-analysis queue: a Redis Streams consumer group that pre-computes a
@@ -45,10 +48,44 @@ public class AiAnalysisStreamConfig {
     @Value("${smartrent.ai.verification.queue.consumer-name:worker-1}")
     private String consumerName;
 
+    /**
+     * How many listings may be analysed at once.
+     *
+     * <p>Kept small on purpose: the AI service is the bottleneck, not us. Flooding it
+     * with concurrent multimodal requests buys no throughput and just pins its CPU.
+     */
+    @Value("${smartrent.ai.verification.queue.concurrency:4}")
+    private int concurrency;
+
+    /**
+     * Bounded pool the consumer offloads analyses onto.
+     *
+     * <p>{@link ThreadPoolExecutor.CallerRunsPolicy} is the back-pressure: once the pool
+     * and its queue are full, the poll thread runs the analysis itself, which stops it
+     * reading more from the stream until it catches up. Unacked entries simply stay
+     * pending in Redis — nothing is lost and nothing piles up in memory.
+     */
+    @Bean(destroyMethod = "shutdown")
+    public ThreadPoolExecutor aiAnalysisQueuePool() {
+        int size = concurrency > 0 ? concurrency : 4;
+        return new ThreadPoolExecutor(
+                size, size,
+                60L, TimeUnit.SECONDS,
+                new ArrayBlockingQueue<>(size * 4),
+                r -> {
+                    Thread t = new Thread(r, "ai-queue-worker");
+                    t.setDaemon(true);
+                    return t;
+                },
+                new ThreadPoolExecutor.CallerRunsPolicy());
+    }
+
     @Bean
     public AiAnalysisStreamConsumer aiAnalysisStreamConsumer(
-            AiAnalysisWorker worker, StringRedisTemplate redisTemplate) {
-        return new AiAnalysisStreamConsumer(worker, redisTemplate, GROUP);
+            AiAnalysisWorker worker,
+            StringRedisTemplate redisTemplate,
+            ThreadPoolExecutor aiAnalysisQueuePool) {
+        return new AiAnalysisStreamConsumer(worker, redisTemplate, GROUP, aiAnalysisQueuePool);
     }
 
     @Bean(destroyMethod = "stop")
@@ -62,9 +99,8 @@ public class AiAnalysisStreamConfig {
 
         StreamMessageListenerContainerOptions<String, MapRecord<String, String, String>> options =
                 StreamMessageListenerContainerOptions.builder()
-                        // An AI analysis is a slow, blocking I/O job (~30s). Give the container
-                        // its own bounded pool so several listings can be analysed at once
-                        // without a slow one stalling the others behind it.
+                        // The container calls the listener synchronously on this poll thread —
+                        // the parallelism lives in the consumer's pool, not here.
                         .pollTimeout(Duration.ofSeconds(1))
                         .batchSize(1)
                         .build();

--- a/smart-rent/src/main/java/com/smartrent/service/ai/impl/AiAnalysisStreamConsumer.java
+++ b/smart-rent/src/main/java/com/smartrent/service/ai/impl/AiAnalysisStreamConsumer.java
@@ -5,9 +5,20 @@ import org.springframework.data.redis.connection.stream.MapRecord;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.stream.StreamListener;
 
+import java.util.concurrent.Executor;
+
 /**
  * Reads listing IDs delivered to the AI-analysis consumer group and runs the
  * store-only pre-computation for each, acknowledging every message when done.
+ *
+ * <p>Work is handed to {@code executor} rather than run inline. Spring Data's
+ * {@code StreamMessageListenerContainer} calls {@link #onMessage} <b>synchronously
+ * on the subscription's poll thread</b>, so doing a ~30s AI call here would stall
+ * every other listing behind it — ten listings submitted at once would leave the
+ * last one waiting five minutes. Dispatching lets several analyses overlap; the
+ * pool is bounded with a caller-runs policy, so when it saturates the poll thread
+ * runs the job itself and reading naturally stops — back-pressure instead of an
+ * unbounded backlog.
  */
 @Slf4j
 public class AiAnalysisStreamConsumer
@@ -16,27 +27,52 @@ public class AiAnalysisStreamConsumer
     private final AiAnalysisWorker worker;
     private final StringRedisTemplate redisTemplate;
     private final String group;
+    private final Executor executor;
 
     public AiAnalysisStreamConsumer(
-            AiAnalysisWorker worker, StringRedisTemplate redisTemplate, String group) {
+            AiAnalysisWorker worker,
+            StringRedisTemplate redisTemplate,
+            String group,
+            Executor executor) {
         this.worker = worker;
         this.redisTemplate = redisTemplate;
         this.group = group;
+        this.executor = executor;
     }
 
     @Override
     public void onMessage(MapRecord<String, String, String> message) {
+        final Long listingId;
         try {
-            String raw = message.getValue().get("listingId");
-            worker.analyze(Long.valueOf(raw));
+            listingId = Long.valueOf(message.getValue().get("listingId"));
         } catch (Exception e) {
-            // Acknowledge below regardless: processSingleListing already tracks its own
-            // retryCount, and the reconciliation sweep re-discovers anything left in
-            // PENDING. Leaving the message unacked would only poison the consumer group.
-            log.error("Failed to process queued AI analysis {}: {}", message.getId(), e.getMessage(), e);
-        } finally {
+            // Unparseable payload will never become parseable — ACK it away rather than
+            // letting it sit pending forever.
+            log.error("Malformed AI analysis message {}: {}", message.getId(), message.getValue(), e);
+            acknowledge(message);
+            return;
+        }
+
+        executor.execute(() -> {
+            try {
+                worker.analyze(listingId);
+            } catch (Exception e) {
+                // ACK below regardless: processSingleListing tracks its own retryCount, and
+                // the reconciliation sweep re-discovers anything left PENDING. Leaving the
+                // message unacked would only poison the consumer group.
+                log.error("Failed to analyse queued listing {}: {}", listingId, e.getMessage(), e);
+            } finally {
+                acknowledge(message);
+            }
+        });
+    }
+
+    private void acknowledge(MapRecord<String, String, String> message) {
+        try {
             redisTemplate.opsForStream()
                     .acknowledge(RedisStreamAiAnalysisQueue.STREAM_KEY, group, message.getId());
+        } catch (Exception e) {
+            log.warn("Failed to ACK AI analysis message {}: {}", message.getId(), e.getMessage());
         }
     }
 }

--- a/smart-rent/src/main/resources/application.yml
+++ b/smart-rent/src/main/resources/application.yml
@@ -541,6 +541,10 @@ smartrent:
         enabled: ${AI_QUEUE_ENABLED:true}
         # Give each instance a distinct name when running >1 replica.
         consumer-name: ${AI_QUEUE_CONSUMER_NAME:worker-1}
+        # Listings analysed at once. Small on purpose — the AI service is the
+        # bottleneck; flooding it with concurrent multimodal requests buys no
+        # throughput and just pins its CPU.
+        concurrency: ${AI_QUEUE_CONCURRENCY:4}
       # BACKSTOP sweep — OFF for now. The queue is the only trigger.
       #
       # It exists to catch listings the queue could never have delivered (Redis

--- a/smart-rent/src/test/java/com/smartrent/service/ai/AiAnalysisQueueIntegrationTest.java
+++ b/smart-rent/src/test/java/com/smartrent/service/ai/AiAnalysisQueueIntegrationTest.java
@@ -1,0 +1,222 @@
+package com.smartrent.service.ai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import com.smartrent.config.ai.AiAnalysisStreamConfig;
+import com.smartrent.service.ai.impl.AiAnalysisStreamConsumer;
+import com.smartrent.service.ai.impl.AiAnalysisWorker;
+import com.smartrent.service.ai.impl.RedisStreamAiAnalysisQueue;
+import java.net.ServerSocket;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.connection.stream.Consumer;
+import org.springframework.data.redis.connection.stream.MapRecord;
+import org.springframework.data.redis.connection.stream.PendingMessagesSummary;
+import org.springframework.data.redis.connection.stream.ReadOffset;
+import org.springframework.data.redis.connection.stream.StreamOffset;
+import org.springframework.data.redis.core.RedisCallback;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.stream.StreamMessageListenerContainer;
+import org.springframework.data.redis.stream.StreamMessageListenerContainer.StreamMessageListenerContainerOptions;
+import redis.embedded.RedisServer;
+
+/**
+ * End-to-end proof that the AI analysis queue actually delivers: producer XADDs a
+ * listing id, the consumer group hands it to the worker, and the message is ACKed
+ * (so it is not redelivered forever).
+ *
+ * <p>Runs against a real embedded Redis — the plumbing (consumer group creation,
+ * offsets, serialization) is exactly what breaks in production, and a mock would
+ * prove none of it.
+ */
+class AiAnalysisQueueIntegrationTest {
+
+  private static RedisServer redisServer;
+  private static int port;
+
+  private LettuceConnectionFactory connectionFactory;
+  private StringRedisTemplate redisTemplate;
+  private StreamMessageListenerContainer<String, MapRecord<String, String, String>> container;
+
+  @BeforeAll
+  static void startRedis() throws Exception {
+    try (ServerSocket socket = new ServerSocket(0)) {
+      port = socket.getLocalPort();
+    }
+    redisServer = RedisServer.newRedisServer().port(port).build();
+    redisServer.start();
+  }
+
+  @AfterAll
+  static void stopRedis() throws Exception {
+    if (redisServer != null) {
+      redisServer.stop();
+    }
+  }
+
+  @BeforeEach
+  void setUp() {
+    connectionFactory = new LettuceConnectionFactory("localhost", port);
+    connectionFactory.afterPropertiesSet();
+    redisTemplate = new StringRedisTemplate(connectionFactory);
+    redisTemplate.afterPropertiesSet();
+    redisTemplate.getConnectionFactory().getConnection().serverCommands().flushAll();
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (container != null) {
+      container.stop();
+    }
+    connectionFactory.destroy();
+  }
+
+  /** Mirrors AiAnalysisStreamConfig.ensureConsumerGroup. */
+  private void ensureConsumerGroup() {
+    redisTemplate.execute(
+        (RedisCallback<String>)
+            connection ->
+                connection
+                    .streamCommands()
+                    .xGroupCreate(
+                        RedisStreamAiAnalysisQueue.STREAM_KEY.getBytes(StandardCharsets.UTF_8),
+                        AiAnalysisStreamConfig.GROUP,
+                        ReadOffset.from("0"),
+                        true));
+  }
+
+  private void startConsumer(AiAnalysisWorker worker) {
+    startConsumer(worker, Executors.newFixedThreadPool(2));
+  }
+
+  private void startConsumer(AiAnalysisWorker worker, Executor executor) {
+    AiAnalysisStreamConsumer consumer =
+        new AiAnalysisStreamConsumer(worker, redisTemplate, AiAnalysisStreamConfig.GROUP, executor);
+
+    StreamMessageListenerContainerOptions<String, MapRecord<String, String, String>> options =
+        StreamMessageListenerContainerOptions.builder()
+            .pollTimeout(Duration.ofMillis(100))
+            .batchSize(1)
+            .build();
+
+    container = StreamMessageListenerContainer.create(connectionFactory, options);
+    container.receive(
+        Consumer.from(AiAnalysisStreamConfig.GROUP, "test-worker"),
+        StreamOffset.create(RedisStreamAiAnalysisQueue.STREAM_KEY, ReadOffset.lastConsumed()),
+        consumer);
+    container.start();
+  }
+
+  @Test
+  void enqueue_addsListingIdToStream() {
+    RedisStreamAiAnalysisQueue queue = new RedisStreamAiAnalysisQueue(redisTemplate);
+
+    queue.enqueue(123L);
+
+    Long size = redisTemplate.opsForStream().size(RedisStreamAiAnalysisQueue.STREAM_KEY);
+    assertThat(size).isEqualTo(1L);
+  }
+
+  @Test
+  void enqueuedListing_isDeliveredToWorker_andAcknowledged() {
+    ensureConsumerGroup();
+    AiAnalysisWorker worker = mock(AiAnalysisWorker.class);
+    startConsumer(worker);
+
+    new RedisStreamAiAnalysisQueue(redisTemplate).enqueue(456L);
+
+    // The worker actually gets the listing — this is the link that was never proven.
+    await()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(() -> verify(worker).analyze(456L));
+
+    // ...and the message is ACKed, so it is not redelivered on every restart.
+    await()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              PendingMessagesSummary pending =
+                  redisTemplate
+                      .opsForStream()
+                      .pending(
+                          RedisStreamAiAnalysisQueue.STREAM_KEY, AiAnalysisStreamConfig.GROUP);
+              assertThat(pending.getTotalPendingMessages()).isZero();
+            });
+  }
+
+  /**
+   * The container calls onMessage synchronously on its single poll thread, so without
+   * the consumer offloading to a pool a slow analysis blocks every listing behind it.
+   * Two slow listings must overlap, not run back-to-back.
+   */
+  @Test
+  void slowAnalyses_runConcurrently_ratherThanBlockingEachOtherOnThePollThread()
+      throws Exception {
+    ensureConsumerGroup();
+
+    CountDownLatch bothStarted = new CountDownLatch(2);
+    CountDownLatch release = new CountDownLatch(1);
+    AiAnalysisWorker worker = mock(AiAnalysisWorker.class);
+    org.mockito.Mockito.doAnswer(
+            inv -> {
+              bothStarted.countDown();
+              // Block until the test releases us. If analyses were serialised on the poll
+              // thread, the second listing could never start and this latch never reaches 0.
+              release.await(10, TimeUnit.SECONDS);
+              return null;
+            })
+        .when(worker)
+        .analyze(org.mockito.ArgumentMatchers.anyLong());
+
+    startConsumer(worker, Executors.newFixedThreadPool(2));
+
+    RedisStreamAiAnalysisQueue queue = new RedisStreamAiAnalysisQueue(redisTemplate);
+    queue.enqueue(1L);
+    queue.enqueue(2L);
+
+    assertThat(bothStarted.await(10, TimeUnit.SECONDS))
+        .as("both listings should be in-flight at the same time")
+        .isTrue();
+
+    release.countDown();
+  }
+
+  @Test
+  void workerThrowing_stillAcknowledges_soOneBadListingCannotPoisonTheQueue() {
+    ensureConsumerGroup();
+    AiAnalysisWorker worker = mock(AiAnalysisWorker.class);
+    org.mockito.Mockito.doThrow(new RuntimeException("AI service down"))
+        .when(worker)
+        .analyze(789L);
+    startConsumer(worker);
+
+    new RedisStreamAiAnalysisQueue(redisTemplate).enqueue(789L);
+
+    await().atMost(10, TimeUnit.SECONDS).untilAsserted(() -> verify(worker).analyze(789L));
+
+    await()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              PendingMessagesSummary pending =
+                  redisTemplate
+                      .opsForStream()
+                      .pending(
+                          RedisStreamAiAnalysisQueue.STREAM_KEY, AiAnalysisStreamConfig.GROUP);
+              assertThat(pending.getTotalPendingMessages()).isZero();
+            });
+  }
+}


### PR DESCRIPTION
…e works

The container calls onMessage synchronously on the subscription's single poll thread, so each ~30s analysis blocked every listing behind it: ten listings submitted at once left the last one waiting five minutes. A comment in the config claimed the container had "its own bounded pool" — it never did; no executor was ever passed. The comment described code that did not exist.

Offload from the consumer instead: a bounded pool (concurrency 4 by default, AI_QUEUE_CONCURRENCY) with CallerRunsPolicy, so when it saturates the poll thread runs the job itself and stops reading — back-pressure rather than an unbounded in-memory backlog. Kept small deliberately: the AI service is the bottleneck, and flooding it with concurrent multimodal requests buys no throughput.

Also adds the end-to-end test the queue never had, against a real embedded Redis: enqueue -> consumer group delivers to the worker -> message is ACKed; a throwing worker still ACKs (one bad listing cannot poison the group); and two slow analyses overlap instead of serialising. That last test fails against the previous inline behaviour, which is how the serialisation above was confirmed rather than assumed.