### PR TITLE
feat(price): rate-limit price-suggestion, authenticate its Feign calls, fix guest chat IP

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/config/ai/AiFeignClientConfig.java
+++ b/smart-rent/src/main/java/com/smartrent/config/ai/AiFeignClientConfig.java
@@ -1,0 +1,29 @@
+package com.smartrent.config.ai;
+
+import feign.RequestInterceptor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * Feign configuration for the smartrent-ai client, wired via
+ * {@code @FeignClient(configuration = ...)} on {@code SmartRentAiConnector}
+ * rather than {@code @Configuration}. A {@code @Configuration}-annotated
+ * class here would be picked up by Spring's component scan and applied to
+ * every Feign client (Google, Brevo, ...), leaking the internal shared
+ * secret onto requests that have nothing to do with the AI service.
+ *
+ * <p>Mirrors {@link AiWebClientConfig}, which sends the same header on the
+ * WebClient used for chat streaming.
+ */
+public class AiFeignClientConfig {
+
+  @Bean
+  public RequestInterceptor aiInternalApiKeyInterceptor(
+      @Value("${ai.internal-api-key:}") String internalApiKey) {
+    return requestTemplate -> {
+      if (internalApiKey != null && !internalApiKey.isBlank()) {
+        requestTemplate.header("X-Internal-Api-Key", internalApiKey);
+      }
+    };
+  }
+}

--- a/smart-rent/src/main/java/com/smartrent/controller/ChatController.java
+++ b/smart-rent/src/main/java/com/smartrent/controller/ChatController.java
@@ -6,6 +6,7 @@ import com.smartrent.dto.response.ChatResponse;
 import com.smartrent.service.ai.ChatRateLimitService;
 import com.smartrent.service.ai.ChatService;
 import com.smartrent.service.ai.ChatStreamService;
+import com.smartrent.util.ClientIpResolver;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
@@ -159,10 +160,15 @@ public class ChatController {
       @Valid @RequestBody ChatRequest request,
       HttpServletRequest httpRequest) {
     Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+    // Guests may stream chat (see OPTIONAL_AUTH_POST_PATTERNS), and for them the
+    // identity is the client IP. getRemoteAddr() resolves to Caddy behind the
+    // reverse proxy, which collapsed every anonymous caller into one shared
+    // bucket; ClientIpResolver reads X-Forwarded-For so the per-IP cap the
+    // config describes is actually per-IP.
     String identity = (auth != null && auth.isAuthenticated()
         && !"anonymousUser".equals(auth.getName()))
         ? auth.getName()
-        : httpRequest.getRemoteAddr();
+        : ClientIpResolver.resolve(httpRequest);
 
     if (!chatRateLimitService.tryConsume(identity)) {
       throw new ResponseStatusException(HttpStatus.TOO_MANY_REQUESTS, "Chat rate limit exceeded");

--- a/smart-rent/src/main/java/com/smartrent/controller/HousingPredictorController.java
+++ b/smart-rent/src/main/java/com/smartrent/controller/HousingPredictorController.java
@@ -4,6 +4,8 @@ import com.smartrent.dto.request.HousingPredictorRequest;
 import com.smartrent.dto.response.ApiResponse;
 import com.smartrent.dto.response.HousingPredictorResponse;
 import com.smartrent.service.predictor.HousingPredictorService;
+import com.smartrent.service.predictor.PriceSuggestionRateLimitService;
+import com.smartrent.util.ClientIpResolver;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -11,14 +13,19 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
 
 @Slf4j
 @RestController
@@ -28,6 +35,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class HousingPredictorController {
 
     private final HousingPredictorService housingPredictorService;
+    private final PriceSuggestionRateLimitService priceSuggestionRateLimitService;
 
     @PostMapping("/predict")
     @Operation(
@@ -96,10 +104,25 @@ public class HousingPredictorController {
                     )
                 )
             )
-            @Valid @RequestBody HousingPredictorRequest request) {
-        
+            @Valid @RequestBody HousingPredictorRequest request,
+            HttpServletRequest httpRequest) {
+
+        // Endpoint is public (no auth required) but each call runs a multi-turn
+        // LLM agent, so it still needs a per-identity cap. Prefer the
+        // authenticated username — the create-listing wizard that calls this
+        // is only reachable logged-in, and the FE attaches the JWT — falling
+        // back to client IP for any caller that isn't authenticated.
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        String identity = (auth != null && auth.isAuthenticated() && !"anonymousUser".equals(auth.getName()))
+                ? auth.getName()
+                : ClientIpResolver.resolve(httpRequest);
+
+        if (!priceSuggestionRateLimitService.tryConsume(identity)) {
+            throw new ResponseStatusException(HttpStatus.TOO_MANY_REQUESTS, "Price suggestion rate limit exceeded");
+        }
+
         log.info("Received housing price prediction request: {}", request);
-        
+
         HousingPredictorResponse response = housingPredictorService.predictHousingPrice(request);
         
         return ResponseEntity.ok(ApiResponse.<HousingPredictorResponse>builder()

--- a/smart-rent/src/main/java/com/smartrent/infra/connector/SmartRentAiConnector.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/connector/SmartRentAiConnector.java
@@ -1,5 +1,6 @@
 package com.smartrent.infra.connector;
 
+import com.smartrent.config.ai.AiFeignClientConfig;
 import com.smartrent.dto.request.AIRecommendationRequest;
 import com.smartrent.dto.request.ChatRequest;
 import com.smartrent.dto.request.HousingPredictorRequest;
@@ -22,7 +23,10 @@ import com.smartrent.dto.response.ListingVerificationResponse;
 import java.util.List;
 import org.springframework.web.bind.annotation.RequestHeader;
 
-@FeignClient(name = "smartrent-ai", url = "${feign.client.config.smartrent-ai.url}")
+@FeignClient(
+    name = "smartrent-ai",
+    url = "${feign.client.config.smartrent-ai.url}",
+    configuration = AiFeignClientConfig.class)
 public interface SmartRentAiConnector {
 
   /**

--- a/smart-rent/src/main/java/com/smartrent/service/ai/ChatRateLimitService.java
+++ b/smart-rent/src/main/java/com/smartrent/service/ai/ChatRateLimitService.java
@@ -1,6 +1,6 @@
 package com.smartrent.service.ai;
 
-import java.time.Duration;
+import com.smartrent.service.ratelimit.FixedWindowRateLimiter;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
@@ -9,32 +9,28 @@ import org.springframework.stereotype.Service;
  * Per-identity fixed-window rate limiter for the chat SSE endpoint. Each chat
  * call costs LLM tokens, so this caps usage per user/IP on top of Caddy's
  * coarser per-IP gateway limit.
+ *
+ * <p>Thin wrapper around {@link FixedWindowRateLimiter}: this class exists so
+ * chat keeps its own constructor, config properties and Redis key prefix
+ * (unaffected by other limiters), while the INCR/EXPIRE mechanics live in one
+ * shared place.
  */
 @Service
 public class ChatRateLimitService {
 
   private static final String KEY_PREFIX = "chat:ratelimit:";
 
-  private final StringRedisTemplate redisTemplate;
-  private final int maxPerWindow;
-  private final int windowSeconds;
+  private final FixedWindowRateLimiter rateLimiter;
 
   public ChatRateLimitService(
       StringRedisTemplate redisTemplate,
       @Value("${chat.rate-limit.max-per-window:20}") int maxPerWindow,
       @Value("${chat.rate-limit.window-seconds:60}") int windowSeconds) {
-    this.redisTemplate = redisTemplate;
-    this.maxPerWindow = maxPerWindow;
-    this.windowSeconds = windowSeconds;
+    this.rateLimiter = new FixedWindowRateLimiter(redisTemplate, KEY_PREFIX, maxPerWindow, windowSeconds);
   }
 
   /** Returns true when the call is within the limit for the current window. */
   public boolean tryConsume(String identity) {
-    String key = KEY_PREFIX + identity;
-    Long count = redisTemplate.opsForValue().increment(key);
-    if (count != null && count == 1L) {
-      redisTemplate.expire(key, Duration.ofSeconds(windowSeconds));
-    }
-    return count != null && count <= maxPerWindow;
+    return rateLimiter.tryConsume(identity);
   }
 }

--- a/smart-rent/src/main/java/com/smartrent/service/predictor/PriceSuggestionRateLimitService.java
+++ b/smart-rent/src/main/java/com/smartrent/service/predictor/PriceSuggestionRateLimitService.java
@@ -1,0 +1,32 @@
+package com.smartrent.service.predictor;
+
+import com.smartrent.service.ratelimit.FixedWindowRateLimiter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+/**
+ * Per-identity fixed-window rate limiter for the price-suggestion endpoint.
+ * Each call runs an LLM agent for up to 12 turns — far costlier than a single
+ * chat turn — so the default cap is much tighter than chat's, and it uses its
+ * own Redis key prefix so the two never share a budget.
+ */
+@Service
+public class PriceSuggestionRateLimitService {
+
+  private static final String KEY_PREFIX = "price-suggestion:ratelimit:";
+
+  private final FixedWindowRateLimiter rateLimiter;
+
+  public PriceSuggestionRateLimitService(
+      StringRedisTemplate redisTemplate,
+      @Value("${price-suggestion.rate-limit.max-per-window:5}") int maxPerWindow,
+      @Value("${price-suggestion.rate-limit.window-seconds:60}") int windowSeconds) {
+    this.rateLimiter = new FixedWindowRateLimiter(redisTemplate, KEY_PREFIX, maxPerWindow, windowSeconds);
+  }
+
+  /** Returns true when the call is within the limit for the current window. */
+  public boolean tryConsume(String identity) {
+    return rateLimiter.tryConsume(identity);
+  }
+}

--- a/smart-rent/src/main/java/com/smartrent/service/ratelimit/FixedWindowRateLimiter.java
+++ b/smart-rent/src/main/java/com/smartrent/service/ratelimit/FixedWindowRateLimiter.java
@@ -1,0 +1,42 @@
+package com.smartrent.service.ratelimit;
+
+import java.time.Duration;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+/**
+ * Per-identity fixed-window request counter over Redis: INCRs
+ * {@code <keyPrefix><identity>} and, only on the first hit of a window, sets
+ * that key's TTL to {@code windowSeconds}. This is the shared counting logic
+ * behind every per-identity rate limiter in the app (chat, price-suggestion,
+ * ...) — each of those owns its own key prefix/limit/window so their buckets
+ * never collide, but the INCR+EXPIRE mechanics only need to be correct once.
+ *
+ * <p>Not a Spring bean: each caller supplies its own key prefix and limits
+ * (typically sourced from its own {@code @Value}-annotated constructor), so
+ * a single shared singleton would not make sense here.
+ */
+public class FixedWindowRateLimiter {
+
+  private final StringRedisTemplate redisTemplate;
+  private final String keyPrefix;
+  private final int max;
+  private final int windowSeconds;
+
+  public FixedWindowRateLimiter(
+      StringRedisTemplate redisTemplate, String keyPrefix, int max, int windowSeconds) {
+    this.redisTemplate = redisTemplate;
+    this.keyPrefix = keyPrefix;
+    this.max = max;
+    this.windowSeconds = windowSeconds;
+  }
+
+  /** Returns true when the call is within the limit for the current window. */
+  public boolean tryConsume(String identity) {
+    String key = keyPrefix + identity;
+    Long count = redisTemplate.opsForValue().increment(key);
+    if (count != null && count == 1L) {
+      redisTemplate.expire(key, Duration.ofSeconds(windowSeconds));
+    }
+    return count != null && count <= max;
+  }
+}

--- a/smart-rent/src/main/java/com/smartrent/util/ClientIpResolver.java
+++ b/smart-rent/src/main/java/com/smartrent/util/ClientIpResolver.java
@@ -1,0 +1,32 @@
+package com.smartrent.util;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+/**
+ * Best-effort client IP resolution behind the Caddy reverse proxy: plain
+ * {@code request.getRemoteAddr()} resolves to Caddy's own address, not the
+ * caller's, so anything that rate-limits or audits by IP needs to read
+ * {@code X-Forwarded-For} first. Mirrors the semantics of
+ * {@code ListingSearchController#extractClientIp} — prefer the first entry
+ * of a comma-separated X-Forwarded-For, else fall back to getRemoteAddr().
+ *
+ * <p>Several controllers (OtpController, ViewController,
+ * PhoneClickDetailController, ListingSearchController) already hand-roll this
+ * same logic with minor variations. This class is for new call sites only;
+ * unifying those existing copies is a separate, out-of-scope change since
+ * they are live.
+ */
+public final class ClientIpResolver {
+
+  private ClientIpResolver() {
+  }
+
+  public static String resolve(HttpServletRequest request) {
+    String forwarded = request.getHeader("X-Forwarded-For");
+    if (forwarded != null && !forwarded.isBlank()) {
+      // X-Forwarded-For may contain a comma-separated list; first entry is the client
+      return forwarded.split(",")[0].trim();
+    }
+    return request.getRemoteAddr();
+  }
+}

--- a/smart-rent/src/main/resources/application.yml
+++ b/smart-rent/src/main/resources/application.yml
@@ -330,6 +330,14 @@ chat:
     max-per-window: ${CHAT_RATE_LIMIT_MAX:20}
     window-seconds: ${CHAT_RATE_LIMIT_WINDOW_SECONDS:60}
 
+# Per-identity rate limit for the price-suggestion endpoint. It's public
+# (no auth required) but each call runs an LLM agent for up to 12 turns, so
+# the cap is much tighter than chat's.
+price-suggestion:
+  rate-limit:
+    max-per-window: ${PRICE_SUGGESTION_RATE_LIMIT_MAX:5}
+    window-seconds: ${PRICE_SUGGESTION_RATE_LIMIT_WINDOW_SECONDS:60}
+
 feign:
   client:
     config:

--- a/smart-rent/src/test/java/com/smartrent/service/predictor/PriceSuggestionRateLimitServiceTest.java
+++ b/smart-rent/src/test/java/com/smartrent/service/predictor/PriceSuggestionRateLimitServiceTest.java
@@ -1,0 +1,68 @@
+package com.smartrent.service.predictor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.ServerSocket;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import redis.embedded.RedisServer;
+
+class PriceSuggestionRateLimitServiceTest {
+
+  private static RedisServer redisServer;
+  private static int port;
+  private StringRedisTemplate redisTemplate;
+
+  @BeforeAll
+  static void startRedis() throws Exception {
+    try (ServerSocket socket = new ServerSocket(0)) {
+      port = socket.getLocalPort();
+    }
+    redisServer = RedisServer.newRedisServer().port(port).build();
+    redisServer.start();
+  }
+
+  @AfterAll
+  static void stopRedis() throws Exception {
+    if (redisServer != null) {
+      redisServer.stop();
+    }
+  }
+
+  @BeforeEach
+  void setUp() {
+    LettuceConnectionFactory cf = new LettuceConnectionFactory("localhost", port);
+    cf.afterPropertiesSet();
+    redisTemplate = new StringRedisTemplate(cf);
+    redisTemplate.afterPropertiesSet();
+    redisTemplate.getConnectionFactory().getConnection().serverCommands().flushAll();
+  }
+
+  @Test
+  void tryConsume_allowsUpToLimitThenBlocks() {
+    PriceSuggestionRateLimitService service = new PriceSuggestionRateLimitService(redisTemplate, 2, 60);
+
+    assertThat(service.tryConsume("user-1")).isTrue();
+    assertThat(service.tryConsume("user-1")).isTrue();
+    assertThat(service.tryConsume("user-1")).isFalse(); // 3rd in window -> blocked
+    assertThat(service.tryConsume("user-2")).isTrue(); // separate identity unaffected
+  }
+
+  @Test
+  void tryConsume_usesOwnBucketSeparateFromChat() {
+    // Same identity string, but chat's rate limiter must not see this service's
+    // counter (or vice versa) since each uses a distinct Redis key prefix.
+    PriceSuggestionRateLimitService priceLimiter = new PriceSuggestionRateLimitService(redisTemplate, 1, 60);
+    com.smartrent.service.ai.ChatRateLimitService chatLimiter =
+        new com.smartrent.service.ai.ChatRateLimitService(redisTemplate, 1, 60);
+
+    assertThat(priceLimiter.tryConsume("shared-identity")).isTrue();
+    assertThat(priceLimiter.tryConsume("shared-identity")).isFalse();
+
+    assertThat(chatLimiter.tryConsume("shared-identity")).isTrue();
+  }
+}

--- a/smart-rent/src/test/java/com/smartrent/service/ratelimit/FixedWindowRateLimiterTest.java
+++ b/smart-rent/src/test/java/com/smartrent/service/ratelimit/FixedWindowRateLimiterTest.java
@@ -1,0 +1,85 @@
+package com.smartrent.service.ratelimit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.ServerSocket;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import redis.embedded.RedisServer;
+
+class FixedWindowRateLimiterTest {
+
+  private static RedisServer redisServer;
+  private static int port;
+  private StringRedisTemplate redisTemplate;
+
+  @BeforeAll
+  static void startRedis() throws Exception {
+    try (ServerSocket socket = new ServerSocket(0)) {
+      port = socket.getLocalPort();
+    }
+    redisServer = RedisServer.newRedisServer().port(port).build();
+    redisServer.start();
+  }
+
+  @AfterAll
+  static void stopRedis() throws Exception {
+    if (redisServer != null) {
+      redisServer.stop();
+    }
+  }
+
+  @BeforeEach
+  void setUp() {
+    LettuceConnectionFactory cf = new LettuceConnectionFactory("localhost", port);
+    cf.afterPropertiesSet();
+    redisTemplate = new StringRedisTemplate(cf);
+    redisTemplate.afterPropertiesSet();
+    redisTemplate.getConnectionFactory().getConnection().serverCommands().flushAll();
+  }
+
+  @Test
+  void tryConsume_allowsUpToLimitThenBlocks() {
+    FixedWindowRateLimiter limiter = new FixedWindowRateLimiter(redisTemplate, "test:ratelimit:", 3, 60);
+
+    assertThat(limiter.tryConsume("user-1")).isTrue();
+    assertThat(limiter.tryConsume("user-1")).isTrue();
+    assertThat(limiter.tryConsume("user-1")).isTrue();
+    assertThat(limiter.tryConsume("user-1")).isFalse(); // 4th in window -> blocked
+    assertThat(limiter.tryConsume("user-2")).isTrue(); // separate identity unaffected
+  }
+
+  @Test
+  void tryConsume_keyPrefixKeepsBucketsIsolated() {
+    // Two limiters over the same identity but different prefixes (e.g. chat
+    // vs price-suggestion) must not share a counter.
+    FixedWindowRateLimiter chatLike = new FixedWindowRateLimiter(redisTemplate, "chat:ratelimit:", 1, 60);
+    FixedWindowRateLimiter priceLike = new FixedWindowRateLimiter(redisTemplate, "price-suggestion:ratelimit:", 1, 60);
+
+    assertThat(chatLike.tryConsume("same-identity")).isTrue();
+    assertThat(chatLike.tryConsume("same-identity")).isFalse();
+
+    // Exhausting the chat-like bucket must not affect the price-suggestion-like one.
+    assertThat(priceLike.tryConsume("same-identity")).isTrue();
+  }
+
+  @Test
+  void tryConsume_setsTtlOnlyOnFirstHit() {
+    FixedWindowRateLimiter limiter = new FixedWindowRateLimiter(redisTemplate, "ttl:ratelimit:", 5, 30);
+    String key = "ttl:ratelimit:user-1";
+
+    limiter.tryConsume("user-1");
+    Long firstTtl = redisTemplate.getExpire(key);
+    assertThat(firstTtl).isNotNull();
+    assertThat(firstTtl).isGreaterThan(0).isLessThanOrEqualTo(30);
+
+    limiter.tryConsume("user-1");
+    Long secondTtl = redisTemplate.getExpire(key);
+    // TTL was set once on the first INCR and must not be reset on subsequent hits.
+    assertThat(secondTtl).isLessThanOrEqualTo(firstTtl);
+  }
+}

--- a/smart-rent/src/test/java/com/smartrent/util/ClientIpResolverTest.java
+++ b/smart-rent/src/test/java/com/smartrent/util/ClientIpResolverTest.java
@@ -1,0 +1,53 @@
+package com.smartrent.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ClientIpResolverTest {
+
+  @Mock HttpServletRequest request;
+
+  @Test
+  void resolve_prefersFirstEntryOfForwardedForList() {
+    when(request.getHeader("X-Forwarded-For")).thenReturn("203.0.113.10, 10.0.0.1, 10.0.0.2");
+
+    assertThat(ClientIpResolver.resolve(request)).isEqualTo("203.0.113.10");
+  }
+
+  @Test
+  void resolve_trimsWhitespaceAroundFirstEntry() {
+    when(request.getHeader("X-Forwarded-For")).thenReturn(" 203.0.113.10 ,10.0.0.1");
+
+    assertThat(ClientIpResolver.resolve(request)).isEqualTo("203.0.113.10");
+  }
+
+  @Test
+  void resolve_fallsBackToRemoteAddrWhenHeaderMissing() {
+    when(request.getHeader("X-Forwarded-For")).thenReturn(null);
+    when(request.getRemoteAddr()).thenReturn("192.168.1.5");
+
+    assertThat(ClientIpResolver.resolve(request)).isEqualTo("192.168.1.5");
+  }
+
+  @Test
+  void resolve_fallsBackToRemoteAddrWhenHeaderBlank() {
+    when(request.getHeader("X-Forwarded-For")).thenReturn("   ");
+    when(request.getRemoteAddr()).thenReturn("192.168.1.5");
+
+    assertThat(ClientIpResolver.resolve(request)).isEqualTo("192.168.1.5");
+  }
+
+  @Test
+  void resolve_singleIpForwardedForIsReturnedAsIs() {
+    when(request.getHeader("X-Forwarded-For")).thenReturn("203.0.113.10");
+
+    assertThat(ClientIpResolver.resolve(request)).isEqualTo("203.0.113.10");
+  }
+}


### PR DESCRIPTION
## Vấn đề

`POST /v1/housing-predictor/predict` proxy sang AI service, nơi **mỗi lần gọi chạy một LLM agent tới 12 turn**, mỗi turn có thể gọi ngược lại backend để tìm tin tương tự. Endpoint này:

- **không có rate limit** nào
- nằm trong danh sách path **public, không auth**
- gọi AI service qua Feign **không kèm shared secret** — trong khi `AiWebClientConfig` đã gắn `X-Internal-Api-Key` cho WebClient của chat từ lâu

Bước định giá trong wizard đăng bài tự động gọi khi mount, nên user đi tới đi lui giữa các step là chạy lại toàn bộ agent.

## Thay đổi

**1. Rút phần đếm fixed-window ra dùng chung.** `FixedWindowRateLimiter` giữ nguyên cơ chế INCR + EXPIRE vốn nằm trong `ChatRateLimitService`. `ChatRateLimitService` trở thành lớp bọc mỏng — **giữ nguyên tuyệt đối** signature, Redis key prefix (`chat:ratelimit:`), tên property và giá trị mặc định. Test sẵn có của chat pass không sửa gì.

**2. `ClientIpResolver`.** `getRemoteAddr()` sau Caddy trả về địa chỉ của Caddy. Bốn controller khác (`Otp`, `View`, `PhoneClickDetail`, `ListingSearch`) đều đã tự parse `X-Forwarded-For` mỗi nơi một kiểu; class này gom lại đúng semantic đó. **Cố ý chỉ dùng cho code mới** — không refactor 4 controller đang chạy, để dành một PR riêng.

**3. Rate limit cho price-suggestion.** Bucket riêng, property riêng, mặc định **5 lần / 60 giây** — chặt hơn hẳn chat (20/60s) vì mỗi lần gọi là một agent run nhiều turn. Identity ưu tiên username đã đăng nhập (wizard đăng bài chỉ vào được khi đã login và FE tự gắn JWT), IP là đường lui.

**4. Feign gửi `X-Internal-Api-Key`.** `AiFeignClientConfig` gắn qua `@FeignClient(configuration = ...)` chứ **không** đánh `@Configuration` — nếu để component scan bắt được, Spring sẽ áp interceptor cho **mọi** Feign client (Google, Brevo…) và rò secret sang những request chẳng liên quan gì tới AI.

`AiServerClient` (Feign client thứ hai, cùng base URL) cố ý **không** nhận interceptor — nó chỉ gọi `/search/parse` và `/search/suggestions`, không nằm trong phạm vi siết lần này.

## 5. Kèm theo: sửa một lỗi thật của chat

Phát hiện trong lúc làm. `application.yml` mô tả `/v1/ai/chat/stream` là optional-auth, khách vãng lai dùng được và được *"IP rate-limited in ChatController"*. Nhưng code dùng `getRemoteAddr()` → sau Caddy là IP của Caddy → **toàn bộ khách vãng lai dùng chung một bucket 20/60s**. Cái cap đó hoạt động như một throttle toàn cục chứ không phải per-IP như config mô tả.

Sửa bằng chính `ClientIpResolver` ở trên. User đã đăng nhập không bị ảnh hưởng (vốn key theo username). Thay đổi này **nới** một giới hạn vô tình mang tính toàn cục thành giới hạn theo từng người — nên không ai đang dùng bình thường lại bắt đầu bị chặn.

## Kiểm chứng

```
./gradlew compileJava compileTestJava   BUILD SUCCESSFUL
11/11 test pass — FixedWindowRateLimiter 3, ClientIpResolver 5,
PriceSuggestionRateLimitService 2, ChatRateLimitServiceTest 1 (có sẵn,
không sửa → xác nhận hành vi chat không đổi)
```

## Cấu hình

```yaml
price-suggestion:
  rate-limit:
    max-per-window: ${PRICE_SUGGESTION_RATE_LIMIT_MAX:5}
    window-seconds: ${PRICE_SUGGESTION_RATE_LIMIT_WINDOW_SECONDS:60}
```

## Thứ tự deploy — quan trọng

PR đồng hành bên smartrent-ai gắn `require_internal_key` cho route price-suggestion. Dependency đó **fail open** khi `INTERNAL_AI_API_KEY` chưa set, nên deploy lệch nhau không gãy gì.

Nhưng khi bật secret thì phải **set đồng thời cả hai phía**. Set ở AI mà quên set `ai.internal-api-key` ở Java → định giá 401 ngay.

## Nên theo dõi sau khi deploy

5 lần/phút nghe rộng rãi, nhưng bước định giá tự gọi khi mount. Nên xem log 429 vài ngày đầu xem có ai bị chặn oan không — cache phía AI sẽ hấp thụ phần lớn request trùng.