### PR TITLE
Fix: restore countByBrokerVerificationStatus dropped by a stale rebase

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/infra/repository/UserRepository.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/UserRepository.java
@@ -1,5 +1,6 @@
 package com.smartrent.infra.repository;
 
+import com.smartrent.enums.BrokerVerificationStatus;
 import com.smartrent.infra.repository.entity.User;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -44,4 +45,11 @@ public interface UserRepository extends JpaRepository<User, String>, JpaSpecific
                         "FROM users u WHERE u.created_at BETWEEN :start AND :end AND u.is_broker = true " +
                         "GROUP BY u.broker_verification_status", nativeQuery = true)
         List<Object[]> countNewBrokersByVerificationStatus(@Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
+
+        /**
+         * System-wide count of brokers in a given verification state, independent of any date range.
+         * Used for the "brokers pending approval" KPI, which reflects the current backlog rather
+         * than only brokers who registered within the selected analytics window.
+         */
+        long countByBrokerVerificationStatus(BrokerVerificationStatus status);
 }


### PR DESCRIPTION
My previous commit copied UserRepository.java from a local checkout that was 11 commits behind main and didn't yet have this method (added by admin-analytics' broker-pending KPI), silently deleting it. Verified with a full gradle compileJava this time instead of trusting a stale local build.