### PR TITLE
fix: exclude drafts/shadow listings from admin totalListings stat

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/infra/repository/ListingRepository.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/ListingRepository.java
@@ -396,6 +396,13 @@ public interface ListingRepository extends JpaRepository<Listing, Long>, JpaSpec
      * Get admin statistics in a single query instead of 11 separate COUNT queries.
      * Returns: [pendingVerification, verified, expired, rejected, drafts, shadows,
      *          normalListings, silverListings, goldListings, diamondListings, totalListings]
+     *
+     * <p>{@code totalListings} excludes drafts and shadow listings — same convention as
+     * {@link #countByCreatedAtBeforeAndIsDraftFalseAndIsShadowFalse}, which backs the
+     * "total listings" figure on the analytics dashboard (GET /v1/admin/analytics/listings).
+     * A plain {@code COUNT(l)} here would count unsubmitted drafts and internal shadow
+     * listings as "posts", inflating this total above that page's and contradicting the
+     * "all submitted posts" label shown with it.
      */
     @Query("""
         SELECT
@@ -409,7 +416,7 @@ public interface ListingRepository extends JpaRepository<Listing, Long>, JpaSpec
             SUM(CASE WHEN l.vipType = 'SILVER' THEN 1 ELSE 0 END),
             SUM(CASE WHEN l.vipType = 'GOLD' THEN 1 ELSE 0 END),
             SUM(CASE WHEN l.vipType = 'DIAMOND' THEN 1 ELSE 0 END),
-            COUNT(l)
+            SUM(CASE WHEN l.isDraft = false AND l.isShadow = false THEN 1 ELSE 0 END)
         FROM listings l
     """)
     List<Object[]> getAdminStatistics();

--- a/smart-rent/src/main/java/com/smartrent/service/listing/AdminListingStatsService.java
+++ b/smart-rent/src/main/java/com/smartrent/service/listing/AdminListingStatsService.java
@@ -14,13 +14,17 @@ import java.util.List;
  * Dashboard statistics for {@code POST /v1/listings/admin/list}.
  *
  * <p>{@code getStatistics()} aggregates over the ENTIRE listings table
- * (no WHERE clause) — every admin list request was paying that full scan on
- * top of the paginated query, regardless of page/filters. Cached with a
- * short TTL (see application.yml) so repeated admin requests within the
- * window reuse one computed result instead of re-scanning the table each
- * time. Lives in its own bean (not a private method on ListingServiceImpl)
- * because {@code @Cacheable} can't intercept self-invoked calls within the
- * same class.
+ * (no WHERE clause on moderation status/page filters) — every admin list
+ * request was paying that full scan on top of the paginated query,
+ * regardless of page/filters. Cached with a short TTL (see application.yml)
+ * so repeated admin requests within the window reuse one computed result
+ * instead of re-scanning the table each time. Lives in its own bean (not a
+ * private method on ListingServiceImpl) because {@code @Cacheable} can't
+ * intercept self-invoked calls within the same class.
+ *
+ * <p>{@code totalListings} itself still excludes drafts and shadow listings
+ * (see {@link ListingRepository#getAdminStatistics()}), matching the
+ * "total listings" figure on the analytics dashboard.
  */
 @Service
 @RequiredArgsConstructor


### PR DESCRIPTION
statistics.totalListings on POST /v1/listings/admin/list (shown as "Tổng Bài Đăng" on /content/posts) was a plain COUNT(l) over the whole listings table, so it included unsubmitted drafts and internal shadow listings. That inflated it above the "Tổng Tin Đăng" total on /insights/posts, which already excludes drafts/shadows, and contradicted its own "all submitted posts" label. Now both totals use the same non-draft, non-shadow definition.