### PR TITLE
perf(admin-analytics): covering index for /analytics/listings breakdowns (44s -> ~1s)

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/infra/repository/entity/Listing.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/entity/Listing.java
@@ -109,7 +109,16 @@ import java.util.List;
                 // (~9.3s measured) the APPROVED tab hit. Mirrors idx_listings_admin_default_sort
                 // (V100) with moderation_status inserted. Built by V109.
                 @Index(name = "idx_listings_admin_moderation_sort",
-                        columnList = "is_shadow, moderation_status, vip_type_sort_order, updated_at")
+                        columnList = "is_shadow, moderation_status, vip_type_sort_order, updated_at"),
+                // Admin analytics breakdowns (GET /v1/admin/analytics/listings). Same
+                // (is_shadow, is_draft) equality + created_at range prefix as the daily
+                // series, then the three breakdown columns (listing_type, product_type,
+                // verified) as a covering-only suffix so each aggregate is an index-only
+                // range scan over the requested date slice instead of a ~99k-row scan via
+                // idx_is_shadow (measured 6.38s -> 0.07s). Supersedes the manually-created
+                // idx_listings_shadow_draft_created (a strict prefix of this). Built by V115.
+                @Index(name = "idx_listings_analytics_breakdown",
+                        columnList = "is_shadow, is_draft, created_at, listing_type, product_type, verified")
         })
 @Getter
 @Setter

--- a/smart-rent/src/main/resources/db/migration/V115__Add_listings_analytics_covering_index.sql
+++ b/smart-rent/src/main/resources/db/migration/V115__Add_listings_analytics_covering_index.sql
@@ -1,0 +1,51 @@
+-- Migration V115: covering index for the admin /v1/admin/analytics/listings endpoint.
+-- ============================================================================
+-- That endpoint runs 5 aggregate queries over `listings`, all filtered by the
+-- same predicate: (is_shadow = false, is_draft = false, created_at in range).
+-- The daily time-series and the cumulative baseline COUNT are covered by
+-- idx_listings_shadow_draft_created (is_shadow, is_draft, created_at) and run in
+-- <200ms. But the three breakdown queries also read a column that is NOT in that
+-- index — listing_type / product_type / verified — so the index stops being
+-- covering for them. With the low-cardinality boolean statistics mis-estimating
+-- selectivity, the optimizer then abandons it and falls back to idx_is_shadow /
+-- idx_listings_public_search, scanning ~99k rows (the entire non-shadow table)
+-- with random row lookups. Measured on prod: 5.1s / 6.4s / 34.3s for the three
+-- breakdowns, so the endpoint took ~44s end-to-end and timed out at the proxy
+-- (the admin console showed "fail to load" and retried in a loop).
+--
+-- This composite keeps the identical (is_shadow, is_draft) equality + created_at
+-- range prefix, then appends the three breakdown columns purely as a covering
+-- suffix. Every one of the five queries becomes an index-only range scan over
+-- just the requested date slice (~15.7k rows). Verified on prod: the product_type
+-- breakdown dropped from 6.38s to 0.07s (rows examined 99,029 -> 15,785).
+--
+-- created_at stays the last range-usable column; the trailing three columns are
+-- never used for filtering, only to avoid table access.
+--
+-- idx_listings_shadow_draft_created is now a STRICT PREFIX of this index (it also
+-- serves the daily series and the baseline COUNT), so it is dropped as redundant.
+-- Note: idx_listings_shadow_draft_created was created directly on prod during a
+-- 2026-07-12 index audit but never codified as a migration, which is exactly why
+-- it survived on the old DB yet this whole endpoint regressed after listings were
+-- reshaped to 100k and the DB moved hosts — nothing recreated it, and stale stats
+-- pushed the breakdowns onto the boolean indexes. Codifying here so fresh Flyway
+-- builds and future host moves keep the covering index.
+--
+-- Idempotent guarded style matches V94-V110 (inline PREPARE, no DELIMITER so
+-- Flyway's statement splitter handles it). On prod both DDLs are effectively
+-- no-ops: the covering index already exists (created during diagnosis) and the
+-- prefix index still needs dropping.
+-- ============================================================================
+
+-- 1) Create the covering index (no-op if it already exists).
+SET @cnt = (SELECT COUNT(*) FROM information_schema.statistics WHERE table_schema = DATABASE() AND table_name = 'listings' AND index_name = 'idx_listings_analytics_breakdown');
+SET @ddl = IF(@cnt = 0, 'CREATE INDEX idx_listings_analytics_breakdown ON listings (is_shadow, is_draft, created_at, listing_type, product_type, verified)', 'SELECT 1');
+PREPARE s FROM @ddl; EXECUTE s; DEALLOCATE PREPARE s;
+
+-- 2) Drop the now-redundant prefix index (no-op if already gone).
+SET @cnt = (SELECT COUNT(*) FROM information_schema.statistics WHERE table_schema = DATABASE() AND table_name = 'listings' AND index_name = 'idx_listings_shadow_draft_created');
+SET @ddl = IF(@cnt > 0, 'ALTER TABLE listings DROP INDEX idx_listings_shadow_draft_created', 'SELECT 1');
+PREPARE s FROM @ddl; EXECUTE s; DEALLOCATE PREPARE s;
+
+-- 3) Refresh optimizer statistics so the new index is costed correctly.
+ANALYZE TABLE listings;


### PR DESCRIPTION
## Problem

`GET /v1/admin/analytics/listings?from=...&to=...` took **~44s** and timed out at the proxy — the admin console showed **"fail to load"** and retried in a loop. Confirmed with an authenticated call: `HTTP 200`, `ttfb=43.76s`, body only 2.8KB (all time is server-side query work, not payload).

## Root cause

The endpoint runs 5 aggregate queries over `listings`, all with the same filter `(is_shadow=false, is_draft=false, created_at BETWEEN ...)`. `EXPLAIN ANALYZE` on prod:

| Query | Index chosen | Rows examined | Time |
|---|---|---|---|
| daily `GROUP BY DATE(created_at)` | ✅ `idx_listings_shadow_draft_created` (covering) | 15,785 | 0.09s |
| baseline `COUNT(*) created_at < from` | ✅ covering prefix | 82,048 | 0.20s |
| `GROUP BY listing_type` | ❌ `idx_is_shadow` | **99,029** | **5.1s** |
| `GROUP BY product_type` | ❌ `idx_is_shadow` | **99,029** | **6.4s** |
| `GROUP BY verified` | ❌ `idx_listings_public_search` | **97,833** | **34.3s** |

The daily series and baseline count are **covered** by `idx_listings_shadow_draft_created (is_shadow, is_draft, created_at)` and stay fast. The three breakdown queries additionally read a column **not** in that index (`listing_type` / `product_type` / `verified`), so it stops being covering for them. With mis-estimated low-cardinality boolean stats, the optimizer abandons it and falls back to the boolean indexes, scanning ~99k rows (the whole non-shadow table) with random row lookups.

## Fix

Add a covering index with the same equality+range prefix plus the three breakdown columns as a covering-only suffix:

```
idx_listings_analytics_breakdown (is_shadow, is_draft, created_at, listing_type, product_type, verified)
```

Every analytics query becomes an index-only range scan over just the requested date slice (~15.7k rows). `idx_listings_shadow_draft_created` is now a strict prefix of it, so it's dropped as redundant.

**Verified on prod** (index applied live during diagnosis): `product_type` breakdown **6.38s -> 0.07s** (rows examined 99,029 -> 15,785). Endpoint now returns in ~1s.

## Why it regressed (and why codify it)

`idx_listings_shadow_draft_created` was created **directly on prod** during a 2026-07-12 index audit but **never turned into a migration**. After listings were reshaped to 100k and the DB moved hosts, nothing recreated the covering guarantees and stale boolean stats pushed the breakdowns onto the wrong indexes. This PR ships the fix as **V115** + a matching `@Index` on the `Listing` entity (same name so `ddl-auto=update` can't reintroduce a duplicate), so fresh Flyway builds and future host moves keep it.

## Migration notes

`V115` is idempotent (guarded `information_schema` checks, V94–V110 style). On the current prod both DDLs are effectively no-ops — the covering index already exists (created during diagnosis) and only the redundant prefix index still needs dropping — followed by `ANALYZE TABLE listings`.