### PR TITLE
fix: seller My Listings sorts strictly by date, not VIP tier

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/service/listing/ListingQueryService.java
+++ b/smart-rent/src/main/java/com/smartrent/service/listing/ListingQueryService.java
@@ -165,7 +165,8 @@ public class ListingQueryService {
      * @return Pageable object for JPA query
      */
     private Pageable buildPageable(ListingFilterRequest filter) {
-        Sort sort = buildSort(filter.getSortBy(), filter.getSortDirection());
+        Sort sort = buildSort(filter.getSortBy(), filter.getSortDirection(),
+                Boolean.TRUE.equals(filter.getIsOwnerRequest()));
 
         // Ensure valid page and size values
         // Convert from 1-based (frontend) to 0-based (Spring Data)
@@ -177,20 +178,26 @@ public class ListingQueryService {
 
     /**
      * Build Sort object from sort field and direction
-     * DEFAULT SORTING: All listings are always sorted by:
+     * DEFAULT SORTING (public/admin requests): All listings are sorted by:
      * 1. vipTypeSortOrder ASC (DIAMOND=1, GOLD=2, SILVER=3, NORMAL=4)
      * 2. updatedAt DESC (newest first within each VIP tier)
+     *
+     * Owner requests (the seller's own "My Listings" dashboard) skip the VIP-tier
+     * grouping entirely — a seller looking at only their own listings expects
+     * "Newest"/"Oldest" to be a plain date sort, not grouped by package tier.
      *
      * User can specify additional sorting criteria which will be applied AFTER the default sorting
      *
      * @param sortBy Sort field name (postDate, price, area, createdAt, updatedAt)
      * @param sortDirection Sort direction (ASC or DESC)
+     * @param isOwnerRequest true for the seller's own listings dashboard
      * @return Sort object for JPA query
      */
-    private Sort buildSort(String sortBy, String sortDirection) {
-        // Default sorting: vipTypeSortOrder ASC, then updatedAt DESC
-        Sort defaultSort = Sort.by(Sort.Direction.ASC, "vipTypeSortOrder")
-                .and(Sort.by(Sort.Direction.DESC, "updatedAt"));
+    private Sort buildSort(String sortBy, String sortDirection, boolean isOwnerRequest) {
+        Sort defaultSort = isOwnerRequest
+                ? Sort.by(Sort.Direction.DESC, "updatedAt")
+                : Sort.by(Sort.Direction.ASC, "vipTypeSortOrder")
+                        .and(Sort.by(Sort.Direction.DESC, "updatedAt"));
 
         // If user specifies custom sorting, apply it
         if (sortBy != null && !sortBy.isEmpty()) {
@@ -201,10 +208,14 @@ public class ListingQueryService {
             // NEWEST/OLDEST replace default sort entirely (otherwise updatedAt conflicts)
             // PRICE_ASC/PRICE_DESC prepend price sort before default
             return switch (sortBy) {
-                case "NEWEST" -> Sort.by(Sort.Direction.ASC, "vipTypeSortOrder")
-                        .and(Sort.by(Sort.Direction.DESC, "updatedAt"));
-                case "OLDEST" -> Sort.by(Sort.Direction.ASC, "vipTypeSortOrder")
-                        .and(Sort.by(Sort.Direction.ASC, "updatedAt"));
+                case "NEWEST" -> isOwnerRequest
+                        ? Sort.by(Sort.Direction.DESC, "updatedAt")
+                        : Sort.by(Sort.Direction.ASC, "vipTypeSortOrder")
+                                .and(Sort.by(Sort.Direction.DESC, "updatedAt"));
+                case "OLDEST" -> isOwnerRequest
+                        ? Sort.by(Sort.Direction.ASC, "updatedAt")
+                        : Sort.by(Sort.Direction.ASC, "vipTypeSortOrder")
+                                .and(Sort.by(Sort.Direction.ASC, "updatedAt"));
                 case "PRICE_ASC" -> Sort.by(Sort.Direction.ASC, "price")
                         .and(defaultSort);
                 case "PRICE_DESC" -> Sort.by(Sort.Direction.DESC, "price")

--- a/smart-rent/src/test/java/com/smartrent/service/listing/ListingQueryServiceOwnerSortTest.java
+++ b/smart-rent/src/test/java/com/smartrent/service/listing/ListingQueryServiceOwnerSortTest.java
@@ -1,0 +1,102 @@
+package com.smartrent.service.listing;
+
+import com.smartrent.dto.request.ListingFilterRequest;
+import com.smartrent.infra.repository.ListingRepository;
+import com.smartrent.infra.repository.entity.Listing;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+/**
+ * getMyListings (isOwnerRequest=true) must sort strictly by date, ignoring
+ * vipTypeSortOrder — a seller looking at only their own listings should not see
+ * them regrouped by package tier when sorting by "Newest"/"Oldest". Public/admin
+ * requests (isOwnerRequest=false) keep the existing VIP-first ordering.
+ */
+@ExtendWith(MockitoExtension.class)
+class ListingQueryServiceOwnerSortTest {
+
+    @Mock
+    ListingRepository listingRepository;
+
+    @InjectMocks
+    ListingQueryService service;
+
+    private static ListingFilterRequest.ListingFilterRequestBuilder baseFilter() {
+        return ListingFilterRequest.builder().page(1).size(10);
+    }
+
+    private Sort captureSort(ListingFilterRequest filter) {
+        when(listingRepository.findAll(any(Specification.class), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of()));
+
+        service.executeQuery(filter);
+
+        ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
+        org.mockito.Mockito.verify(listingRepository)
+                .findAll(any(Specification.class), pageableCaptor.capture());
+        return pageableCaptor.getValue().getSort();
+    }
+
+    @Test
+    void ownerRequest_newest_sortsByUpdatedAtOnly_noVipTierGrouping() {
+        ListingFilterRequest filter = baseFilter()
+                .isOwnerRequest(true)
+                .sortBy("NEWEST")
+                .build();
+
+        Sort sort = captureSort(filter);
+
+        assertEquals(Sort.by(Sort.Direction.DESC, "updatedAt"), sort);
+    }
+
+    @Test
+    void ownerRequest_oldest_sortsByUpdatedAtOnly_noVipTierGrouping() {
+        ListingFilterRequest filter = baseFilter()
+                .isOwnerRequest(true)
+                .sortBy("OLDEST")
+                .build();
+
+        Sort sort = captureSort(filter);
+
+        assertEquals(Sort.by(Sort.Direction.ASC, "updatedAt"), sort);
+    }
+
+    @Test
+    void ownerRequest_noSortBy_defaultsToUpdatedAtDesc_noVipTierGrouping() {
+        ListingFilterRequest filter = baseFilter()
+                .isOwnerRequest(true)
+                .build();
+
+        Sort sort = captureSort(filter);
+
+        assertEquals(Sort.by(Sort.Direction.DESC, "updatedAt"), sort);
+    }
+
+    @Test
+    void publicRequest_newest_stillGroupsByVipTierFirst() {
+        ListingFilterRequest filter = baseFilter()
+                .sortBy("NEWEST")
+                .build();
+
+        Sort sort = captureSort(filter);
+
+        Sort expected = Sort.by(Sort.Direction.ASC, "vipTypeSortOrder")
+                .and(Sort.by(Sort.Direction.DESC, "updatedAt"));
+        assertEquals(expected, sort);
+    }
+}


### PR DESCRIPTION
getMyListings shared the same buildSort() as public search, which always prepends vipTypeSortOrder ASC before updatedAt — grouping a seller's own listings by package tier (DIAMOND/GOLD/SILVER/NORMAL) even when they pick "Newest"/"Oldest". Skip the VIP-tier prefix when filter.isOwnerRequest is set so the owner dashboard sorts purely by date; public/admin search keep the existing VIP-first ordering.