### PR TITLE
feat: search and filter admin listings by exact ID

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/controller/ListingAdminController.java
+++ b/smart-rent/src/main/java/com/smartrent/controller/ListingAdminController.java
@@ -29,6 +29,8 @@ import org.springframework.web.bind.annotation.*;
         **Dashboard statistics:** pendingVerification, verified, expired, rejected counts, VIP tier breakdown.
 
         **Common filter combinations:**
+        - By exact listing ID: `{"id": 12345}` (PK lookup — fastest possible filter)
+        - Quick search also matches ID: `{"keyword": "12345"}` matches listing #12345 as well as title/address/description text
         - Pending review: `{"verified": false, "isVerify": true}`
         - By moderation status: `{"moderationStatus": "PENDING_REVIEW"}`
         - By VIP tier: `{"vipType": "GOLD"}`
@@ -141,6 +143,17 @@ public class ListingAdminController {
                               "page": 1,
                               "size": 20,
                               "moderationStatus": "PENDING_REVIEW"
+                            }
+                            """
+                    ),
+                    @ExampleObject(
+                        name = "Find by exact listing ID",
+                        summary = "Exact match on the listing ID (PK lookup)",
+                        value = """
+                            {
+                              "page": 1,
+                              "size": 20,
+                              "id": 12345
                             }
                             """
                     ),

--- a/smart-rent/src/main/java/com/smartrent/dto/request/ListingFilterRequest.java
+++ b/smart-rent/src/main/java/com/smartrent/dto/request/ListingFilterRequest.java
@@ -265,8 +265,13 @@ public class ListingFilterRequest {
     Integer minMediaCount;
 
     // ============ CONTENT SEARCH ============
-    @Schema(description = "Keyword search in title and description (FULLTEXT)", example = "căn hộ cao cấp view đẹp")
+    @Schema(description = "Keyword search in title and description (FULLTEXT). A purely-numeric keyword " +
+            "also matches the listing ID exactly (e.g. typing \"12345\" finds listing #12345).",
+            example = "căn hộ cao cấp view đẹp")
     String keyword;
+
+    @Schema(description = "Admin-only: exact match on listing ID (PK lookup, O(1) regardless of table size).", example = "12345")
+    Long id;
 
     @Schema(description = "Case-insensitive substring search on listing TITLE only (admin table view)", example = "Tân Bình")
     String title;

--- a/smart-rent/src/main/java/com/smartrent/infra/repository/specification/ListingSpecification.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/specification/ListingSpecification.java
@@ -677,9 +677,31 @@ public class ListingSpecification {
                 ));
             }
 
-            // ============ KEYWORD SEARCH (FULLTEXT + LIKE fallback) ============
+            // ============ ADMIN: EXACT LISTING ID FILTER ============
+            // Pure PK equality — MySQL always picks the clustered-index seek for this
+            // regardless of what else is filtered, so no dedicated index is needed.
+            if (filter.getId() != null) {
+                predicates.add(criteriaBuilder.equal(root.get("listingId"), filter.getId()));
+            }
+
+            // ============ KEYWORD SEARCH (FULLTEXT + LIKE fallback + numeric ID) ============
             if (filter.getKeyword() != null && !filter.getKeyword().trim().isEmpty()) {
-                String normalized = TextNormalizer.normalize(filter.getKeyword());
+                String trimmedKeyword = filter.getKeyword().trim();
+
+                // A purely-numeric keyword (e.g. a pasted listing ID) also matches the
+                // listing PK directly — OR'd with the text match below — so the one
+                // quick-search box doubles as an ID lookup with no separate field needed.
+                Predicate idMatch = null;
+                if (trimmedKeyword.matches("\\d+")) {
+                    try {
+                        idMatch = criteriaBuilder.equal(root.get("listingId"), Long.valueOf(trimmedKeyword));
+                    } catch (NumberFormatException ignored) {
+                        // Too large for a Long (unrealistic for a listing id) — skip the ID match.
+                    }
+                }
+
+                String normalized = TextNormalizer.normalize(trimmedKeyword);
+                Predicate textMatch = null;
                 if (normalized != null && !normalized.isEmpty()) {
                     // Use MySQL FULLTEXT MATCH...AGAINST in BOOLEAN MODE for indexed search
                     // Each word gets a '+' prefix for AND semantics, '*' suffix for prefix matching
@@ -712,8 +734,16 @@ public class ListingSpecification {
                         // honored and exact substrings always match.
                         Predicate likeMatch = criteriaBuilder.and(
                             likeAllWords.toArray(new Predicate[0]));
-                        predicates.add(criteriaBuilder.or(ftMatch, likeMatch));
+                        textMatch = criteriaBuilder.or(ftMatch, likeMatch);
                     }
+                }
+
+                if (idMatch != null && textMatch != null) {
+                    predicates.add(criteriaBuilder.or(idMatch, textMatch));
+                } else if (idMatch != null) {
+                    predicates.add(idMatch);
+                } else if (textMatch != null) {
+                    predicates.add(textMatch);
                 }
             }
 


### PR DESCRIPTION
Adds an `id` field to the admin listing filter (exact PK match) and makes the existing `keyword` quick-search also match a purely-numeric term against the listing ID, so admins can jump straight to a listing without scanning pages. No new index needed — both paths hit the clustered PK.