### PR TITLE
Record pricing_histories when price changes via listing edit flows

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/service/listing/impl/ListingServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/listing/impl/ListingServiceImpl.java
@@ -140,6 +140,7 @@ public class ListingServiceImpl implements ListingService {
     NotificationService notificationService;
     org.springframework.context.ApplicationEventPublisher eventPublisher;
     com.smartrent.infra.repository.ListingAiModerationRepository listingAiModerationRepository;
+    com.smartrent.service.pricing.PricingHistoryService pricingHistoryService;
 
     @Override
     @Transactional
@@ -722,6 +723,8 @@ public class ListingServiceImpl implements ListingService {
         if (request.getVipType() != null) existing.setVipType(Listing.VipType.valueOf(request.getVipType()));
         if (request.getCategoryId() != null) existing.setCategoryId(request.getCategoryId());
         if (request.getProductType() != null) existing.setProductType(Listing.ProductType.valueOf(request.getProductType()));
+        BigDecimal oldPrice = existing.getPrice();
+        Listing.PriceUnit oldPriceUnit = existing.getPriceUnit();
         if (request.getPrice() != null) existing.setPrice(request.getPrice());
         if (request.getPriceUnit() != null) existing.setPriceUnit(Listing.PriceUnit.valueOf(request.getPriceUnit()));
         if (request.getArea() != null) existing.setArea(request.getArea());
@@ -782,6 +785,12 @@ public class ListingServiceImpl implements ListingService {
         Listing saved = listingRepository.save(existing);
         if (sentBackToReview) {
             queueAiAnalysis(saved);
+        }
+        boolean priceChanged = request.getPrice() != null
+                && (oldPrice == null || oldPrice.compareTo(saved.getPrice()) != 0 || oldPriceUnit != saved.getPriceUnit());
+        if (priceChanged) {
+            pricingHistoryService.recordExternalPriceChange(id, oldPrice, oldPriceUnit,
+                    saved.getPrice(), saved.getPriceUnit(), userId, "Cập nhật qua chỉnh sửa tin đăng");
         }
         com.smartrent.dto.response.UserCreationResponse user = buildUserResponse(saved.getUserId());
         com.smartrent.dto.response.AddressResponse addressResponse = buildAddressResponse(saved.getAddress());

--- a/smart-rent/src/main/java/com/smartrent/service/moderation/impl/ListingModerationServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/moderation/impl/ListingModerationServiceImpl.java
@@ -46,6 +46,7 @@ import org.springframework.cache.annotation.Caching;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.List;
@@ -72,6 +73,7 @@ public class ListingModerationServiceImpl implements ListingModerationService {
     NotificationService notificationService;
     UserFollowService userFollowService;
     org.springframework.context.ApplicationEventPublisher eventPublisher;
+    com.smartrent.service.pricing.PricingHistoryService pricingHistoryService;
 
     @NonFinal
     @Value("${application.email.sender.email}")
@@ -451,6 +453,8 @@ public class ListingModerationServiceImpl implements ListingModerationService {
         if (request.getListingType() != null) listing.setListingType(Listing.ListingType.valueOf(request.getListingType()));
         if (request.getCategoryId() != null) listing.setCategoryId(request.getCategoryId());
         if (request.getProductType() != null) listing.setProductType(Listing.ProductType.valueOf(request.getProductType()));
+        BigDecimal oldPrice = listing.getPrice();
+        Listing.PriceUnit oldPriceUnit = listing.getPriceUnit();
         if (request.getPrice() != null) listing.setPrice(request.getPrice());
         if (request.getPriceUnit() != null) listing.setPriceUnit(Listing.PriceUnit.valueOf(request.getPriceUnit()));
         if (request.getArea() != null) listing.setArea(request.getArea());
@@ -489,7 +493,14 @@ public class ListingModerationServiceImpl implements ListingModerationService {
         listing.setVerified(false);
         listing.setIsVerify(true); // Back to IN_REVIEW in legacy view
         listing.setRevisionCount(listing.getRevisionCount() + 1);
-        listingRepository.save(listing);
+        Listing saved = listingRepository.save(listing);
+
+        boolean priceChanged = request.getPrice() != null
+                && (oldPrice == null || oldPrice.compareTo(saved.getPrice()) != 0 || oldPriceUnit != saved.getPriceUnit());
+        if (priceChanged) {
+            pricingHistoryService.recordExternalPriceChange(listingId, oldPrice, oldPriceUnit,
+                    saved.getPrice(), saved.getPriceUnit(), userId, "Cập nhật qua chỉnh sửa & gửi lại tin đăng");
+        }
 
         // --- AI Moderation Integration ---
         listingAiModerationRepository.findById(listing.getListingId())

--- a/smart-rent/src/main/java/com/smartrent/service/pricing/PricingHistoryService.java
+++ b/smart-rent/src/main/java/com/smartrent/service/pricing/PricingHistoryService.java
@@ -3,6 +3,7 @@ package com.smartrent.service.pricing;
 import com.smartrent.dto.request.PriceUpdateRequest;
 import com.smartrent.dto.response.PageResponse;
 import com.smartrent.dto.response.PricingHistoryResponse;
+import com.smartrent.infra.repository.entity.Listing;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -15,6 +16,14 @@ public interface PricingHistoryService {
 
     // Update price and create pricing history
     PricingHistoryResponse updatePrice(Long listingId, PriceUpdateRequest request, String changedBy);
+
+    // Record a price change made through a non-dedicated flow (e.g. the generic
+    // listing edit form), where the caller already knows old/new price and has
+    // already performed ownership checks. Backfills a baseline row first if the
+    // listing has no pricing history yet, so the edit shows up as a real delta.
+    void recordExternalPriceChange(Long listingId, BigDecimal oldPrice, Listing.PriceUnit oldPriceUnit,
+                                    BigDecimal newPrice, Listing.PriceUnit newPriceUnit,
+                                    String changedBy, String changeReason);
 
     // Get pricing history for a listing
     List<PricingHistoryResponse> getPricingHistoryByListingId(Long listingId);

--- a/smart-rent/src/main/java/com/smartrent/service/pricing/impl/PricingHistoryServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/pricing/impl/PricingHistoryServiceImpl.java
@@ -195,6 +195,63 @@ public class PricingHistoryServiceImpl implements PricingHistoryService {
     }
 
     @Override
+    @Transactional
+    public void recordExternalPriceChange(Long listingId, BigDecimal oldPrice, Listing.PriceUnit oldPriceUnit,
+                                           BigDecimal newPrice, Listing.PriceUnit newPriceUnit,
+                                           String changedBy, String changeReason) {
+        log.info("Recording external price change for listing: {} ({} -> {})", listingId, oldPrice, newPrice);
+
+        Listing listing = listingRepository.findById(listingId)
+                .orElseThrow(() -> new RuntimeException("Listing not found with id: " + listingId));
+
+        boolean hasCurrent = pricingHistoryRepository.findByListingListingIdAndIsCurrentTrue(listingId).isPresent();
+        if (!hasCurrent && oldPrice != null) {
+            // No history yet (createInitialPricing isn't wired into listing creation) — backfill
+            // a baseline at the pre-edit price so this edit renders as a real delta on the chart,
+            // mirroring what the V68 migration did for pre-existing listings.
+            PricingHistory baseline = PricingHistory.builder()
+                    .listing(listing)
+                    .oldPrice(null)
+                    .newPrice(oldPrice)
+                    .oldPriceUnit(null)
+                    .newPriceUnit(oldPriceUnit != null ? oldPriceUnit : newPriceUnit)
+                    .changeType(PricingHistory.PriceChangeType.INITIAL)
+                    .changePercentage(BigDecimal.ZERO)
+                    .changeAmount(BigDecimal.ZERO)
+                    .isCurrent(false)
+                    .changedBy(changedBy)
+                    .changeReason("Initial pricing (backfilled on edit)")
+                    .changedAt(listing.getCreatedAt() != null ? listing.getCreatedAt() : LocalDateTime.now())
+                    .build();
+            pricingHistoryRepository.save(baseline);
+        }
+
+        BigDecimal effectiveOldPrice = oldPrice != null ? oldPrice : newPrice;
+        Listing.PriceUnit effectiveOldUnit = oldPriceUnit != null ? oldPriceUnit : newPriceUnit;
+        PricingHistory.PriceChangeType changeType = determineChangeType(effectiveOldPrice, newPrice, effectiveOldUnit, newPriceUnit);
+        BigDecimal changeAmount = newPrice.subtract(effectiveOldPrice);
+        BigDecimal changePercentage = calculateChangePercentage(effectiveOldPrice, newPrice);
+
+        pricingHistoryRepository.updateIsCurrentFalseByListingListingId(listingId);
+
+        PricingHistory newPricing = PricingHistory.builder()
+                .listing(listing)
+                .oldPrice(oldPrice)
+                .newPrice(newPrice)
+                .oldPriceUnit(oldPriceUnit)
+                .newPriceUnit(newPriceUnit)
+                .changeType(changeType)
+                .changePercentage(changePercentage)
+                .changeAmount(changeAmount)
+                .isCurrent(true)
+                .changedBy(changedBy)
+                .changeReason(changeReason)
+                .changedAt(LocalDateTime.now())
+                .build();
+        pricingHistoryRepository.save(newPricing);
+    }
+
+    @Override
     public PriceStatistics getPriceStatistics(Long listingId) {
         log.info("Getting price statistics for listing: {}", listingId);
 


### PR DESCRIPTION
The generic listing edit (PUT /v1/listings/{id}) and update-and-resubmit (PUT /{id}/update-and-resubmit) endpoints wrote listing.price directly without ever touching pricing_histories, so most price edits (the normal "edit post" path real users take) silently disappeared from the price history chart. Only the dedicated PUT /price endpoint, called solely by the AI chat assistant, recorded history.

Both flows now call the new PricingHistoryService.recordExternalPriceChange after saving, which backfills a baseline row first if the listing has no history yet (createInitialPricing was never wired into listing creation), so the edit still renders as a real delta on the chart.