### PR TITLE
fix: remove the now-dead degraded-signal fields, log AI error_code on…

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/dto/response/AiListingVerificationResponse.java
+++ b/smart-rent/src/main/java/com/smartrent/dto/response/AiListingVerificationResponse.java
@@ -81,18 +81,6 @@ public class AiListingVerificationResponse {
     @Schema(description = "Time taken to process the verification", example = "6.2")
     private Double processingTimeSeconds;
 
-    @JsonProperty("ai_available")
-    @Schema(description = "False when the LLM failed and scores come from basic rules, not a real AI analysis", example = "true")
-    private Boolean aiAvailable;
-
-    @JsonProperty("error_code")
-    @Schema(description = "Machine-readable reason the AI did not run (e.g. LLM_QUOTA_EXCEEDED); null on success", example = "LLM_QUOTA_EXCEEDED")
-    private String errorCode;
-
-    @JsonProperty("error_detail")
-    @Schema(description = "Underlying provider error, for diagnostics; null on success")
-    private String errorDetail;
-
     @Getter
     @Setter
     @Builder

--- a/smart-rent/src/main/java/com/smartrent/service/ai/impl/AiListingVerificationServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/ai/impl/AiListingVerificationServiceImpl.java
@@ -200,6 +200,19 @@ public class AiListingVerificationServiceImpl implements AiListingVerificationSe
                 throw new AppException(DomainCode.AI_SERVICE_INVALID_RESPONSE);
             }
             
+        } catch (feign.FeignException e) {
+            // The AI service now reports a failed analysis as a real HTTP error
+            // (503, body {"error": "<error_code>", "message": ..., ...}) instead of
+            // a fake 200 with fabricated scores. Log the body here — it carries the
+            // classified error_code (LLM_QUOTA_EXCEEDED, LLM_AUTH, ...) — so a
+            // failure is diagnosable from server logs even though the admin only
+            // sees a generic "AI verification failed" in the UI.
+            long processingTime = System.currentTimeMillis() - startTime;
+            log.error("AI service returned an error after {}ms (status={}): {}",
+                    processingTime, e.status(), e.contentUTF8());
+            throw new AppException(e.status() == 503
+                    ? DomainCode.AI_SERVICE_UNAVAILABLE
+                    : DomainCode.AI_SERVICE_ERROR);
         } catch (ResourceAccessException e) {
             long processingTime = System.currentTimeMillis() - startTime;
             log.error("AI service timeout or connection error after {}ms: {}", processingTime, e.getMessage());


### PR DESCRIPTION
… failure

The AI service no longer returns 200 with a fabricated fallback response when the LLM fails (see the companion smartrent-ai PR) — it returns a real HTTP error. That makes ai_available/error_code/error_detail on AiListingVerificationResponse permanently vestigial: nothing ever sets them false/non-null anymore, since a failure never reaches response construction at all. Remove them; grep confirmed no other Java or frontend code reads them.

Add a FeignException catch so the classified error_code the AI service now reports (LLM_QUOTA_EXCEEDED, LLM_AUTH, ...) is still visible somewhere — logged server-side from the error response body, since the admin-facing error stays a generic "AI verification failed" either way. Without this the classified code would only ever reach a log line on the Python side.