### PR TITLE
fix(ai): send listing media to AI in gallery display order

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/mapper/impl/AiListingMapperImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/mapper/impl/AiListingMapperImpl.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -115,16 +116,35 @@ public class AiListingMapperImpl implements AiListingMapper {
                 .build();
     }
 
+    /**
+     * Orders media exactly as the listing gallery shows it: primary first, then by
+     * sortOrder. The AI numbers its per-media findings ("Ảnh N" / "Video N") by the
+     * order it receives the media, so this MUST match the display order in
+     * {@link ListingMapperImpl}. Otherwise "Ảnh 1" in the AI result points at a
+     * different image than the admin sees first in the review dialog — the media
+     * collection comes back in JPA/PK order, which is unrelated to display order.
+     */
+    private static final Comparator<Media> DISPLAY_ORDER =
+            Comparator.comparing((Media m) -> !Boolean.TRUE.equals(m.getIsPrimary()))
+                    .thenComparing(Media::getSortOrder,
+                            Comparator.nullsLast(Comparator.naturalOrder()));
+
     private List<String> buildImages(List<Media> mediaList) {
         return mediaList.stream()
+                // ACTIVE-only + display order so the AI sees the same images, in the
+                // same order, the admin/user does (mirrors ListingMapperImpl).
+                .filter(media -> media.getStatus() == Media.MediaStatus.ACTIVE)
                 .filter(media -> media.getMediaType() == Media.MediaType.IMAGE)
+                .sorted(DISPLAY_ORDER)
                 .map(Media::getUrl)
                 .collect(Collectors.toList());
     }
 
     private List<AiListingVerificationRequest.VideoObject> buildVideos(List<Media> mediaList) {
         return mediaList.stream()
+                .filter(media -> media.getStatus() == Media.MediaStatus.ACTIVE)
                 .filter(media -> media.getMediaType() == Media.MediaType.VIDEO)
+                .sorted(DISPLAY_ORDER)
                 .map(media -> AiListingVerificationRequest.VideoObject.builder()
                         .url(media.getUrl())
                         .caption(media.getDescription())


### PR DESCRIPTION
buildImages/buildVideos streamed the JPA media collection as-is (PK/insertion order) with no ACTIVE filter, while the review dialog and public detail show media ACTIVE-only, primary-first, then by sortOrder. The AI numbers its per-media findings "Ảnh N"/"Video N" by the order it receives them, so its "Ảnh 1" pointed at a different image than the admin sees first — findings looked mis-ordered even though the AI was correct about the media it got.

Order the AI input with the same primary-first + sortOrder comparator the display path uses (and filter to ACTIVE), so the AI's numbering lines up with the admin's gallery.