### PR TITLE
fix(draft): stop losing the street, the media and the package on publish

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/dto/request/DraftListingRequest.java
+++ b/smart-rent/src/main/java/com/smartrent/dto/request/DraftListingRequest.java
@@ -106,5 +106,14 @@ public class DraftListingRequest {
 
     @Schema(description = "Service fee")
     String serviceFee;
+
+    @Schema(description = "Listing duration in days for the chosen package", example = "30")
+    Integer durationDays;
+
+    @Schema(description = "Whether the listing is to be published with membership quota")
+    Boolean useMembershipQuota;
+
+    @Schema(description = "Membership benefit IDs to spend when publishing with quota")
+    Set<Long> benefitIds;
 }
 

--- a/smart-rent/src/main/java/com/smartrent/dto/response/DraftListingResponse.java
+++ b/smart-rent/src/main/java/com/smartrent/dto/response/DraftListingResponse.java
@@ -114,6 +114,16 @@ public class DraftListingResponse {
             "May be empty if no media uploaded yet.", implementation = MediaResponse.class)
     Set<MediaResponse> media;
 
+    // Package / payment selection, so reopening a draft restores what the user picked
+    @Schema(description = "Listing duration in days for the chosen package", example = "30")
+    Integer durationDays;
+
+    @Schema(description = "Whether the listing is to be published with membership quota")
+    Boolean useMembershipQuota;
+
+    @Schema(description = "Membership benefit IDs to spend when publishing with quota")
+    Set<Long> benefitIds;
+
     // Timestamps
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
     @Schema(description = "Timestamp when draft was created", example = "2024-12-06T10:30:00")

--- a/smart-rent/src/main/java/com/smartrent/infra/repository/entity/ListingDraft.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/entity/ListingDraft.java
@@ -150,6 +150,18 @@ public class ListingDraft {
     @Column(name = "media_ids", length = 500)
     String mediaIds;
 
+    // How the listing is meant to be paid for. Kept on the draft so reopening one
+    // restores the package the user picked instead of silently re-defaulting it.
+    @Column(name = "duration_days")
+    Integer durationDays;
+
+    @Column(name = "use_membership_quota")
+    Boolean useMembershipQuota;
+
+    // Benefit IDs stored as comma-separated string, like amenity_ids/media_ids
+    @Column(name = "benefit_ids", length = 500)
+    String benefitIds;
+
     // Timestamps
     @Column(name = "created_at", updatable = false)
     @CreationTimestamp

--- a/smart-rent/src/main/java/com/smartrent/service/listing/impl/ListingServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/listing/impl/ListingServiceImpl.java
@@ -1337,6 +1337,8 @@ public class ListingServiceImpl implements ListingService {
                 .electricityPrice(request.getElectricityPrice())
                 .internetPrice(request.getInternetPrice())
                 .serviceFee(request.getServiceFee())
+                .durationDays(request.getDurationDays())
+                .useMembershipQuota(request.getUseMembershipQuota())
                 .build();
 
         // Extract address fields if provided (support BOTH legacy AND new structures)
@@ -1394,6 +1396,13 @@ public class ListingServiceImpl implements ListingService {
         // Store media IDs as comma-separated string
         if (request.getMediaIds() != null && !request.getMediaIds().isEmpty()) {
             draft.setMediaIds(request.getMediaIds().stream()
+                    .map(String::valueOf)
+                    .collect(Collectors.joining(",")));
+        }
+
+        // Store the package/quota selection so reopening the draft restores it
+        if (request.getBenefitIds() != null && !request.getBenefitIds().isEmpty()) {
+            draft.setBenefitIds(request.getBenefitIds().stream()
                     .map(String::valueOf)
                     .collect(Collectors.joining(",")));
         }
@@ -2539,6 +2548,19 @@ public class ListingServiceImpl implements ListingService {
                     .collect(Collectors.joining(",")));
         }
 
+        // Update the package/quota selection if provided
+        if (request.getDurationDays() != null) {
+            draft.setDurationDays(request.getDurationDays());
+        }
+        if (request.getUseMembershipQuota() != null) {
+            draft.setUseMembershipQuota(request.getUseMembershipQuota());
+        }
+        if (request.getBenefitIds() != null) {
+            draft.setBenefitIds(request.getBenefitIds().stream()
+                    .map(String::valueOf)
+                    .collect(Collectors.joining(",")));
+        }
+
         // Save draft
         ListingDraft savedDraft = listingDraftRepository.save(draft);
         log.info("Draft listing {} updated successfully", draftId);
@@ -2703,9 +2725,28 @@ public class ListingServiceImpl implements ListingService {
                 .serviceFee(draft.getServiceFee())
                 .amenities(amenities)
                 .media(media)
+                .durationDays(draft.getDurationDays())
+                .useMembershipQuota(draft.getUseMembershipQuota())
+                .benefitIds(parseCsvIds(draft.getBenefitIds()))
                 .createdAt(draft.getCreatedAt())
                 .updatedAt(draft.getUpdatedAt())
                 .build();
+    }
+
+    /**
+     * Parse one of the draft's comma-separated id columns. Null/blank yields null so
+     * the response omits the field rather than reporting an empty selection.
+     */
+    private Set<Long> parseCsvIds(String csv) {
+        if (csv == null || csv.isBlank()) {
+            return null;
+        }
+        Set<Long> ids = java.util.Arrays.stream(csv.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .map(Long::parseLong)
+                .collect(Collectors.toSet());
+        return ids.isEmpty() ? null : ids;
     }
 
     /**
@@ -3101,7 +3142,13 @@ public class ListingServiceImpl implements ListingService {
                 NewAddressData newAddr = new NewAddressData();
                 newAddr.setProvinceCode(draft.getProvinceCode());
                 newAddr.setWardCode(draft.getWardCode());
-                newAddr.setStreet(draft.getStreet());
+                // new_street, not street: createDraftListing/updateDraft persist the two
+                // structures' streets to separate columns, and a pure new-address draft
+                // only fills new_street. Reading street here published them with none.
+                // Fall back for drafts that only ever got the legacy column filled.
+                newAddr.setStreet(draft.getNewStreet() != null
+                        ? draft.getNewStreet()
+                        : draft.getStreet());
                 addressReq.setNewAddress(newAddr);
             }
             addressReq.setProjectId(draft.getProjectId() != null ? draft.getProjectId().intValue() : null);
@@ -3110,8 +3157,11 @@ public class ListingServiceImpl implements ListingService {
             merged.setAddress(addressReq);
         }
 
-        // Handle amenity IDs
-        if (request.getAmenityIds() != null) {
+        // Handle amenity IDs.
+        // An empty collection counts as "not provided", the same way createDraftListing
+        // reads it. Treating it as authoritative let a publish body carrying
+        // "amenityIds": [] wipe what the draft had, and the draft is deleted right after.
+        if (request.getAmenityIds() != null && !request.getAmenityIds().isEmpty()) {
             merged.setAmenityIds(request.getAmenityIds());
         } else if (draft.getAmenityIds() != null && !draft.getAmenityIds().isEmpty()) {
             merged.setAmenityIds(java.util.Arrays.stream(draft.getAmenityIds().split(","))
@@ -3121,8 +3171,10 @@ public class ListingServiceImpl implements ListingService {
                     .collect(Collectors.toSet()));
         }
 
-        // Handle media IDs
-        if (request.getMediaIds() != null) {
+        // Handle media IDs — same empty-means-absent rule as amenities above. This one
+        // is the costlier of the two: an empty list published the listing with no photos
+        // at all, after the user had uploaded them into the draft.
+        if (request.getMediaIds() != null && !request.getMediaIds().isEmpty()) {
             merged.setMediaIds(request.getMediaIds());
         } else if (draft.getMediaIds() != null && !draft.getMediaIds().isEmpty()) {
             merged.setMediaIds(java.util.Arrays.stream(draft.getMediaIds().split(","))

--- a/smart-rent/src/main/resources/db/migration/V117__Add_package_fields_to_listing_drafts.sql
+++ b/smart-rent/src/main/resources/db/migration/V117__Add_package_fields_to_listing_drafts.sql
@@ -1,0 +1,15 @@
+-- V117: keep the package/quota selection on a draft.
+--
+-- listing_drafts stored vip_type but none of the three fields that decide HOW a
+-- listing gets paid for. Reopening a draft therefore lost them: the create-post
+-- form re-defaulted duration to 10 days from today, and with benefit_ids and
+-- use_membership_quota gone the UI flipped the CTA from "Đăng tin" to "Thanh
+-- toán" — asking the user to pay for a listing their membership already covers.
+--
+-- benefit_ids is a comma-separated list, matching the existing amenity_ids /
+-- media_ids columns on this table.
+
+ALTER TABLE listing_drafts
+    ADD COLUMN duration_days INT NULL AFTER vip_type,
+    ADD COLUMN use_membership_quota BOOLEAN NOT NULL DEFAULT FALSE AFTER duration_days,
+    ADD COLUMN benefit_ids VARCHAR(500) NULL AFTER use_membership_quota;

--- a/smart-rent/src/test/java/com/smartrent/service/listing/impl/ListingServiceImplPublishDraftTest.java
+++ b/smart-rent/src/test/java/com/smartrent/service/listing/impl/ListingServiceImplPublishDraftTest.java
@@ -15,6 +15,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.math.BigDecimal;
 import java.util.Optional;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
@@ -101,6 +102,56 @@ class ListingServiceImplPublishDraftTest {
 
         // Quota path: listing already exists, no pending payment -> draft is safe to remove now.
         verify(listingDraftRepository).delete(draft);
+    }
+
+    @Test
+    void publishesNewAddressDraftWithItsOwnStreet() {
+        // A pure new-address draft only fills new_street; street stays null. Reading the
+        // legacy column here published the listing with no street at all, and the draft
+        // screen hid it by rendering new_street correctly.
+        Long draftId = 4L;
+        String userId = "user-1";
+        ListingDraft draft = ListingDraft.builder()
+                .addressType("NEW")
+                .provinceCode("79")
+                .wardCode("26734")
+                .newStreet("Nguyễn Huệ")
+                .build();
+        when(listingDraftRepository.findByDraftIdAndUserId(draftId, userId))
+                .thenReturn(Optional.of(draft));
+        doReturn(ListingCreationResponse.builder().listingId(1L).build())
+                .when(service).createListing(any());
+
+        ListingCreationRequest request = validPublishRequest();
+        request.setAddress(null); // client sends no address -> merge must fall back to the draft
+
+        service.publishDraft(draftId, request, userId);
+
+        ArgumentCaptor<ListingCreationRequest> captor = ArgumentCaptor.forClass(ListingCreationRequest.class);
+        verify(service).createListing(captor.capture());
+        assertEquals("Nguyễn Huệ", captor.getValue().getAddress().getNewAddress().getStreet());
+    }
+
+    @Test
+    void emptyMediaIdsInPublishBodyDoesNotWipeTheDraftsMedia() {
+        // "mediaIds": [] used to count as authoritative, so the listing published with no
+        // photos and the draft holding them was deleted immediately after.
+        Long draftId = 5L;
+        String userId = "user-1";
+        ListingDraft draft = ListingDraft.builder().mediaIds("11,22,33").build();
+        when(listingDraftRepository.findByDraftIdAndUserId(draftId, userId))
+                .thenReturn(Optional.of(draft));
+        doReturn(ListingCreationResponse.builder().listingId(1L).build())
+                .when(service).createListing(any());
+
+        ListingCreationRequest request = validPublishRequest();
+        request.setMediaIds(Set.of());
+
+        service.publishDraft(draftId, request, userId);
+
+        ArgumentCaptor<ListingCreationRequest> captor = ArgumentCaptor.forClass(ListingCreationRequest.class);
+        verify(service).createListing(captor.capture());
+        assertEquals(Set.of(11L, 22L, 33L), captor.getValue().getMediaIds());
     }
 
     @Test


### PR DESCRIPTION
Ba cách mà một bản nháp đăng lên **khác với thứ user đã lưu**. Tìm ra khi rà lại toàn bộ luồng draft.

## 1. Mất tên đường với địa chỉ cấu trúc mới

`mergeDraftWithRequest` ở nhánh `NEW` đọc `draft.getStreet()` — cột **legacy** — trong khi `createDraftListing`/`updateDraft` ghi street của cấu trúc mới vào `new_street`. Nháp địa chỉ mới thuần túy có `street = NULL`, nên đăng lên **không có tên đường**.

Bug bị che kỹ: `GET /draft/{id}` đọc `new_street` đúng, nên màn hình xem nháp vẫn hiện địa chỉ đầy đủ — chỉ sau khi đăng mới lộ.

## 2. `"mediaIds": []` xoá sạch ảnh của nháp

`mediaIds`/`amenityIds` coi collection rỗng do client gửi là quyết định cuối cùng: `[]` **đè** lên nháp thay vì fallback về nó. Kết quả: tin đăng lên **không ảnh nào**, rồi vài dòng sau nháp giữ ảnh đó bị xoá luôn.

Giờ rỗng = "không gửi", đúng như `createDraftListing` vốn đã đọc chính field đó (`!= null && !isEmpty()`).

## 3. Nháp không nhớ gói đã chọn

`listing_drafts` không có cột cho `durationDays` / `useMembershipQuota` / `benefitIds` — chỉ có `vip_type`. Mở lại nháp là mất gói đã chọn: form tự đặt lại thời hạn, và vì hai field quota biến mất, CTA đổi từ **"Đăng tin"** sang **"Thanh toán"** — đòi user trả tiền cho tin mà hội viên đã bao.

`V117` thêm ba cột, và chúng round-trip qua create / update / draft response.

## Kiểm tra

- `./gradlew compileJava` — BUILD SUCCESSFUL
- `./gradlew test --tests "*PublishDraftTest*"` — 6 passed

Hai test mới (`publishesNewAddressDraftWithItsOwnStreet`, `emptyMediaIdsInPublishBodyDoesNotWipeTheDraftsMedia`) đã được xác nhận **FAIL** khi stash bản fix ra rồi chạy lại — chúng thật sự bắt được bug chứ không chỉ pass thụ động.

## Lưu ý

Phần FE đọc ba field mới ở `mapDraftToFormData` sẽ đi trong PR frontend riêng, và cần PR này lên trước.