### PR TITLE
fix: sort following feed by VIP tier before recency

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/controller/ListingController.java
+++ b/smart-rent/src/main/java/com/smartrent/controller/ListingController.java
@@ -356,7 +356,7 @@ public class ListingController {
     @GetMapping("/my-following-feed")
     @Operation(
             summary = "List public listings from users I follow",
-            description = "Authenticated. Returns paginated card-shaped listings posted by users that the current viewer follows, newest first. Drafts, shadow rows, and unverified listings are excluded. Pass `userId` to narrow the feed to a single followed user — ignored if the viewer does not actually follow that user.",
+            description = "Authenticated. Returns paginated card-shaped listings posted by users that the current viewer follows, sorted by VIP tier (DIAMOND, then GOLD, SILVER, NORMAL) and newest first within each tier. Drafts, shadow rows, and unverified listings are excluded. Pass `userId` to narrow the feed to a single followed user — ignored if the viewer does not actually follow that user.",
             security = @SecurityRequirement(name = "Bearer Authentication"),
             parameters = {
                     @Parameter(name = "userId", description = "Optional — when provided, narrow the feed to listings from this single followed user", example = "u-1234"),

--- a/smart-rent/src/main/java/com/smartrent/service/listing/impl/ListingServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/listing/impl/ListingServiceImpl.java
@@ -2333,12 +2333,18 @@ public class ListingServiceImpl implements ListingService {
             followingIds = java.util.List.of(targetUserId);
         }
 
+        // VIP tier first (vipTypeSortOrder: DIAMOND=1, GOLD=2, SILVER=3, NORMAL=4),
+        // same default ordering as the main search endpoint (see
+        // ListingQueryService#buildSort), then newest within each tier.
         org.springframework.data.domain.Pageable pageable = org.springframework.data.domain.PageRequest.of(
                 safePage - 1,
                 safeSize,
                 org.springframework.data.domain.Sort.by(
-                        org.springframework.data.domain.Sort.Direction.DESC,
-                        "postDate", "createdAt"));
+                                org.springframework.data.domain.Sort.Direction.ASC,
+                                "vipTypeSortOrder")
+                        .and(org.springframework.data.domain.Sort.by(
+                                org.springframework.data.domain.Sort.Direction.DESC,
+                                "postDate", "createdAt")));
 
         Page<Listing> result = listingRepository.findPublicListingsByUserIdIn(followingIds, pageable);
         List<ListingCardResponse> cards = batchMapCardListings(result.getContent());

--- a/smart-rent/src/test/java/com/smartrent/service/listing/impl/ListingServiceImplFollowingFeedTest.java
+++ b/smart-rent/src/test/java/com/smartrent/service/listing/impl/ListingServiceImplFollowingFeedTest.java
@@ -1,0 +1,69 @@
+package com.smartrent.service.listing.impl;
+
+import com.smartrent.dto.response.ListingCardListResponse;
+import com.smartrent.infra.repository.ListingRepository;
+import com.smartrent.infra.repository.UserFollowRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+import java.util.Iterator;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * GET /v1/listings/my-following-feed used to sort purely by postDate/createdAt,
+ * so a DIAMOND-tier post from a followed user could sit behind an older NORMAL
+ * post. Locks in that the feed reuses the same vipTypeSortOrder-first ordering
+ * as the main search endpoint (see ListingQueryService#buildSort): DIAMOND(1)
+ * before GOLD(2) before SILVER(3) before NORMAL(4), newest first within a tier.
+ */
+@ExtendWith(MockitoExtension.class)
+class ListingServiceImplFollowingFeedTest {
+
+    @Mock
+    UserFollowRepository userFollowRepository;
+
+    @Mock
+    ListingRepository listingRepository;
+
+    @InjectMocks
+    ListingServiceImpl service;
+
+    @Test
+    void sortsByVipTierBeforeRecency() {
+        when(userFollowRepository.findFollowingIdsByFollowerId("viewer-1"))
+                .thenReturn(List.of("followed-1"));
+        when(listingRepository.findPublicListingsByUserIdIn(anyCollection(), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of(), Pageable.unpaged(), 0));
+
+        ListingCardListResponse response =
+                service.getListingsFromFollowedUsers("viewer-1", null, 1, 12);
+
+        assertEquals(0, response.getTotalCount());
+
+        ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
+        verify(listingRepository).findPublicListingsByUserIdIn(anyCollection(), pageableCaptor.capture());
+
+        Iterator<Sort.Order> orders = pageableCaptor.getValue().getSort().iterator();
+
+        Sort.Order first = orders.next();
+        assertEquals("vipTypeSortOrder", first.getProperty());
+        assertEquals(Sort.Direction.ASC, first.getDirection());
+
+        Sort.Order second = orders.next();
+        assertEquals("postDate", second.getProperty());
+        assertEquals(Sort.Direction.DESC, second.getDirection());
+    }
+}


### PR DESCRIPTION
The /my-following-feed endpoint (used by the following/feed page) only sorted by postDate/createdAt, so a DIAMOND-tier post from a followed user could rank behind an older NORMAL post. Reuse the existing vipTypeSortOrder index (DIAMOND=1 .. NORMAL=4) so it sorts diamond down, same default ordering as the main search endpoint.