### PR TITLE
feat(reports): persist resolution action taken on a listing report

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/dto/request/ResolveReportRequest.java
+++ b/smart-rent/src/main/java/com/smartrent/dto/request/ResolveReportRequest.java
@@ -25,6 +25,12 @@ public class ResolveReportRequest {
             example = "Please update listing title and real area")
     String adminNotes;
 
+    @Schema(description = "The concrete action taken, recorded for later display. " +
+            "If omitted, the server derives it from status/removeListing/ownerActionRequired.",
+            example = "SUSPENDED",
+            allowableValues = {"SUSPENDED", "REVISION_REQUESTED", "DISMISSED", "RESOLVED"})
+    String resolutionAction;
+
     // ── Owner action fields ──
     @Schema(description = "Whether the listing owner must take action", example = "true")
     Boolean ownerActionRequired;

--- a/smart-rent/src/main/java/com/smartrent/dto/response/ListingReportResponse.java
+++ b/smart-rent/src/main/java/com/smartrent/dto/response/ListingReportResponse.java
@@ -55,6 +55,10 @@ public class ListingReportResponse {
     @Schema(description = "Admin notes/comments on the report", example = "Verified and took action")
     String adminNotes;
 
+    @Schema(description = "Concrete action taken at resolution (null while pending / for legacy rows)",
+            example = "SUSPENDED", allowableValues = {"SUSPENDED", "REVISION_REQUESTED", "DISMISSED", "RESOLVED"})
+    String resolutionAction;
+
     @Schema(description = "Report creation timestamp")
     LocalDateTime createdAt;
 

--- a/smart-rent/src/main/java/com/smartrent/enums/ReportResolutionAction.java
+++ b/smart-rent/src/main/java/com/smartrent/enums/ReportResolutionAction.java
@@ -1,0 +1,16 @@
+package com.smartrent.enums;
+
+/**
+ * The concrete action an admin took when resolving a listing report.
+ * <p>
+ * {@link ReportStatus} only distinguishes PENDING / RESOLVED / REJECTED, and both
+ * "suspend the listing" and "request the owner to revise it" collapse into RESOLVED.
+ * This enum records which action actually happened so the admin console can show it
+ * afterwards without inferring it from the listing's (mutable) moderation status.
+ */
+public enum ReportResolutionAction {
+    SUSPENDED,          // Listing đình chỉ / removed (confirmed violation)
+    REVISION_REQUESTED, // Owner asked to fix and resubmit the listing
+    DISMISSED,          // Report bỏ qua — no action needed
+    RESOLVED            // Handled without a specific listing action (generic / legacy)
+}

--- a/smart-rent/src/main/java/com/smartrent/infra/repository/entity/ListingReport.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/entity/ListingReport.java
@@ -1,6 +1,7 @@
 package com.smartrent.infra.repository.entity;
 
 import com.smartrent.enums.ReportCategory;
+import com.smartrent.enums.ReportResolutionAction;
 import com.smartrent.enums.ReportStatus;
 import jakarta.persistence.*;
 import lombok.*;
@@ -89,6 +90,12 @@ public class ListingReport {
 
     @Column(name = "admin_notes", columnDefinition = "TEXT")
     String adminNotes;
+
+    // Concrete action taken at resolution time (suspend / request revision / dismiss).
+    // Null for still-pending reports and legacy rows resolved before this was tracked.
+    @Enumerated(EnumType.STRING)
+    @Column(name = "resolution_action", length = 32)
+    ReportResolutionAction resolutionAction;
 
     @CreationTimestamp
     @Column(name = "created_at", updatable = false)

--- a/smart-rent/src/main/java/com/smartrent/mapper/impl/ListingReportMapperImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/mapper/impl/ListingReportMapperImpl.java
@@ -39,6 +39,8 @@ public class ListingReportMapperImpl implements ListingReportMapper {
                 .resolvedBy(listingReport.getResolvedBy())
                 .resolvedAt(listingReport.getResolvedAt())
                 .adminNotes(listingReport.getAdminNotes())
+                .resolutionAction(listingReport.getResolutionAction() != null
+                        ? listingReport.getResolutionAction().name() : null)
                 .createdAt(listingReport.getCreatedAt())
                 .updatedAt(listingReport.getUpdatedAt())
                 .build();

--- a/smart-rent/src/main/java/com/smartrent/service/report/impl/ListingReportServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/report/impl/ListingReportServiceImpl.java
@@ -9,6 +9,7 @@ import com.smartrent.enums.ListingStatus;
 import com.smartrent.enums.NotificationType;
 import com.smartrent.enums.RecipientType;
 import com.smartrent.enums.ReportCategory;
+import com.smartrent.enums.ReportResolutionAction;
 import com.smartrent.enums.ReportStatus;
 import com.smartrent.infra.exception.DomainException;
 import com.smartrent.infra.exception.ResourceNotFoundException;
@@ -273,6 +274,7 @@ public class ListingReportServiceImpl implements ListingReportService {
         report.setResolvedBy(adminId);
         report.setResolvedAt(LocalDateTime.now());
         report.setAdminNotes(request.getAdminNotes());
+        report.setResolutionAction(resolveResolutionAction(request, newStatus));
 
         ListingReport savedReport = listingReportRepository.save(report);
         log.info("Report {} successfully {} by admin {}", reportId, newStatus.name().toLowerCase(), adminId);
@@ -420,6 +422,31 @@ public class ListingReportServiceImpl implements ListingReportService {
     /**
      * Helper method to map report to response with admin information
      */
+    /**
+     * Resolve which concrete action to record on the report. Prefers the value the
+     * admin console sends explicitly; otherwise derives it from the request flags so
+     * older/other callers still get a sensible value.
+     */
+    private ReportResolutionAction resolveResolutionAction(ResolveReportRequest request, ReportStatus status) {
+        if (request.getResolutionAction() != null && !request.getResolutionAction().isBlank()) {
+            try {
+                return ReportResolutionAction.valueOf(request.getResolutionAction().trim().toUpperCase());
+            } catch (IllegalArgumentException ignored) {
+                // Unknown value — fall through to derive from flags.
+            }
+        }
+        if (status == ReportStatus.REJECTED) {
+            return ReportResolutionAction.DISMISSED;
+        }
+        if (Boolean.TRUE.equals(request.getRemoveListing())) {
+            return ReportResolutionAction.SUSPENDED;
+        }
+        if (Boolean.TRUE.equals(request.getOwnerActionRequired())) {
+            return ReportResolutionAction.REVISION_REQUESTED;
+        }
+        return ReportResolutionAction.RESOLVED;
+    }
+
     private ListingReportResponse mapToResponseWithAdminInfo(ListingReport report) {
         ListingReportResponse response = listingReportMapper.mapFromListingReportEntityToResponse(report);
 

--- a/smart-rent/src/main/resources/db/migration/V116__Add_resolution_action_to_listing_reports.sql
+++ b/smart-rent/src/main/resources/db/migration/V116__Add_resolution_action_to_listing_reports.sql
@@ -1,0 +1,47 @@
+-- Record the concrete action an admin took when resolving a report.
+--
+-- listing_reports.status only distinguishes PENDING / RESOLVED / REJECTED, and
+-- both "suspend the listing" and "request the owner to revise it" resolve to
+-- RESOLVED. The admin console previously had to guess the outcome from the
+-- listing's live moderation_status, which drifts once the owner resubmits.
+-- This column records the action at resolution time so it stays accurate.
+
+ALTER TABLE listing_reports
+    ADD COLUMN resolution_action VARCHAR(32) NULL AFTER admin_notes;
+
+-- ── Backfill existing reports from durable signals ──
+
+-- Dismissed: report rejected, listing untouched.
+UPDATE listing_reports
+SET resolution_action = 'DISMISSED'
+WHERE status = 'REJECTED'
+  AND resolution_action IS NULL;
+
+-- Suspended/removed: report resolution permanently removed the listing
+-- (handleReportResolutionRemoval sets permanently_removed = TRUE).
+UPDATE listing_reports r
+SET r.resolution_action = 'SUSPENDED'
+WHERE r.status = 'RESOLVED'
+  AND r.resolution_action IS NULL
+  AND EXISTS (
+      SELECT 1 FROM listings l
+      WHERE l.listing_id = r.listing_id
+        AND l.permanently_removed = TRUE
+  );
+
+-- Revision requested: report resolution created a REPORT_RESOLVED owner action
+-- pointing back at this report (handleReportResolutionOwnerAction).
+UPDATE listing_reports r
+SET r.resolution_action = 'REVISION_REQUESTED'
+WHERE r.status = 'RESOLVED'
+  AND r.resolution_action IS NULL
+  AND EXISTS (
+      SELECT 1 FROM listing_owner_actions oa
+      WHERE oa.listing_id = r.listing_id
+        AND oa.trigger_type = 'REPORT_RESOLVED'
+        AND oa.trigger_ref_id = r.report_id
+  );
+
+-- Remaining RESOLVED rows have no reliable historical signal of the exact action
+-- and stay NULL; the admin console falls back to deriving the outcome from the
+-- listing's current moderation status for those.


### PR DESCRIPTION
## Vấn đề

`listing_reports.status` chỉ có `PENDING` / `RESOLVED` / `REJECTED`. Cả **đình chỉ** (suspend/remove) lẫn **yêu cầu sửa đổi** đều đưa report về `RESOLVED`, nên admin console không phân biệt được hành động đã làm và phải suy đoán từ `moderation_status` hiện tại của listing — vốn bị **trôi** khi chủ tin sửa & đăng lại.

## Thay đổi

Lưu lại hành động cụ thể tại thời điểm resolve, qua enum mới `ReportResolutionAction`:

| Giá trị | Ý nghĩa |
|---|---|
| `SUSPENDED` | Đình chỉ / gỡ tin (vi phạm) |
| `REVISION_REQUESTED` | Yêu cầu chủ tin sửa & đăng lại |
| `DISMISSED` | Bỏ qua báo cáo |
| `RESOLVED` | Đã xử lý chung (fallback/legacy) |

- **Entity + cột** `resolution_action` (nullable, `EnumType.STRING`).
- **`resolveReport`**: ưu tiên `resolutionAction` client gửi lên; nếu không có thì suy từ `status` / `removeListing` / `ownerActionRequired` (thuần thông tin, **không** gây side-effect trùng lặp với luồng moderation).
- **DTO** request + response + **mapper** thêm field.
- **V116** thêm cột và **backfill** dữ liệu cũ từ tín hiệu bền vững: `REJECTED` → `DISMISSED`, listing `permanently_removed` → `SUSPENDED`, có owner action `REPORT_RESOLVED` → `REVISION_REQUESTED`. Các row `RESOLVED` còn lại để `NULL` (FE tự fallback).

> V116 vì `origin/main` đã có tới V115 (PR #436).

## Kiểm tra

- `./gradlew compileJava` + `compileTestJava` (offline) — **exit 0**.
- Không có chỗ nào dùng constructor positional của các class `@AllArgsConstructor` đã thêm field (chỉ dùng builder) → an toàn.

Đi kèm PR frontend `feat/report-resolution-action` (repo smartrent-fe) để hiển thị badge kết quả xử lý.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
