### PR TITLE
feat: relay AI degraded-mode signal (ai_available/error_code) to the …

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/dto/response/AiListingVerificationResponse.java
+++ b/smart-rent/src/main/java/com/smartrent/dto/response/AiListingVerificationResponse.java
@@ -81,6 +81,18 @@ public class AiListingVerificationResponse {
     @Schema(description = "Time taken to process the verification", example = "6.2")
     private Double processingTimeSeconds;
 
+    @JsonProperty("ai_available")
+    @Schema(description = "False when the LLM failed and scores come from basic rules, not a real AI analysis", example = "true")
+    private Boolean aiAvailable;
+
+    @JsonProperty("error_code")
+    @Schema(description = "Machine-readable reason the AI did not run (e.g. LLM_QUOTA_EXCEEDED); null on success", example = "LLM_QUOTA_EXCEEDED")
+    private String errorCode;
+
+    @JsonProperty("error_detail")
+    @Schema(description = "Underlying provider error, for diagnostics; null on success")
+    private String errorDetail;
+
     @Getter
     @Setter
     @Builder


### PR DESCRIPTION
…admin UI

When the LLM call fails, the AI service returns 200 with a response built from basic field-presence rules that is otherwise indistinguishable from a real analysis. It now sets ai_available=false + error_code/error_detail; pass those through so the review dialog can show "AI unavailable, these are not AI scores" instead of presenting placeholder numbers as a verdict.