### PR TITLE
Remove copyright footer line and redundant resubmit prompt from mail …

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/utility/EmailBuilder.java
+++ b/smart-rent/src/main/java/com/smartrent/utility/EmailBuilder.java
@@ -101,8 +101,7 @@ public class EmailBuilder {
 
     // Footer
     htmlContent.append("<div class=\"footer\">");
-    htmlContent.append("Nếu bạn không yêu cầu xác minh này, vui lòng bỏ qua email này.<br>");
-    htmlContent.append("&copy; %d %s. Bản quyền được bảo lưu.".formatted(currentYear(), senderName));
+    htmlContent.append("Nếu bạn không yêu cầu xác minh này, vui lòng bỏ qua email này.");
     htmlContent.append("</div>");
 
     htmlContent.append("</div>"); // End container
@@ -156,8 +155,7 @@ public class EmailBuilder {
 
     // Footer
     htmlContent.append("<div class=\"footer\">");
-    htmlContent.append("Email này được gửi tự động &mdash; bạn không cần phản hồi.<br>");
-    htmlContent.append("&copy; %d %s. Bản quyền được bảo lưu.".formatted(currentYear(), senderName));
+    htmlContent.append("Email này được gửi tự động &mdash; bạn không cần phản hồi.");
     htmlContent.append("</div>");
 
     htmlContent.append("</div>"); // End container
@@ -211,8 +209,7 @@ public class EmailBuilder {
 
     // Footer
     htmlContent.append("<div class=\"footer\">");
-    htmlContent.append("Email này được gửi tự động &mdash; bạn không cần phản hồi.<br>");
-    htmlContent.append("&copy; %d %s. Bản quyền được bảo lưu.".formatted(currentYear(), senderName));
+    htmlContent.append("Email này được gửi tự động &mdash; bạn không cần phản hồi.");
     htmlContent.append("</div>");
 
     htmlContent.append("</div>"); // End container
@@ -269,8 +266,7 @@ public class EmailBuilder {
     htmlContent.append("</div>"); // End content
 
     htmlContent.append("<div class=\"footer\">");
-    htmlContent.append("Email này được gửi tự động &mdash; bạn không cần phản hồi.<br>");
-    htmlContent.append("&copy; %d %s. Bản quyền được bảo lưu.".formatted(currentYear(), senderName));
+    htmlContent.append("Email này được gửi tự động &mdash; bạn không cần phản hồi.");
     htmlContent.append("</div>");
 
     htmlContent.append("</div>"); // End container

--- a/smart-rent/src/main/java/com/smartrent/utility/ModerationEmailBuilder.java
+++ b/smart-rent/src/main/java/com/smartrent/utility/ModerationEmailBuilder.java
@@ -22,7 +22,6 @@ public class ModerationEmailBuilder {
         html.append("<div class=\"card-body\">Đã duyệt &mdash; đang hiển thị công khai.</div>");
         html.append("</div>");
         html.append("</div>");
-        html.append("<div class=\"footer\">&copy; %d SmartRent. Bản quyền được bảo lưu.</div>".formatted(EmailBuilder.currentYear()));
         html.append("</div></body></html>");
         return html.toString();
     }
@@ -42,9 +41,7 @@ public class ModerationEmailBuilder {
             html.append("<div class=\"card-body\">%s</div>".formatted(safe(reason)));
             html.append("</div>");
         }
-        html.append("<div class=\"message\">Vui lòng cập nhật tin đăng và gửi lại để được xem xét.</div>");
         html.append("</div>");
-        html.append("<div class=\"footer\">&copy; %d SmartRent. Bản quyền được bảo lưu.</div>".formatted(EmailBuilder.currentYear()));
         html.append("</div></body></html>");
         return html.toString();
     }
@@ -66,7 +63,6 @@ public class ModerationEmailBuilder {
         }
         html.append("<div class=\"message\">Vui lòng chỉnh sửa tin đăng và nhấn &ldquo;Gửi lại để xem xét&rdquo; khi bạn hoàn tất.</div>");
         html.append("</div>");
-        html.append("<div class=\"footer\">&copy; %d SmartRent. Bản quyền được bảo lưu.</div>".formatted(EmailBuilder.currentYear()));
         html.append("</div></body></html>");
         return html.toString();
     }
@@ -88,7 +84,6 @@ public class ModerationEmailBuilder {
         }
         html.append("<div class=\"message\">Vui lòng cập nhật tin đăng và gửi lại để được xem xét.</div>");
         html.append("</div>");
-        html.append("<div class=\"footer\">&copy; %d SmartRent. Bản quyền được bảo lưu.</div>".formatted(EmailBuilder.currentYear()));
         html.append("</div></body></html>");
         return html.toString();
     }
@@ -114,7 +109,6 @@ public class ModerationEmailBuilder {
         }
         html.append("<div class=\"message\">Nếu bạn cho rằng đây là nhầm lẫn, vui lòng liên hệ đội ngũ hỗ trợ của SmartRent.</div>");
         html.append("</div>");
-        html.append("<div class=\"footer\">&copy; %d SmartRent. Bản quyền được bảo lưu.</div>".formatted(EmailBuilder.currentYear()));
         html.append("</div></body></html>");
         return html.toString();
     }
@@ -152,7 +146,6 @@ public class ModerationEmailBuilder {
         }
         html.append("<div class=\"message\">Chúng tôi đánh giá cao sự giúp đỡ của bạn trong việc giữ SmartRent trở thành nền tảng an toàn và chính xác.</div>");
         html.append("</div>");
-        html.append("<div class=\"footer\">&copy; %d SmartRent. Bản quyền được bảo lưu.</div>".formatted(EmailBuilder.currentYear()));
         html.append("</div></body></html>");
         return html.toString();
     }
@@ -189,7 +182,6 @@ public class ModerationEmailBuilder {
             html.append("</div>");
         }
         html.append("</div>");
-        html.append("<div class=\"footer\">&copy; %d SmartRent. Bản quyền được bảo lưu.</div>".formatted(EmailBuilder.currentYear()));
         html.append("</div></body></html>");
         return html.toString();
     }


### PR DESCRIPTION
…templates

- Drop "Vui lòng cập nhật tin đăng và gửi lại để được xem xét" from the listing-rejected email template.
- Remove the "Bản quyền được bảo lưu" copyright line from every email footer across EmailBuilder and ModerationEmailBuilder.