### PR TITLE
fix: send full listing fields to AI verify (price unit, listing type,…

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/dto/request/AiListingVerificationRequest.java
+++ b/smart-rent/src/main/java/com/smartrent/dto/request/AiListingVerificationRequest.java
@@ -46,6 +46,14 @@ public class AiListingVerificationRequest {
     @Schema(description = "Listing price", example = "20000000", required = true)
     private BigDecimal price;
 
+    @JsonProperty("price_unit")
+    @Schema(description = "Unit the price is denominated in", example = "MONTH")
+    private String priceUnit;
+
+    @JsonProperty("listing_type")
+    @Schema(description = "Listing type (RENT, SALE, SHARE)", example = "RENT")
+    private String listingType;
+
     @JsonProperty("address")
     @NotBlank(message = "Address is required")
     @Size(min = 5, max = 500, message = "Address must be between 5 and 500 characters")
@@ -78,6 +86,35 @@ public class AiListingVerificationRequest {
     @JsonProperty("metadata")
     @Schema(description = "Additional property metadata")
     private PropertyMetadata metadata;
+
+    @JsonProperty("direction")
+    @Schema(description = "House/room direction", example = "SOUTH")
+    private String direction;
+
+    @JsonProperty("furnishing")
+    @Schema(description = "Furnishing status", example = "FULLY_FURNISHED")
+    private String furnishing;
+
+    @JsonProperty("room_capacity")
+    @Min(value = 0, message = "Room capacity must be non-negative")
+    @Schema(description = "Max occupants the room supports", example = "4")
+    private Integer roomCapacity;
+
+    @JsonProperty("water_price")
+    @Schema(description = "Water cost", example = "20000/m3")
+    private String waterPrice;
+
+    @JsonProperty("electricity_price")
+    @Schema(description = "Electricity cost", example = "3500/kWh")
+    private String electricityPrice;
+
+    @JsonProperty("internet_price")
+    @Schema(description = "Internet cost", example = "100000/thang")
+    private String internetPrice;
+
+    @JsonProperty("service_fee")
+    @Schema(description = "Service/management fee", example = "500000/thang")
+    private String serviceFee;
 
     @Getter
     @Setter

--- a/smart-rent/src/main/java/com/smartrent/dto/request/ListingVerificationRequest.java
+++ b/smart-rent/src/main/java/com/smartrent/dto/request/ListingVerificationRequest.java
@@ -21,6 +21,12 @@ public class ListingVerificationRequest {
     @JsonProperty("price")
     private BigDecimal price;
 
+    @JsonProperty("price_unit")
+    private String priceUnit;
+
+    @JsonProperty("listing_type")
+    private String listingType;
+
     @JsonProperty("area")
     private Float area;
 
@@ -41,6 +47,27 @@ public class ListingVerificationRequest {
 
     @JsonProperty("metadata")
     private MetadataDto metadata;
+
+    @JsonProperty("direction")
+    private String direction;
+
+    @JsonProperty("furnishing")
+    private String furnishing;
+
+    @JsonProperty("room_capacity")
+    private Integer roomCapacity;
+
+    @JsonProperty("water_price")
+    private String waterPrice;
+
+    @JsonProperty("electricity_price")
+    private String electricityPrice;
+
+    @JsonProperty("internet_price")
+    private String internetPrice;
+
+    @JsonProperty("service_fee")
+    private String serviceFee;
 
     @Data
     @Builder

--- a/smart-rent/src/main/java/com/smartrent/mapper/impl/AiListingMapperImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/mapper/impl/AiListingMapperImpl.java
@@ -31,6 +31,8 @@ public class AiListingMapperImpl implements AiListingMapper {
                 .title(listing.getTitle())
                 .description(listing.getDescription())
                 .price(listing.getPrice())
+                .priceUnit(listing.getPriceUnit() != null ? listing.getPriceUnit().name() : null)
+                .listingType(listing.getListingType() != null ? listing.getListingType().name() : null)
                 .address(getAddressString(listing))
                 .propertyType(convertProductType(listing.getProductType()))
                 .area(listing.getArea() != null ? listing.getArea().doubleValue() : null)
@@ -38,6 +40,13 @@ public class AiListingMapperImpl implements AiListingMapper {
                 .images(buildImages(listing.getMedia()))
                 .videos(buildVideos(listing.getMedia()))
                 .metadata(buildMetadata(listing))
+                .direction(listing.getDirection() != null ? listing.getDirection().name() : null)
+                .furnishing(listing.getFurnishing() != null ? listing.getFurnishing().name() : null)
+                .roomCapacity(listing.getRoomCapacity())
+                .waterPrice(listing.getWaterPrice())
+                .electricityPrice(listing.getElectricityPrice())
+                .internetPrice(listing.getInternetPrice())
+                .serviceFee(listing.getServiceFee())
                 .build();
     }
 

--- a/smart-rent/src/main/java/com/smartrent/service/ai/impl/AiListingVerificationServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/ai/impl/AiListingVerificationServiceImpl.java
@@ -57,11 +57,20 @@ public class AiListingVerificationServiceImpl implements AiListingVerificationSe
                 .title(normalizedRequest.getTitle())
                 .description(normalizedRequest.getDescription())
                 .price(normalizedRequest.getPrice())
+                .priceUnit(normalizedRequest.getPriceUnit())
+                .listingType(normalizedRequest.getListingType())
                 .area(normalizedRequest.getArea() != null ? normalizedRequest.getArea().floatValue() : null)
                 .address(normalizedRequest.getAddress())
                 .propertyType(normalizedRequest.getPropertyType() != null ? normalizedRequest.getPropertyType().name() : null)
                 .amenities(normalizedRequest.getAmenities())
                 .images(normalizedRequest.getImages())
+                .direction(normalizedRequest.getDirection())
+                .furnishing(normalizedRequest.getFurnishing())
+                .roomCapacity(normalizedRequest.getRoomCapacity())
+                .waterPrice(normalizedRequest.getWaterPrice())
+                .electricityPrice(normalizedRequest.getElectricityPrice())
+                .internetPrice(normalizedRequest.getInternetPrice())
+                .serviceFee(normalizedRequest.getServiceFee())
                 .build();
                 
             // Set metadata if present


### PR DESCRIPTION
… specs, utilities)

The queue-driven AI verification payload was missing listingType and priceUnit, so the AI prompt hardcoded "VND per month" for every listing — a for-sale listing's lump-sum price was evaluated as if it were monthly rent. Also add direction, furnishing, roomCapacity, and the four utility cost fields so the AI sees the same listing data the seller filled in on the create-post form.