### PR TITLE
fix(publish): stop the two ways a paid publish takes money and creates nothing

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/infra/exception/model/DomainCode.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/exception/model/DomainCode.java
@@ -105,6 +105,10 @@ public enum DomainCode {
   // practice the draft was published before and the client is republishing a stale copy.
   LISTING_MEDIA_ALREADY_LINKED("12004", HttpStatus.CONFLICT,
       "Media %s is already linked to listing %s"),
+  // Raised when a draft is published again while an earlier publish of the same draft
+  // is still waiting on its payment.
+  DRAFT_PUBLISH_ALREADY_PENDING("12005", HttpStatus.CONFLICT,
+      "This draft is already waiting on payment %s"),
   //    Quota Error 13xxx
   INSUFFICIENT_QUOTA("13001", HttpStatus.BAD_REQUEST, "Insufficient quota: %s"),
   BENEFIT_NOT_FOUND("13002", HttpStatus.NOT_FOUND, "Membership benefit not found: %s"),

--- a/smart-rent/src/main/java/com/smartrent/infra/repository/entity/ListingDraft.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/entity/ListingDraft.java
@@ -162,6 +162,12 @@ public class ListingDraft {
     @Column(name = "benefit_ids", length = 500)
     String benefitIds;
 
+    // Payment this draft is currently waiting on, if any. Set when a publish returns
+    // "payment required" and cleared once that payment is no longer outstanding, so the
+    // same draft cannot be published a second time while the first is in flight.
+    @Column(name = "pending_transaction_id", length = 100)
+    String pendingTransactionId;
+
     // Timestamps
     @Column(name = "created_at", updatable = false)
     @CreationTimestamp

--- a/smart-rent/src/main/java/com/smartrent/service/listing/impl/ListingServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/listing/impl/ListingServiceImpl.java
@@ -28,6 +28,7 @@ import com.smartrent.enums.BenefitType;
 import com.smartrent.enums.ModerationStatus;
 import com.smartrent.enums.NotificationType;
 import com.smartrent.enums.PostSource;
+import com.smartrent.enums.TransactionStatus;
 import com.smartrent.infra.exception.AppException;
 import com.smartrent.infra.exception.DomainException;
 import com.smartrent.infra.exception.model.DomainCode;
@@ -91,6 +92,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -180,24 +182,26 @@ public class ListingServiceImpl implements ListingService {
             return createListingWithPayment(request);
         }
 
-        // Get the first benefit to determine the benefit type and infer vipType
+        // Decide quota-vs-payment WITHOUT letting an exception cross a transactional
+        // boundary. quotaService methods are @Transactional and participate in this
+        // transaction, so an exception thrown out of one marks the shared transaction
+        // rollback-only (globalRollbackOnParticipationFailure). Catching it here used to
+        // look like a graceful fallback while the transaction was already doomed: we
+        // then inserted a payment transaction row, wrote Redis and called out to the
+        // payment provider for a real checkout URL, only for the commit to blow up with
+        // UnexpectedRollbackException. The user got a 500 and an live payment link whose
+        // local transaction row no longer existed — and paying it hit
+        // triggerBusinessLogicCompletion's "transaction == null -> log and return".
         Long firstBenefitId = request.getBenefitIds().iterator().next();
-        UserMembershipBenefit firstBenefit;
-        try {
-            firstBenefit = quotaService.getBenefitById(request.getUserId(), firstBenefitId);
-        } catch (IllegalArgumentException e) {
-            log.warn("Benefit not found for user {}: {}, falling back to payment flow",
-                    request.getUserId(), e.getMessage());
-            // Fall back to payment flow when benefit not found
-            return createListingWithPayment(request);
-        } catch (IllegalStateException e) {
-            log.warn("Benefit expired for user {}: {}, falling back to payment flow",
-                    request.getUserId(), e.getMessage());
-            // Fall back to payment flow when benefit expired
+        Optional<UserMembershipBenefit> firstBenefitLookup =
+                quotaService.findSpendableBenefit(request.getUserId(), firstBenefitId);
+        if (firstBenefitLookup.isEmpty()) {
+            log.warn("Benefit {} not spendable for user {}, falling back to payment flow",
+                    firstBenefitId, request.getUserId());
             return createListingWithPayment(request);
         }
 
-        BenefitType benefitType = firstBenefit.getBenefitType();
+        BenefitType benefitType = firstBenefitLookup.get().getBenefitType();
 
         // Validate benefit type is a posting type (POST_SILVER, POST_GOLD, POST_DIAMOND)
         String vipType;
@@ -222,20 +226,26 @@ public class ListingServiceImpl implements ListingService {
         // doesn't burn a post benefit on a request we'd reject afterwards.
         vipTierLimitValidator.validateForCreate(vipType, request.getMediaIds());
 
-        // Consume quota from specified benefit IDs (this also validates all benefits have the same type)
-        try {
-            quotaService.consumeQuotaByBenefitIds(request.getUserId(), request.getBenefitIds(), benefitType);
-        } catch (IllegalArgumentException e) {
-            log.warn("Invalid benefit IDs for user {}: {}, falling back to payment flow",
-                    request.getUserId(), e.getMessage());
-            // Fall back to payment flow when benefit IDs are invalid
-            return createListingWithPayment(request);
-        } catch (IllegalStateException e) {
-            log.warn("Insufficient quota for user {}: {}, falling back to payment flow",
-                    request.getUserId(), e.getMessage());
-            // Fall back to payment flow when quota is insufficient
+        // Every benefit must be spendable and of the same type before we consume any of
+        // them. consumeQuotaByBenefitIds validates and deducts inside one loop, so a
+        // rejection on the third id happens after the first two were already deducted —
+        // it relies on the rollback to give them back, which is exactly why its
+        // exceptions must not be swallowed.
+        boolean allSpendable = request.getBenefitIds().stream()
+                .map(benefitId -> quotaService.findSpendableBenefit(request.getUserId(), benefitId))
+                .allMatch(benefit -> benefit
+                        .filter(b -> b.getBenefitType() == benefitType)
+                        .isPresent());
+        if (!allSpendable) {
+            log.warn("Not all benefits {} are spendable for user {}, falling back to payment flow",
+                    request.getBenefitIds(), request.getUserId());
             return createListingWithPayment(request);
         }
+
+        // Pre-checked above, so a failure here is a genuine inconsistency (a concurrent
+        // spend, say) and must surface as an error rather than silently becoming a
+        // payment the user did not ask for.
+        quotaService.consumeQuotaByBenefitIds(request.getUserId(), request.getBenefitIds(), benefitType);
 
         // Set the inferred vipType on the request so the mapper uses it
         request.setVipType(vipType);
@@ -2603,6 +2613,8 @@ public class ListingServiceImpl implements ListingService {
                 .orElseThrow(() -> new AppException(DomainCode.LISTING_NOT_FOUND,
                         "Draft not found with id: " + draftId));
 
+        rejectIfPaymentStillPending(draft);
+
         // Merge draft data with request (request takes precedence)
         ListingCreationRequest mergedRequest = mergeDraftWithRequest(draft, request);
         mergedRequest.setUserId(userId);
@@ -2619,7 +2631,10 @@ public class ListingServiceImpl implements ListingService {
         if (Boolean.TRUE.equals(response.getPaymentRequired())) {
             // Listing is not created yet - it will be materialised from the cache after
             // payment succeeds, and the draft is deleted there. Keep the draft for now so a
-            // failed/abandoned payment doesn't lose the user's work.
+            // failed/abandoned payment doesn't lose the user's work. Record which payment
+            // it is waiting on so it cannot be published again in the meantime.
+            draft.setPendingTransactionId(response.getTransactionId());
+            listingDraftRepository.save(draft);
             log.info("Draft {} kept pending payment for transaction {}",
                     draftId, response.getTransactionId());
         } else {
@@ -2644,6 +2659,46 @@ public class ListingServiceImpl implements ListingService {
 
         listingDraftRepository.delete(draft);
         log.info("Draft listing {} deleted successfully", draftId);
+    }
+
+    /**
+     * Refuse to publish a draft that is still waiting on an earlier publish's payment.
+     *
+     * <p>Without this, a draft could be published twice: once through payment (which keeps
+     * the draft alive while the payment is outstanding) and again through quota. The
+     * second publish creates the listing and stamps its id onto the media, so when the
+     * first payment finally lands the callback cannot link that media and fails — and the
+     * IPN handler swallows the failure. The user is charged, no listing is created for
+     * that transaction, and nothing surfaces but a log line.
+     *
+     * <p>Only a still-PENDING transaction blocks. A failed, cancelled or vanished one is
+     * cleared so the user can publish the draft again, which is the whole point of keeping
+     * it. A COMPLETED one means the listing exists and the draft is about to be deleted by
+     * the callback, so it blocks too.
+     */
+    private void rejectIfPaymentStillPending(ListingDraft draft) {
+        String pendingTransactionId = draft.getPendingTransactionId();
+        if (pendingTransactionId == null || pendingTransactionId.isBlank()) {
+            return;
+        }
+
+        Transaction pending = transactionService.getTransaction(pendingTransactionId);
+        boolean stillOutstanding = pending != null
+                && (pending.getStatus() == TransactionStatus.PENDING
+                    || pending.getStatus() == TransactionStatus.COMPLETED);
+
+        if (stillOutstanding) {
+            log.warn("Draft {} republish blocked: transaction {} is {}",
+                    draft.getDraftId(), pendingTransactionId, pending.getStatus());
+            throw new AppException(DomainCode.DRAFT_PUBLISH_ALREADY_PENDING,
+                    "This draft is already waiting on payment " + pendingTransactionId);
+        }
+
+        // Payment failed, was cancelled, or the row is gone - let the user try again.
+        log.info("Draft {} clearing stale pending transaction {} (status {})",
+                draft.getDraftId(), pendingTransactionId,
+                pending != null ? pending.getStatus() : "MISSING");
+        draft.setPendingTransactionId(null);
     }
 
     /**

--- a/smart-rent/src/main/java/com/smartrent/service/quota/QuotaService.java
+++ b/smart-rent/src/main/java/com/smartrent/service/quota/QuotaService.java
@@ -79,5 +79,19 @@ public interface QuotaService {
      * @return true if user has active membership
      */
     boolean hasActiveMembership(String userId);
+
+    /**
+     * Look up a benefit the user can actually spend, without throwing.
+     *
+     * <p>{@link #getBenefitById} signals "not yours / expired" by throwing, which is
+     * fine for a genuine error but not for a routing decision: the exception escapes a
+     * participating transaction, so Spring marks the caller's transaction rollback-only
+     * and catching it upstream no longer helps. Callers that need to *decide* whether
+     * the quota path is viable must use this instead.
+     *
+     * @return the benefit when it exists, belongs to the user, is unexpired and still
+     *         has quota left; otherwise empty
+     */
+    java.util.Optional<UserMembershipBenefit> findSpendableBenefit(String userId, Long benefitId);
 }
 

--- a/smart-rent/src/main/java/com/smartrent/service/quota/impl/QuotaServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/quota/impl/QuotaServiceImpl.java
@@ -190,6 +190,18 @@ public class QuotaServiceImpl implements QuotaService {
 
     @Override
     @Transactional(readOnly = true)
+    public java.util.Optional<UserMembershipBenefit> findSpendableBenefit(String userId, Long benefitId) {
+        if (benefitId == null) {
+            return java.util.Optional.empty();
+        }
+        return userBenefitRepository.findById(benefitId)
+                .filter(benefit -> benefit.getUserId().equals(userId))
+                .filter(benefit -> !benefit.isExpired())
+                .filter(UserMembershipBenefit::hasQuotaAvailable);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
     public boolean hasSufficientQuota(String userId, BenefitType benefitType, int quantity) {
         QuotaStatusResponse quota = checkQuotaAvailability(userId, benefitType);
         return quota.getTotalAvailable() >= quantity;

--- a/smart-rent/src/main/resources/db/migration/V118__Add_pending_transaction_to_listing_drafts.sql
+++ b/smart-rent/src/main/resources/db/migration/V118__Add_pending_transaction_to_listing_drafts.sql
@@ -1,0 +1,20 @@
+-- V118: remember which payment a draft is currently waiting on.
+--
+-- publishDraft deliberately keeps the draft alive while a payment is pending, so an
+-- abandoned payment doesn't lose the user's work. But nothing stopped the same draft
+-- from being published again in the meantime, and that combination takes the user's
+-- money for nothing:
+--
+--   1. publish with payment  -> draft kept, request cached, payment pending
+--   2. publish again with quota -> listing created, media stamped with its listing_id,
+--                                  draft deleted
+--   3. the original payment lands -> the cached request is materialised, but
+--      linkMediaToListing now rejects media that belongs to the listing from step 2.
+--      The callback's error is swallowed by the IPN handler, so the provider is told
+--      "success", the transaction stays COMPLETED, and no listing is ever created.
+--
+-- Holding the pending transaction id on the draft lets publishDraft refuse step 2
+-- while step 1 is still outstanding.
+
+ALTER TABLE listing_drafts
+    ADD COLUMN pending_transaction_id VARCHAR(100) NULL AFTER benefit_ids;

--- a/smart-rent/src/test/java/com/smartrent/service/listing/impl/ListingServiceImplPublishDraftTest.java
+++ b/smart-rent/src/test/java/com/smartrent/service/listing/impl/ListingServiceImplPublishDraftTest.java
@@ -3,8 +3,13 @@ package com.smartrent.service.listing.impl;
 import com.smartrent.dto.request.AddressCreationRequest;
 import com.smartrent.dto.request.ListingCreationRequest;
 import com.smartrent.dto.response.ListingCreationResponse;
+import com.smartrent.enums.TransactionStatus;
+import com.smartrent.infra.exception.AppException;
+import com.smartrent.infra.exception.model.DomainCode;
 import com.smartrent.infra.repository.ListingDraftRepository;
 import com.smartrent.infra.repository.entity.ListingDraft;
+import com.smartrent.infra.repository.entity.Transaction;
+import com.smartrent.service.transaction.TransactionService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -18,6 +23,8 @@ import java.util.Optional;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.never;
@@ -30,6 +37,9 @@ class ListingServiceImplPublishDraftTest {
 
     @Mock
     ListingDraftRepository listingDraftRepository;
+
+    @Mock
+    TransactionService transactionService;
 
     @InjectMocks
     ListingServiceImpl injected;
@@ -152,6 +162,66 @@ class ListingServiceImplPublishDraftTest {
         ArgumentCaptor<ListingCreationRequest> captor = ArgumentCaptor.forClass(ListingCreationRequest.class);
         verify(service).createListing(captor.capture());
         assertEquals(Set.of(11L, 22L, 33L), captor.getValue().getMediaIds());
+    }
+
+    @Test
+    void blocksRepublishWhileTheFirstPublishIsStillAwaitingPayment() {
+        // Publishing twice is how a user ends up charged with nothing created: the second
+        // publish stamps the media with a new listing id, and the first payment's callback
+        // can then never link it — a failure the IPN handler swallows.
+        Long draftId = 6L;
+        String userId = "user-1";
+        ListingDraft draft = ListingDraft.builder().pendingTransactionId("tx-pending").build();
+        when(listingDraftRepository.findByDraftIdAndUserId(draftId, userId))
+                .thenReturn(Optional.of(draft));
+        Transaction pending = new Transaction();
+        pending.setStatus(TransactionStatus.PENDING);
+        when(transactionService.getTransaction("tx-pending")).thenReturn(pending);
+
+        AppException thrown = assertThrows(AppException.class,
+                () -> service.publishDraft(draftId, validPublishRequest(), userId));
+
+        assertEquals(DomainCode.DRAFT_PUBLISH_ALREADY_PENDING, thrown.getErrorCode());
+        verify(service, never()).createListing(any());
+        verify(listingDraftRepository, never()).delete(any());
+    }
+
+    @Test
+    void allowsRepublishOnceTheEarlierPaymentHasFailed() {
+        // The draft is kept precisely so an abandoned payment doesn't lose the user's
+        // work — a dead transaction must not lock them out of it forever.
+        Long draftId = 7L;
+        String userId = "user-1";
+        ListingDraft draft = ListingDraft.builder().pendingTransactionId("tx-failed").build();
+        when(listingDraftRepository.findByDraftIdAndUserId(draftId, userId))
+                .thenReturn(Optional.of(draft));
+        Transaction failed = new Transaction();
+        failed.setStatus(TransactionStatus.FAILED);
+        when(transactionService.getTransaction("tx-failed")).thenReturn(failed);
+        doReturn(ListingCreationResponse.builder().listingId(1L).build())
+                .when(service).createListing(any());
+
+        service.publishDraft(draftId, validPublishRequest(), userId);
+
+        verify(service).createListing(any());
+        assertNull(draft.getPendingTransactionId());
+    }
+
+    @Test
+    void recordsThePendingTransactionOnTheDraftWhenPaymentIsRequired() {
+        Long draftId = 8L;
+        String userId = "user-1";
+        ListingDraft draft = ListingDraft.builder().build();
+        when(listingDraftRepository.findByDraftIdAndUserId(draftId, userId))
+                .thenReturn(Optional.of(draft));
+        doReturn(ListingCreationResponse.builder().paymentRequired(true).transactionId("tx-new").build())
+                .when(service).createListing(any());
+
+        service.publishDraft(draftId, validPublishRequest(), userId);
+
+        // Without this the next publish has nothing to check against.
+        assertEquals("tx-new", draft.getPendingTransactionId());
+        verify(listingDraftRepository).save(draft);
     }
 
     @Test


### PR DESCRIPTION
Hai lỗi trên **luồng tiền**, cả hai đều kết thúc trong im lặng: user bị trừ tiền, không có tin đăng, dấu vết duy nhất là một dòng log.

## 1. Fallback quota → thanh toán chạy trên transaction đã chết

Các hàm của `quotaService` đều `@Transactional` và **participate** vào transaction của `publishDraft`. Khi một hàm ném exception, Spring đánh dấu transaction dùng chung là **rollback-only** (`globalRollbackOnParticipationFailure` mặc định `true`) — nên bắt exception ở `createListingWithMembershipQuota` **trông** như fallback êm ả, nhưng mọi việc sau đó đều làm trên transaction không thể commit:

- INSERT dòng transaction thanh toán → sẽ bị rollback
- Ghi request vào Redis → **không** rollback
- Gọi provider lấy checkout URL → **payment URL thật, tồn tại ngoài đời**

Commit → `UnexpectedRollbackException` → user nhận **500** trong khi đang cầm một link thanh toán sống mà dòng transaction dưới DB đã biến mất. Nếu họ trả tiền qua link đó, `triggerBusinessLogicCompletion` rơi đúng vào nhánh `transaction == null` → **log rồi return**, không tạo gì, không báo ai.

**Sửa:** quyết định bằng lookup không ném. `QuotaService.findSpendableBenefit` trả `Optional`, không bao giờ ném, nên quyết định fallback không còn cắt ngang ranh giới transaction. Toàn bộ benefit được pre-check trước khi trừ bất kỳ cái nào, và exception của `consumeQuotaByBenefitIds` **không còn bị nuốt**.

> Chi tiết quan trọng: cách sửa gọn hơn — `noRollbackFor` — là **sai** ở đây. `consumeQuotaByBenefitIds` validate và trừ quota xen kẽ trong cùng một vòng lặp, nên nó có thể trừ benefit thứ nhất rồi ném ở thứ hai. Nó đang dựa vào rollback để trả lại. Bỏ rollback là user **mất quota thật**.

## 2. Đăng một nháp hai lần

`publishDraft` cố ý giữ nháp khi thanh toán còn treo, để thanh toán hỏng không mất việc của user. Nhưng không có gì chặn lần đăng thứ hai xen vào:

1. Đăng lần 1 qua thanh toán → nháp giữ lại, request cache, payment pending
2. Đăng lần 2 qua quota → tin được tạo, media bị đóng dấu `listing_id`, nháp bị xoá
3. Thanh toán lần 1 về → callback không link được media nữa → fail → **IPN handler nuốt lỗi**, báo provider "thành công", transaction ở nguyên `COMPLETED`

**Sửa:** `V118` ghi lại nháp đang chờ giao dịch nào. Giao dịch còn `PENDING` (hoặc đã `COMPLETED`) thì chặn đăng lại bằng mã `12005`; giao dịch `FAILED`/`CANCELLED`/không còn thì xoá dấu để user đăng lại được — vốn là lý do giữ nháp ngay từ đầu.

## Kiểm tra

- `./gradlew compileJava` — BUILD SUCCESSFUL
- `./gradlew test` (toàn bộ) — BUILD SUCCESSFUL

Ba test mới đã được xác nhận **FAIL** khi stash bản fix ra rồi chạy lại:

```
blocksRepublishWhileTheFirstPublishIsStillAwaitingPayment() FAILED
allowsRepublishOnceTheEarlierPaymentHasFailed() FAILED
recordsThePendingTransactionOnTheDraftWhenPaymentIsRequired() FAILED
```

## Chưa làm trong PR này

- FE chưa xử lý mã `12005` — hiện sẽ rơi vào dialog lỗi chung. Cần PR frontend riêng nếu muốn thông báo tử tế ("tin này đang chờ thanh toán").
- Việc IPN handler nuốt lỗi vẫn giữ nguyên (bạn đã chọn hướng chặn tận gốc). Các ca callback fail vì lý do khác vẫn sẽ im lặng.