### PR TITLE
feat(ai): implement persisted on-demand listing re-verify endpoint

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/controller/AiListingVerificationController.java
+++ b/smart-rent/src/main/java/com/smartrent/controller/AiListingVerificationController.java
@@ -5,6 +5,7 @@ import com.smartrent.dto.response.AiListingVerificationResponse;
 import com.smartrent.dto.response.ApiResponse;
 import com.smartrent.dto.response.DuplicateCheckResponse;
 import com.smartrent.dto.response.StoredAiModerationResponse;
+import com.smartrent.service.ai.AiListingReVerifyService;
 import com.smartrent.service.ai.AiListingVerificationService;
 import com.smartrent.service.ai.AiVerificationSettingService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -31,6 +32,7 @@ import org.springframework.web.bind.annotation.*;
 public class AiListingVerificationController {
 
     private final AiListingVerificationService aiListingVerificationService;
+    private final AiListingReVerifyService aiListingReVerifyService;
     private final AiVerificationSettingService aiVerificationSettingService;
 
 
@@ -254,12 +256,18 @@ public class AiListingVerificationController {
     @PostMapping("/{listingId}/verify")
     // @PreAuthorize("authentication.authorities.stream().anyMatch(a -> a.authority.startsWith('ROLE_ADMIN') || a.authority.startsWith('ROLE_SUPER_ADMIN'))") // Temporarily disabled for testing
     @Operation(
-        summary = "Verify existing listing by ID",
-        description = "Verifies an existing listing in the system using its ID. Only admins can perform this operation.",
+        summary = "Re-verify an existing listing by ID and store the result",
+        description = "Runs the AI moderation pipeline (verify + duplicate check) for an existing "
+                + "listing by ID and PERSISTS the result as the latest stored moderation, then "
+                + "returns it. Unlike POST /verify (stateless), this updates "
+                + "listing_ai_moderation so the next GET /{listingId}/moderation-result — what the "
+                + "admin review dialog loads when the post is opened — reflects this run. "
+                + "Store-only: it never approves/rejects the listing and never clears the admin's "
+                + "manual decision (manual_override is preserved).",
         parameters = {
             @Parameter(
                 name = "listingId",
-                description = "The ID of the listing to verify",
+                description = "The ID of the listing to re-verify",
                 required = true,
                 example = "123"
             )
@@ -268,7 +276,7 @@ public class AiListingVerificationController {
     @ApiResponses(value = {
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
             responseCode = "200",
-            description = "Listing verified successfully",
+            description = "Listing re-verified and stored successfully",
             content = @Content(
                 mediaType = "application/json",
                 schema = @Schema(implementation = ApiResponse.class)
@@ -284,7 +292,7 @@ public class AiListingVerificationController {
                     name = "Listing not found",
                     value = """
                         {
-                          "code": "4003",
+                          "code": "4004",
                           "message": "Listing not found",
                           "data": null
                         }
@@ -301,14 +309,17 @@ public class AiListingVerificationController {
             )
         )
     })
-    public ResponseEntity<ApiResponse<AiListingVerificationResponse>> verifyListingById(
+    public ResponseEntity<ApiResponse<StoredAiModerationResponse>> verifyListingById(
             @PathVariable Long listingId) {
 
-        log.info("Received AI verification request for listing ID: {}", listingId);
+        log.info("Received AI re-verification request for listing ID: {}", listingId);
 
-        // Note: This would require injecting ListingService to fetch the listing
-        // For now, we'll leave this as a placeholder for future implementation
-        throw new UnsupportedOperationException("Verify by listing ID not yet implemented");
+        StoredAiModerationResponse response = aiListingReVerifyService.reVerifyAndStore(listingId);
+
+        return ResponseEntity.ok(ApiResponse.<StoredAiModerationResponse>builder()
+                .message("Listing re-verified and stored successfully")
+                .data(response)
+                .build());
     }
 
     @GetMapping("/service-status")

--- a/smart-rent/src/main/java/com/smartrent/service/ai/AiListingReVerifyService.java
+++ b/smart-rent/src/main/java/com/smartrent/service/ai/AiListingReVerifyService.java
@@ -1,0 +1,30 @@
+package com.smartrent.service.ai;
+
+import com.smartrent.dto.response.StoredAiModerationResponse;
+
+/**
+ * Admin-triggered, on-demand AI re-verification for an existing listing.
+ *
+ * <p>Unlike {@link AiListingVerificationService#verifyListing} (stateless, returns
+ * a one-off analysis) this <b>persists</b> the fresh result onto
+ * {@code listing_ai_moderation}, so the very next
+ * {@link AiListingVerificationService#getStoredModerationResult} — i.e. what the
+ * admin review dialog loads when the post is opened — reflects this latest run.
+ *
+ * <p>It reuses the exact same store-only pipeline the background auto-moderation
+ * job uses ({@link AiModerationProcessorService#processSingleListing}), so the
+ * stored shape (verification + duplicateCheck) is identical. It never approves or
+ * rejects the listing and never touches the human {@code manual_override} flag —
+ * a manually-verified post can be re-analysed without losing the admin's decision.
+ */
+public interface AiListingReVerifyService {
+
+    /**
+     * Re-run AI moderation (verify + duplicate check) for a listing by ID, persist
+     * the result as the latest stored moderation, and return it.
+     *
+     * @param listingId The listing to re-verify.
+     * @return The freshly stored moderation result (verification + duplicate check).
+     */
+    StoredAiModerationResponse reVerifyAndStore(Long listingId);
+}

--- a/smart-rent/src/main/java/com/smartrent/service/ai/impl/AiListingReVerifyServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/ai/impl/AiListingReVerifyServiceImpl.java
@@ -1,0 +1,69 @@
+package com.smartrent.service.ai.impl;
+
+import com.smartrent.dto.response.StoredAiModerationResponse;
+import com.smartrent.infra.exception.AppException;
+import com.smartrent.infra.exception.model.DomainCode;
+import com.smartrent.infra.repository.ListingAiModerationRepository;
+import com.smartrent.infra.repository.ListingRepository;
+import com.smartrent.infra.repository.entity.Listing;
+import com.smartrent.infra.repository.entity.ListingAiModeration;
+import com.smartrent.service.ai.AiListingReVerifyService;
+import com.smartrent.service.ai.AiListingVerificationService;
+import com.smartrent.service.ai.AiModerationProcessorService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+/**
+ * Default {@link AiListingReVerifyService}.
+ *
+ * <p>Lives in its own bean (rather than on {@link AiListingVerificationService})
+ * to avoid a circular dependency: {@link AiModerationProcessorService} already
+ * depends on {@link AiListingVerificationService}, so the orchestration that
+ * wires the two together must sit outside both.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AiListingReVerifyServiceImpl implements AiListingReVerifyService {
+
+    private final ListingRepository listingRepository;
+    private final ListingAiModerationRepository listingAiModerationRepository;
+    private final AiModerationProcessorService aiModerationProcessorService;
+    private final AiListingVerificationService aiListingVerificationService;
+
+    @Override
+    public StoredAiModerationResponse reVerifyAndStore(Long listingId) {
+        log.info("Admin-triggered AI re-verification for listing ID: {}", listingId);
+
+        // Fetch with address + amenities so the entity stays usable once detached:
+        // processSingleListing runs in its own (REQUIRES_NEW) transaction and reads
+        // listing.getAddress() for the duplicate check, so that association must be
+        // initialized here to avoid a LazyInitializationException.
+        Listing listing = listingRepository.findByIdWithAmenities(listingId)
+                .orElseThrow(() -> new AppException(DomainCode.LISTING_NOT_FOUND));
+
+        // Reuse the existing moderation row so history (retry count) and — crucially —
+        // the human manual_override flag are preserved. A manually-verified post can be
+        // re-analysed on demand without the AI ever clearing the admin's decision.
+        ListingAiModeration moderation = listingAiModerationRepository.findById(listingId)
+                .orElseGet(() -> ListingAiModeration.builder()
+                        .listingId(listingId)
+                        .retryCount(0)
+                        .manualOverride(false)
+                        .build());
+
+        // Store-only: runs verify + duplicate check and writes the result onto the
+        // moderation row (via the Spring proxy, so its REQUIRES_NEW transaction and
+        // commit apply). Never approves/rejects and never touches manual_override.
+        aiModerationProcessorService.processSingleListing(listing, moderation);
+
+        StoredAiModerationResponse stored = aiListingVerificationService.getStoredModerationResult(listingId);
+        if (stored == null) {
+            // processSingleListing swallows AI failures (reverts the row to PENDING) — surface
+            // that to the admin instead of returning an empty 200.
+            throw new AppException(DomainCode.AI_SERVICE_ERROR);
+        }
+        return stored;
+    }
+}


### PR DESCRIPTION
POST /v1/ai/listings/{listingId}/verify was an unimplemented placeholder (threw UnsupportedOperationException). Implement it so the admin review dialog can re-run AI moderation on demand and have the result persisted.

- Add AiListingReVerifyService: loads the listing (with address/amenities so the entity is safe once detached), reuses the existing store-only pipeline AiModerationProcessorService.processSingleListing (verify + duplicate check), and returns the freshly stored StoredAiModerationResponse.
- The result is written to listing_ai_moderation, so the next GET /{listingId}/moderation-result reflects this latest run.
- Store-only: never approves/rejects and preserves the human manual_override flag, so a manually-verified listing can be re-analysed without clearing the admin's decision.
- Lives in its own bean to avoid a circular dependency (the processor already depends on AiListingVerificationService).
- Endpoint now returns StoredAiModerationResponse (verification + duplicateCheck
  + analyzedAt), matching what the moderation-result endpoint returns.