### PR TITLE
fix(listing): distinct error code for media already consumed by a listing

### DIFF
--- a/smart-rent/scripts/cleanup_orphan_drafts.sql
+++ b/smart-rent/scripts/cleanup_orphan_drafts.sql
@@ -1,0 +1,55 @@
+-- Clean up drafts that were already published.
+--
+-- Background
+-- ----------
+-- A draft's media_ids is a CSV of media rows. Publishing a draft creates a listing
+-- and stamps media.listing_id, so a media row can only ever belong to one listing.
+-- The draft is then supposed to be deleted.
+--
+-- Until the fix that ships with this script, the payment path lost the draft id on
+-- the way to the gateway (the client read `listingId` off a response that returns
+-- `draftId`), so the draft survived a successful payment. Reopening such a draft and
+-- publishing it again fails with:
+--
+--     Media <id> is already linked to listing <id>
+--
+-- Those drafts are dead weight: the listing they describe already exists. This script
+-- finds and removes them.
+--
+-- Usage: run STEP 1, eyeball the rows, then run STEP 2 in the same session.
+--   mysql --default-character-set=utf8mb4 -u <user> -p <db> < cleanup_orphan_drafts.sql
+-- (the charset flag matters on Windows, where the client defaults to cp850)
+
+
+-- STEP 1 — inspect. Every row here is a draft whose media already belongs to a
+-- published listing, i.e. a draft that was published and never cleaned up.
+SELECT d.draft_id,
+       d.user_id,
+       d.title,
+       d.updated_at,
+       GROUP_CONCAT(DISTINCT m.listing_id ORDER BY m.listing_id) AS published_as_listing_ids,
+       COUNT(DISTINCT m.media_id)                                AS consumed_media_count
+FROM listing_drafts d
+         JOIN media m ON FIND_IN_SET(m.media_id, d.media_ids) > 0
+WHERE d.media_ids IS NOT NULL
+  AND d.media_ids <> ''
+  AND m.listing_id IS NOT NULL
+GROUP BY d.draft_id, d.user_id, d.title, d.updated_at
+ORDER BY d.updated_at DESC;
+
+
+-- STEP 2 — delete. Same predicate as STEP 1, so it removes exactly the rows above.
+-- Guarded by an explicit transaction: check the row count before committing.
+START TRANSACTION;
+
+DELETE d
+FROM listing_drafts d
+WHERE d.media_ids IS NOT NULL
+  AND d.media_ids <> ''
+  AND EXISTS (SELECT 1
+              FROM media m
+              WHERE FIND_IN_SET(m.media_id, d.media_ids) > 0
+                AND m.listing_id IS NOT NULL);
+
+-- Expect the same count as STEP 1 returned. If it differs, ROLLBACK instead.
+COMMIT;

--- a/smart-rent/src/main/java/com/smartrent/infra/exception/model/DomainCode.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/exception/model/DomainCode.java
@@ -101,6 +101,10 @@ public enum DomainCode {
   LISTING_CREATION_CACHE_NOT_FOUND("12001", HttpStatus.NOT_FOUND, "Listing creation request not found in cache"),
   LISTING_CREATION_PAYMENT_FAILED("12002", HttpStatus.PAYMENT_REQUIRED, "Payment failed for listing creation"),
   LISTING_ALREADY_EXISTS_FOR_TRANSACTION("12003", HttpStatus.CONFLICT, "Listing already exists for this transaction"),
+  // Raised when a publish reuses media that a previous publish already consumed — in
+  // practice the draft was published before and the client is republishing a stale copy.
+  LISTING_MEDIA_ALREADY_LINKED("12004", HttpStatus.CONFLICT,
+      "Media %s is already linked to listing %s"),
   //    Quota Error 13xxx
   INSUFFICIENT_QUOTA("13001", HttpStatus.BAD_REQUEST, "Insufficient quota: %s"),
   BENEFIT_NOT_FOUND("13002", HttpStatus.NOT_FOUND, "Membership benefit not found: %s"),

--- a/smart-rent/src/main/java/com/smartrent/service/listing/impl/ListingServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/listing/impl/ListingServiceImpl.java
@@ -920,9 +920,11 @@ public class ListingServiceImpl implements ListingService {
                         "Media " + mediaId + " is not active (status: " + media.getStatus() + ")");
             }
 
-            // Validate media is not already linked to another listing
+            // Validate media is not already linked to another listing.
+            // Distinct code (not a generic 400) so the client can tell the user their
+            // draft was already published instead of surfacing a raw internal message.
             if (media.getListing() != null) {
-                throw new AppException(DomainCode.BAD_REQUEST_ERROR,
+                throw new AppException(DomainCode.LISTING_MEDIA_ALREADY_LINKED,
                         "Media " + mediaId + " is already linked to listing " +
                         media.getListing().getListingId());
             }

--- a/smart-rent/src/test/java/com/smartrent/service/listing/impl/ListingServiceImplPublishDraftTest.java
+++ b/smart-rent/src/test/java/com/smartrent/service/listing/impl/ListingServiceImplPublishDraftTest.java
@@ -102,4 +102,23 @@ class ListingServiceImplPublishDraftTest {
         // Quota path: listing already exists, no pending payment -> draft is safe to remove now.
         verify(listingDraftRepository).delete(draft);
     }
+
+    @Test
+    void deletesDraftWhenListingWentStraightToReview() {
+        // What the quota path actually returns: toCreationResponse() only fills
+        // listingId + status, so paymentRequired comes back null rather than false.
+        // The listing is live in the moderation queue ("đang chờ duyệt") and the
+        // draft has to go with it — a null here must not read as "payment pending".
+        Long draftId = 3L;
+        String userId = "user-1";
+        ListingDraft draft = ListingDraft.builder().build();
+        when(listingDraftRepository.findByDraftIdAndUserId(draftId, userId))
+                .thenReturn(Optional.of(draft));
+        doReturn(ListingCreationResponse.builder().listingId(99L).status("CREATED").build())
+                .when(service).createListing(any());
+
+        service.publishDraft(draftId, validPublishRequest(), userId);
+
+        verify(listingDraftRepository).delete(draft);
+    }
 }


### PR DESCRIPTION
## Vấn đề

Đăng lại một draft đã từng đăng thành công thì chết ở `linkMediaToListing` với 400 chung chung + message nội bộ:

```
Media 1521051 is already linked to listing 757849
```

Media chỉ thuộc về đúng một listing, nên draft đó **vĩnh viễn không đăng được** — mà user không hiểu vì sao và không có đường thoát nào trong UI.

Vì sao draft còn sót lại: xem PR frontend đi kèm (FE đọc nhầm `listingId` trên response trả về `draftId`, nên sau khi thanh toán thành công draft không được xóa).

## Thay đổi

- Thêm `LISTING_MEDIA_ALREADY_LINKED` (`12004`, 409) thay cho `BAD_REQUEST_ERROR`, để FE nhận diện được và hiển thị "tin này đã được đăng rồi" kèm nút xóa draft.
- Thêm `smart-rent/scripts/cleanup_orphan_drafts.sql` để dọn các draft đã ở trạng thái này trên prod (SELECT để soi trước, DELETE trong transaction).

Không đổi hành vi ngoài mã lỗi: vẫn chặn việc gán media cho listing thứ hai.

## Kiểm tra

- `./gradlew compileJava` — BUILD SUCCESSFUL
- `./gradlew test --tests "*PublishDraftTest*"` — BUILD SUCCESSFUL

Script SQL chưa chạy trên prod — chờ merge rồi chạy off-peak.