### PR TITLE
Admin analytics: system-wide broker-pending count + guard report avg-resolution

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/controller/AdminAnalyticsController.java
+++ b/smart-rent/src/main/java/com/smartrent/controller/AdminAnalyticsController.java
@@ -193,7 +193,8 @@ public class AdminAnalyticsController {
                                         "brokerVerificationBreakdown": [
                                           {"category": "PENDING", "count": 3, "percentage": 60.0},
                                           {"category": "APPROVED", "count": 2, "percentage": 40.0}
-                                        ]
+                                        ],
+                                        "brokersPendingApproval": 12
                                       }
                                     }
                                     """)

--- a/smart-rent/src/main/java/com/smartrent/dto/response/AdminUserAnalyticsResponse.java
+++ b/smart-rent/src/main/java/com/smartrent/dto/response/AdminUserAnalyticsResponse.java
@@ -24,4 +24,11 @@ public class AdminUserAnalyticsResponse {
 
     List<CategoryBreakdownItem> roleBreakdown;
     List<CategoryBreakdownItem> brokerVerificationBreakdown;
+
+    /**
+     * Current, system-wide number of brokers awaiting approval (verification status PENDING),
+     * independent of the selected date range. Backs the "brokers pending" KPI so it reflects the
+     * live backlog rather than only brokers registered within the window.
+     */
+    Long brokersPendingApproval;
 }

--- a/smart-rent/src/main/java/com/smartrent/infra/repository/ListingReportRepository.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/ListingReportRepository.java
@@ -96,8 +96,12 @@ public interface ListingReportRepository extends JpaRepository<ListingReport, Lo
             "GROUP BY r.status ORDER BY cnt DESC", nativeQuery = true)
     List<Object[]> countReportsByStatus(@Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
 
+    // Exclude rows where resolved_at precedes created_at: such records are data
+    // errors (a report can't be resolved before it exists) and would drag the
+    // average resolution time negative. Only genuine, non-negative durations count.
     @Query(value = "SELECT AVG(TIMESTAMPDIFF(MINUTE, r.created_at, r.resolved_at)) FROM listing_reports r " +
-            "WHERE r.created_at BETWEEN :start AND :end AND r.resolved_at IS NOT NULL", nativeQuery = true)
+            "WHERE r.created_at BETWEEN :start AND :end AND r.resolved_at IS NOT NULL " +
+            "AND r.resolved_at >= r.created_at", nativeQuery = true)
     Double avgResolutionMinutes(@Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
 
     long countByCreatedAtBefore(LocalDateTime dateTime);

--- a/smart-rent/src/main/java/com/smartrent/infra/repository/UserRepository.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/UserRepository.java
@@ -48,6 +48,13 @@ public interface UserRepository extends JpaRepository<User, String>, JpaSpecific
                         "GROUP BY u.broker_verification_status", nativeQuery = true)
         List<Object[]> countNewBrokersByVerificationStatus(@Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
 
+        /**
+         * System-wide count of brokers in a given verification state, independent of any date range.
+         * Used for the "brokers pending approval" KPI, which reflects the current backlog rather
+         * than only brokers who registered within the selected analytics window.
+         */
+        long countByBrokerVerificationStatus(BrokerVerificationStatus status);
+
         Page<User> findAllByBrokerVerificationStatusOrderByBrokerRegisteredAtAsc(
                         BrokerVerificationStatus status,
                         Pageable pageable);

--- a/smart-rent/src/main/java/com/smartrent/service/admin/analytics/impl/AdminAnalyticsServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/admin/analytics/impl/AdminAnalyticsServiceImpl.java
@@ -1,6 +1,7 @@
 package com.smartrent.service.admin.analytics.impl;
 
 import com.smartrent.dto.response.*;
+import com.smartrent.enums.BrokerVerificationStatus;
 import com.smartrent.infra.repository.ListingReportRepository;
 import com.smartrent.infra.repository.ListingRepository;
 import com.smartrent.infra.repository.TransactionRepository;
@@ -174,6 +175,9 @@ public class AdminAnalyticsServiceImpl implements AdminAnalyticsService {
         List<Object[]> roleRows = userRepository.countNewUsersByRole(start, end);
         List<Object[]> brokerVerificationRows = userRepository.countNewBrokersByVerificationStatus(start, end);
 
+        // Live backlog, not range-scoped: how many brokers are awaiting approval right now.
+        long brokersPendingApproval = userRepository.countByBrokerVerificationStatus(BrokerVerificationStatus.PENDING);
+
         return AdminUserAnalyticsResponse.builder()
                 .dataPoints(series.dataPoints())
                 .total(series.total())
@@ -182,6 +186,7 @@ public class AdminAnalyticsServiceImpl implements AdminAnalyticsService {
                 .totalUsersAsOfRangeEnd(baseline + series.total())
                 .roleBreakdown(buildBreakdown(roleRows))
                 .brokerVerificationBreakdown(buildBreakdown(brokerVerificationRows))
+                .brokersPendingApproval(brokersPendingApproval)
                 .build();
     }
 


### PR DESCRIPTION
## What & why

Two fixes surfaced while verifying the admin **Insights** numbers.

### 1. `brokersPendingApproval` — live, system-wide broker backlog
The "Môi Giới Chờ Duyệt" KPI on **User Analytics** was reading the `PENDING` slice of `brokerVerificationBreakdown`, which is **scoped to the selected date range** (only brokers who *registered* within the window). A broker who registered earlier and is still pending was invisible.

- New repo count `countByBrokerVerificationStatus(PENDING)` (whole-DB, not range-scoped)
- New response field `brokersPendingApproval` on `AdminUserAnalyticsResponse`
- Populated in `AdminAnalyticsServiceImpl`; Swagger example updated
- FE reads this field (separate `smartrent-fe` PR)

### 2. Guard report avg-resolution-time against bad data
"Thời Gian Xử Lý TB" showed **-45.1h**. The query column order is correct; the cause is seed data where `resolved_at < created_at` (a report resolved before it existed). Added `AND r.resolved_at >= r.created_at` so impossible rows can't drag the average negative.

## Notes
- The FE half of change #1 ships in the `smartrent-fe` PR; deploy both.
- After deploy, if every resolved row in a range is bad data, the metric returns `NULL` → FE shows "N/A" (better than a negative). Underlying prod data repaired separately.

## Verify
- `gradlew compileJava` ✅