### PR TITLE
fix: don't push realtime socket notification on report resolution

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/service/notification/NotificationService.java
+++ b/smart-rent/src/main/java/com/smartrent/service/notification/NotificationService.java
@@ -20,6 +20,16 @@ public interface NotificationService {
                           Long referenceId, String referenceType);
 
     /**
+     * Create a notification for a specific recipient, optionally skipping the
+     * realtime WebSocket push. When {@code pushRealtime} is false the notification
+     * is still persisted and shows up the next time the recipient checks their
+     * notifications (poll / open the notification list) — it just isn't delivered live.
+     */
+    void sendNotification(String recipientId, RecipientType recipientType,
+                          NotificationType type, String title, String message,
+                          Long referenceId, String referenceType, boolean pushRealtime);
+
+    /**
      * Create and send a notification to ALL admins.
      */
     void sendToAllAdmins(NotificationType type, String title, String message,

--- a/smart-rent/src/main/java/com/smartrent/service/notification/impl/NotificationServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/notification/impl/NotificationServiceImpl.java
@@ -37,6 +37,14 @@ public class NotificationServiceImpl implements NotificationService {
     public void sendNotification(String recipientId, RecipientType recipientType,
                                  NotificationType type, String title, String message,
                                  Long referenceId, String referenceType) {
+        sendNotification(recipientId, recipientType, type, title, message, referenceId, referenceType, true);
+    }
+
+    @Override
+    @Transactional
+    public void sendNotification(String recipientId, RecipientType recipientType,
+                                 NotificationType type, String title, String message,
+                                 Long referenceId, String referenceType, boolean pushRealtime) {
         try {
             Notification notification = Notification.builder()
                     .recipientId(recipientId)
@@ -50,6 +58,10 @@ public class NotificationServiceImpl implements NotificationService {
 
             Notification saved = notificationRepository.save(notification);
             log.info("Notification saved: type={}, recipient={}:{}", type, recipientType, recipientId);
+
+            if (!pushRealtime) {
+                return;
+            }
 
             // Send WebSocket AFTER transaction commits to avoid race condition
             // where frontend queries DB before TX is visible.

--- a/smart-rent/src/main/java/com/smartrent/service/report/impl/ListingReportServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/report/impl/ListingReportServiceImpl.java
@@ -285,7 +285,9 @@ public class ListingReportServiceImpl implements ListingReportService {
         // Notify the listing owner about the resolution
         sendOwnerNotificationEmail(savedReport, newStatus);
 
-        // Realtime notification: notify reporter
+        // In-app notification: notify reporter. Saved for the user to see next time
+        // they check their notifications — no realtime WebSocket push for report
+        // resolutions, so this doesn't interrupt them with a live toast/badge.
         NotificationType reporterNotifType = (newStatus == ReportStatus.RESOLVED)
                 ? NotificationType.REPORT_RESOLVED : NotificationType.REPORT_REJECTED;
         if (report.getReporterEmail() != null) {
@@ -295,10 +297,10 @@ public class ListingReportServiceImpl implements ListingReportService {
                             reporterNotifType,
                             "Báo cáo của bạn đã được xem xét",
                             "Báo cáo #" + reportId + " của bạn đã được " + newStatus.name().toLowerCase() + ".",
-                            reportId, "REPORT"));
+                            reportId, "REPORT", false));
         }
 
-        // Realtime notification: notify listing owner
+        // In-app notification: notify listing owner (same no-realtime-push behavior).
         Listing listing = listingRepository.findById(report.getListingId()).orElse(null);
         if (listing != null && listing.getUserId() != null) {
             notificationService.sendNotification(
@@ -306,7 +308,7 @@ public class ListingReportServiceImpl implements ListingReportService {
                     reporterNotifType,
                     "Báo cáo về tin đăng của bạn đã được xem xét",
                     "Một báo cáo về tin đăng \"" + listing.getTitle() + "\" của bạn đã được " + newStatus.name().toLowerCase() + ".",
-                    listing.getListingId(), "LISTING");
+                    listing.getListingId(), "LISTING", false);
         }
 
         // If admin resolved and owner action is required, delegate to moderation service


### PR DESCRIPTION
Reporter/owner notifications for resolved or rejected reports are still persisted so users see them next time they check, but no longer pushed live over WebSocket.