### PR TITLE
feat(price): pass through AI price-suggestion evidence fields

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/controller/HousingPredictorController.java
+++ b/smart-rent/src/main/java/com/smartrent/controller/HousingPredictorController.java
@@ -54,7 +54,10 @@ public class HousingPredictorController {
                             },
                             "location": "My Tho, Tien Giang",
                             "property_type": "House",
-                            "currency": "VND"
+                            "currency": "VND",
+                            "source": "ai_comparables",
+                            "listings_found": 12,
+                            "confidence": "medium"
                           }
                         }
                         """

--- a/smart-rent/src/main/java/com/smartrent/dto/response/HousingPredictorResponse.java
+++ b/smart-rent/src/main/java/com/smartrent/dto/response/HousingPredictorResponse.java
@@ -25,7 +25,20 @@ public class HousingPredictorResponse {
     @JsonProperty("currency")
     @Schema(description = "Currency code for the price", example = "VND")
     private String currency;
-    
+
+    @JsonProperty("source")
+    @Schema(description = "How the range was produced: 'ai_comparables' means it was derived from real listings; 'rule_based_fallback' means the AI path failed and a hardcoded table was used",
+            example = "ai_comparables", allowableValues = {"ai_comparables", "rule_based_fallback"})
+    private String source;
+
+    @JsonProperty("listings_found")
+    @Schema(description = "Number of comparable listings actually used as evidence. 0 means the range is not backed by market data", example = "12")
+    private Integer listingsFound;
+
+    @JsonProperty("confidence")
+    @Schema(description = "Confidence in the estimate", example = "medium", allowableValues = {"high", "medium", "low"})
+    private String confidence;
+
     @Getter
     @Setter
     @Schema(description = "Price range with minimum and maximum values")


### PR DESCRIPTION
## Vấn đề

`HousingPredictorResponse` là target deserialize của Feign khi gọi sang smartrent-ai. smartrent-ai#89 thêm 3 field mới vào response của AI service; nếu Java DTO không khai báo, Jackson sẽ **âm thầm bỏ** chúng và FE không bao giờ nhận được.

## Thay đổi

Thêm 3 field passthrough vào `HousingPredictorResponse`:

| Field | Kiểu | Ý nghĩa |
|---|---|---|
| `source` | String | `ai_comparables` = suy ra từ tin đăng thật; `rule_based_fallback` = đường AI lỗi, dùng bảng hardcode |
| `listings_found` | Integer | Số tin comparable thực sự dùng làm bằng chứng. 0 = khoảng giá không có dữ liệu thị trường đỡ |
| `confidence` | String | `high` / `medium` / `low` |

Cập nhật luôn ví dụ Swagger trong `HousingPredictorController` cho khớp.

Không có thay đổi logic — controller/service vẫn là proxy thuần.

## Kiểm chứng

```
./gradlew compileJava → EXIT=0
```

## Thứ tự merge

Merge được độc lập, các field sẽ null cho tới khi smartrent-ai#89 deploy.