### PR TITLE
fix(saved-listings): filter stale listings from saved list, cap saves…

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/infra/exception/model/DomainCode.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/exception/model/DomainCode.java
@@ -155,7 +155,10 @@ public enum DomainCode {
   USER_POSTING_BLOCKED("23001", HttpStatus.FORBIDDEN,
       "Tài khoản của bạn đã bị chặn đăng tin do có nhiều tin vi phạm bị báo cáo. Vui lòng liên hệ quản trị viên để được hỗ trợ."),
   USER_NOT_BLOCK_ELIGIBLE("23002", HttpStatus.BAD_REQUEST,
-      "Người dùng chưa đủ điều kiện bị chặn đăng tin. Cần trên %d report đã được admin duyệt, hiện tại chỉ có %d.")
+      "Người dùng chưa đủ điều kiện bị chặn đăng tin. Cần trên %d report đã được admin duyệt, hiện tại chỉ có %d."),
+  //    Saved Listing Error 24xxx
+  SAVED_LISTING_LIMIT_EXCEEDED("24001", HttpStatus.BAD_REQUEST,
+      "Bạn chỉ có thể lưu tối đa %d tin. Hãy bỏ lưu một tin để lưu tin khác.")
   ;
 
   private final String value;

--- a/smart-rent/src/main/java/com/smartrent/infra/repository/entity/Listing.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/entity/Listing.java
@@ -624,4 +624,19 @@ public class Listing {
         // Default to IN_REVIEW if not verified
         return com.smartrent.enums.ListingStatus.IN_REVIEW;
     }
+
+    /**
+     * Whether this listing may be shown to a normal viewer (e.g. the public
+     * detail endpoint, a user's saved-listings list). Mirrors the status
+     * gate {@code getListingById} enforces, so any list built from data that
+     * skips that gate can reuse this single source of truth instead of
+     * duplicating (and risking drift from) the {@link #computeListingStatus()}
+     * rules.
+     */
+    public boolean isPubliclyVisible() {
+        com.smartrent.enums.ListingStatus status = computeListingStatus();
+        return status == com.smartrent.enums.ListingStatus.DISPLAYING
+                || status == com.smartrent.enums.ListingStatus.EXPIRING_SOON
+                || status == com.smartrent.enums.ListingStatus.VERIFIED;
+    }
 }

--- a/smart-rent/src/main/java/com/smartrent/service/listing/impl/ListingServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/listing/impl/ListingServiceImpl.java
@@ -25,7 +25,6 @@ import com.smartrent.dto.response.ListingResponseWithAdmin;
 import com.smartrent.dto.response.PaymentResponse;
 import com.smartrent.dto.response.ProvinceListingStatsResponse;
 import com.smartrent.enums.BenefitType;
-import com.smartrent.enums.ListingStatus;
 import com.smartrent.enums.ModerationStatus;
 import com.smartrent.enums.NotificationType;
 import com.smartrent.enums.PostSource;
@@ -631,11 +630,7 @@ public class ListingServiceImpl implements ListingService {
         // This endpoint is public (no auth) — only listings currently visible to the public
         // (not pending review, rejected, suspended, expired, etc.) may be served here. Anything
         // else is indistinguishable from "not found" to an anonymous caller.
-        ListingStatus listingStatus = listing.computeListingStatus();
-        boolean isPubliclyVisible = listingStatus == ListingStatus.DISPLAYING
-                || listingStatus == ListingStatus.EXPIRING_SOON
-                || listingStatus == ListingStatus.VERIFIED;
-        if (!isPubliclyVisible) {
+        if (!listing.isPubliclyVisible()) {
             throw new DomainException(DomainCode.LISTING_NOT_FOUND);
         }
 

--- a/smart-rent/src/main/java/com/smartrent/service/listing/impl/SavedListingServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/listing/impl/SavedListingServiceImpl.java
@@ -3,7 +3,10 @@ package com.smartrent.service.listing.impl;
 import com.smartrent.dto.request.SavedListingRequest;
 import com.smartrent.dto.response.PageResponse;
 import com.smartrent.dto.response.SavedListingResponse;
+import com.smartrent.infra.exception.DomainException;
+import com.smartrent.infra.exception.model.DomainCode;
 import com.smartrent.infra.repository.SavedListingRepository;
+import com.smartrent.infra.repository.entity.Listing;
 import com.smartrent.infra.repository.entity.SavedListing;
 import com.smartrent.infra.repository.entity.SavedListingId;
 import com.smartrent.mapper.SavedListingMapper;
@@ -12,14 +15,12 @@ import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -30,6 +31,9 @@ import org.springframework.cache.CacheManager;
 @RequiredArgsConstructor
 @FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
 public class SavedListingServiceImpl implements SavedListingService {
+
+    // Keep in sync with MAX_SAVED_LISTINGS in the FE (src/api/types/saved-listing.type.ts).
+    private static final int MAX_SAVED_LISTINGS = 50;
 
     SavedListingRepository savedListingRepository;
     SavedListingMapper savedListingMapper;
@@ -63,7 +67,17 @@ public class SavedListingServiceImpl implements SavedListingService {
         if (savedListingRepository.existsByIdUserIdAndIdListingId(userId, request.getListingId())) {
             throw new RuntimeException("Listing is already saved by this user");
         }
-        
+
+        // Soft cap so a user's saved list can't grow unbounded. Reads the count
+        // inside this method's transaction rather than relying on a caller-side
+        // check, but a burst of concurrent saves from the same user could still
+        // both read a count under the limit before either insert commits — a
+        // narrow race that's acceptable for a favorites-style limit like this.
+        long currentCount = savedListingRepository.countByIdUserId(userId);
+        if (currentCount >= MAX_SAVED_LISTINGS) {
+            throw new DomainException(DomainCode.SAVED_LISTING_LIMIT_EXCEEDED, MAX_SAVED_LISTINGS);
+        }
+
         SavedListing savedListing = savedListingMapper.toEntity(request, userId);
         SavedListing saved = savedListingRepository.save(savedListing);
         
@@ -89,28 +103,36 @@ public class SavedListingServiceImpl implements SavedListingService {
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional
     public List<SavedListingResponse> getMySavedListings() {
         String userId = getCurrentUserId();
         log.info("Getting saved listings for user {}", userId);
 
-        List<SavedListing> savedListings = savedListingRepository.findByUserIdOrderByCreatedAtDesc(userId);
+        List<SavedListing> visibleSavedListings = fetchVisibleSavedListings(userId);
 
-        return savedListings.stream()
+        return visibleSavedListings.stream()
                 .map(savedListingMapper::toResponseWithListing)
                 .collect(Collectors.toList());
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional
     public PageResponse<SavedListingResponse> getMySavedListings(int page, int size) {
         String userId = getCurrentUserId();
         log.info("Getting saved listings for user {} with pagination - page: {}, size: {}", userId, page, size);
 
-        Pageable pageable = PageRequest.of(page - 1, size);
-        Page<SavedListing> savedListingPage = savedListingRepository.findByUserIdWithDetails(userId, pageable);
+        // The saved list is capped at MAX_SAVED_LISTINGS, so fetching every row for
+        // the user and paginating/filtering in memory is cheap and lets us reuse
+        // Listing.isPubliclyVisible() as the single source of truth instead of
+        // re-deriving its status rules in a native query.
+        List<SavedListing> visibleSavedListings = fetchVisibleSavedListings(userId);
 
-        List<SavedListingResponse> savedListingResponses = savedListingPage.getContent().stream()
+        int totalElements = visibleSavedListings.size();
+        int totalPages = size > 0 ? (int) Math.ceil((double) totalElements / size) : 0;
+        int fromIndex = size > 0 ? Math.min((Math.max(page, 1) - 1) * size, totalElements) : 0;
+        int toIndex = size > 0 ? Math.min(fromIndex + size, totalElements) : 0;
+
+        List<SavedListingResponse> savedListingResponses = visibleSavedListings.subList(fromIndex, toIndex).stream()
                 .map(savedListingMapper::toResponseWithListing)
                 .collect(Collectors.toList());
 
@@ -118,11 +140,43 @@ public class SavedListingServiceImpl implements SavedListingService {
 
         return PageResponse.<SavedListingResponse>builder()
                 .page(page)
-                .size(savedListingPage.getSize())
-                .totalPages(savedListingPage.getTotalPages())
-                .totalElements(savedListingPage.getTotalElements())
+                .size(size)
+                .totalPages(totalPages)
+                .totalElements((long) totalElements)
                 .data(savedListingResponses)
                 .build();
+    }
+
+    /**
+     * Fetches every saved-listing row for the user and drops (and deletes) any
+     * whose listing is no longer publicly visible (expired, unpublished, taken
+     * down by moderation, ...). {@link SavedListingRepository} has no visibility
+     * filter of its own, so without this a stale favorite would keep showing
+     * full listing data while opening it 404s.
+     */
+    private List<SavedListing> fetchVisibleSavedListings(String userId) {
+        List<SavedListing> savedListings = savedListingRepository.findByUserIdOrderByCreatedAtDesc(userId);
+
+        List<SavedListing> visible = new ArrayList<>();
+        boolean removedAny = false;
+        for (SavedListing savedListing : savedListings) {
+            Listing listing = savedListing.getListing();
+            if (listing != null && listing.isPubliclyVisible()) {
+                visible.add(savedListing);
+                continue;
+            }
+
+            Long listingId = savedListing.getId().getListingId();
+            savedListingRepository.deleteByIdUserIdAndIdListingId(userId, listingId);
+            removedAny = true;
+            log.info("Removed stale saved listing {} for user {} (no longer publicly visible)", listingId, userId);
+        }
+
+        if (removedAny) {
+            evictPersonalizedCache(userId);
+        }
+
+        return visible;
     }
 
     @Override

--- a/smart-rent/src/test/java/com/smartrent/service/listing/impl/SavedListingServiceImplTest.java
+++ b/smart-rent/src/test/java/com/smartrent/service/listing/impl/SavedListingServiceImplTest.java
@@ -1,0 +1,139 @@
+package com.smartrent.service.listing.impl;
+
+import com.smartrent.dto.request.SavedListingRequest;
+import com.smartrent.dto.response.PageResponse;
+import com.smartrent.dto.response.SavedListingResponse;
+import com.smartrent.infra.exception.DomainException;
+import com.smartrent.infra.exception.model.DomainCode;
+import com.smartrent.infra.repository.SavedListingRepository;
+import com.smartrent.infra.repository.entity.Listing;
+import com.smartrent.infra.repository.entity.SavedListing;
+import com.smartrent.infra.repository.entity.SavedListingId;
+import com.smartrent.mapper.SavedListingMapper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Saved listings have no visibility filter of their own (see
+ * SavedListingRepository), so an expired/unpublished listing used to keep
+ * showing full data in "Tin đã lưu" even though opening it 404s. These tests
+ * lock in the two fixes: the list-fetch drops (and deletes) stale rows, and
+ * saveListing() enforces the per-user cap instead of growing unbounded.
+ */
+@ExtendWith(MockitoExtension.class)
+class SavedListingServiceImplTest {
+
+    private static final String USER_ID = "user-1";
+
+    @Mock
+    SavedListingRepository savedListingRepository;
+
+    @Mock
+    SavedListingMapper savedListingMapper;
+
+    @InjectMocks
+    SavedListingServiceImpl service;
+
+    @BeforeEach
+    void setUpAuthentication() {
+        SecurityContextHolder.getContext()
+                .setAuthentication(new UsernamePasswordAuthenticationToken(USER_ID, null, List.of()));
+    }
+
+    @AfterEach
+    void clearAuthentication() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void saveListingThrowsWhenAtLimit() {
+        SavedListingRequest request = SavedListingRequest.builder().listingId(999L).build();
+        when(savedListingRepository.existsByIdUserIdAndIdListingId(USER_ID, 999L)).thenReturn(false);
+        when(savedListingRepository.countByIdUserId(USER_ID)).thenReturn(50L);
+
+        DomainException ex = assertThrows(DomainException.class, () -> service.saveListing(request));
+
+        assertEquals(DomainCode.SAVED_LISTING_LIMIT_EXCEEDED, ex.getDomainCode());
+        verify(savedListingRepository, never()).save(any());
+    }
+
+    @Test
+    void saveListingSucceedsWhenUnderLimit() {
+        SavedListingRequest request = SavedListingRequest.builder().listingId(999L).build();
+        SavedListing entity = SavedListing.builder().id(new SavedListingId(USER_ID, 999L)).build();
+        when(savedListingRepository.existsByIdUserIdAndIdListingId(USER_ID, 999L)).thenReturn(false);
+        when(savedListingRepository.countByIdUserId(USER_ID)).thenReturn(49L);
+        when(savedListingMapper.toEntity(request, USER_ID)).thenReturn(entity);
+        when(savedListingRepository.save(entity)).thenReturn(entity);
+        when(savedListingMapper.toResponse(entity)).thenReturn(SavedListingResponse.builder().build());
+
+        service.saveListing(request);
+
+        verify(savedListingRepository, times(1)).save(entity);
+    }
+
+    @Test
+    void getMySavedListingsDropsAndDeletesStaleEntries() {
+        SavedListing visible = SavedListing.builder()
+                .id(new SavedListingId(USER_ID, 1L))
+                .listing(Listing.builder().listingId(1L).verified(true).expired(false).build())
+                .build();
+        SavedListing expired = SavedListing.builder()
+                .id(new SavedListingId(USER_ID, 2L))
+                .listing(Listing.builder().listingId(2L).verified(true).expired(true).build())
+                .build();
+        when(savedListingRepository.findByUserIdOrderByCreatedAtDesc(USER_ID))
+                .thenReturn(List.of(visible, expired));
+        lenient().when(savedListingMapper.toResponseWithListing(visible))
+                .thenReturn(SavedListingResponse.builder().listingId(1L).build());
+
+        List<SavedListingResponse> result = service.getMySavedListings();
+
+        assertEquals(1, result.size());
+        assertEquals(1L, result.get(0).getListingId());
+        verify(savedListingRepository, times(1)).deleteByIdUserIdAndIdListingId(USER_ID, 2L);
+        verify(savedListingRepository, never()).deleteByIdUserIdAndIdListingId(USER_ID, 1L);
+    }
+
+    @Test
+    void getMySavedListingsPagedComputesTotalsFromVisibleOnly() {
+        SavedListing visible = SavedListing.builder()
+                .id(new SavedListingId(USER_ID, 1L))
+                .listing(Listing.builder().listingId(1L).verified(true).expired(false).build())
+                .build();
+        SavedListing expired = SavedListing.builder()
+                .id(new SavedListingId(USER_ID, 2L))
+                .listing(Listing.builder().listingId(2L).verified(true).expired(true).build())
+                .build();
+        when(savedListingRepository.findByUserIdOrderByCreatedAtDesc(USER_ID))
+                .thenReturn(List.of(visible, expired));
+        lenient().when(savedListingMapper.toResponseWithListing(visible))
+                .thenReturn(SavedListingResponse.builder().listingId(1L).build());
+
+        PageResponse<SavedListingResponse> result = service.getMySavedListings(1, 10);
+
+        assertEquals(1L, result.getTotalElements());
+        assertEquals(1, result.getTotalPages());
+        assertEquals(1, result.getData().size());
+        verify(savedListingRepository, times(1)).deleteByIdUserIdAndIdListingId(eq(USER_ID), eq(2L));
+    }
+}


### PR DESCRIPTION
… at 50

The saved-listings query never checked listing status, so an expired or unpublished listing kept showing full data in a user's saved list even though opening it 404s. Reuse the same publicly-visible check the detail endpoint already enforces (now extracted onto Listing as isPubliclyVisible()) to drop and clean up stale saved rows on fetch, and enforce a 50-listing cap in saveListing() so the list can't grow unbounded.