### PR TITLE
fix(reco): age-weight the preferred-location vote

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/infra/repository/PhoneClickDetailRepository.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/PhoneClickDetailRepository.java
@@ -255,5 +255,19 @@ public interface PhoneClickDetailRepository extends JpaRepository<PhoneClickDeta
      */
     @Query("SELECT pc FROM phone_clicks pc ORDER BY pc.clickedAt DESC")
     List<PhoneClickDetail> findRecentGlobalPhoneClicks(Pageable pageable);
+
+    /**
+     * Every listing a user clicked a phone number on, paired with that user's MOST
+     * RECENT click on it. The personalized feed ages the location vote, so it needs
+     * a timestamp per listing rather than the bare DISTINCT ids of
+     * {@link #findListingIdsByUserId(String)}.
+     *
+     * @return rows of [listingId (Long), lastClickedAt (LocalDateTime)]
+     */
+    @Query("SELECT pc.listing.listingId, MAX(pc.clickedAt) FROM phone_clicks pc " +
+           "WHERE pc.user.userId = :userId " +
+           "GROUP BY pc.listing.listingId " +
+           "ORDER BY MAX(pc.clickedAt) DESC")
+    List<Object[]> findListingIdsWithLastClickByUserId(@Param("userId") String userId);
 }
 

--- a/smart-rent/src/main/java/com/smartrent/service/recentlyviewed/RecentlyViewedService.java
+++ b/smart-rent/src/main/java/com/smartrent/service/recentlyviewed/RecentlyViewedService.java
@@ -37,4 +37,13 @@ public interface RecentlyViewedService {
      * @return listing IDs, most recent first (empty if none)
      */
     List<Long> getRecentlyViewedIds(String userId);
+
+    /**
+     * Recently-viewed listing IDs mapped to the epoch-millis timestamp of the view,
+     * most recent first, WITHOUT hydrating listing details. Same ZSET read as
+     * {@link #getRecentlyViewedIds(String)} but keeps the scores, which the
+     * personalized feed needs to age-weight the location vote.
+     * @return ordered map listingId → viewedAt epoch millis (empty if none)
+     */
+    java.util.LinkedHashMap<Long, Long> getRecentlyViewedIdsWithTimestamps(String userId);
 }

--- a/smart-rent/src/main/java/com/smartrent/service/recentlyviewed/impl/RecentlyViewedServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/recentlyviewed/impl/RecentlyViewedServiceImpl.java
@@ -190,6 +190,34 @@ public class RecentlyViewedServiceImpl implements RecentlyViewedService {
         return result;
     }
 
+    @Override
+    public java.util.LinkedHashMap<Long, Long> getRecentlyViewedIdsWithTimestamps(String userId) {
+        String redisKey = buildKey(userId);
+
+        // Same ZSET read as getRecentlyViewedIds, but keeping the scores. Spring
+        // Data returns an insertion-ordered LinkedHashSet, so iterating the tuples
+        // preserves the most-recent-first order into the LinkedHashMap.
+        Set<ZSetOperations.TypedTuple<String>> tuples =
+                redisTemplate.opsForZSet().reverseRangeWithScores(redisKey, 0, MAX_LISTINGS - 1);
+
+        java.util.LinkedHashMap<Long, Long> result = new java.util.LinkedHashMap<>();
+        if (tuples == null || tuples.isEmpty()) {
+            return result;
+        }
+
+        for (ZSetOperations.TypedTuple<String> tuple : tuples) {
+            if (tuple.getValue() == null || tuple.getScore() == null) {
+                continue;
+            }
+            try {
+                result.put(Long.parseLong(tuple.getValue()), tuple.getScore().longValue());
+            } catch (NumberFormatException e) {
+                log.warn("Skipping non-numeric recently-viewed entry '{}' for user {}", tuple.getValue(), userId);
+            }
+        }
+        return result;
+    }
+
     /**
      * Validate timestamp to prevent invalid values
      * @param listing Listing to validate

--- a/smart-rent/src/main/java/com/smartrent/service/recommendation/impl/RecommendationServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/recommendation/impl/RecommendationServiceImpl.java
@@ -48,6 +48,18 @@ public class RecommendationServiceImpl implements RecommendationService {
     Map<String, Optional<com.smartrent.infra.repository.entity.AddressMapping>> legacyMappingCache =
             new java.util.concurrent.ConcurrentHashMap<>();
 
+    // Intent strength per interaction type, shared by the CF weights sent to the AI
+    // and the location vote below.
+    private static final double SAVE_WEIGHT = 3.0;
+    private static final double PHONE_CLICK_WEIGHT = 2.5;
+    private static final double VIEW_WEIGHT = 1.0;
+
+    // Half-life of an interaction's influence on the PREFERRED LOCATION vote.
+    // Renting is a bounded search: a user finds a place in ~2-4 weeks and stops,
+    // and when they come back months later their target area has often changed.
+    // 30 days leaves a 6-month-old save at ~1.5% of its original vote.
+    private static final double LOCATION_VOTE_HALF_LIFE_DAYS = 30.0;
+
     // ─────────────────────────────────────────────
     // PUBLIC: Similar Listings
     // ─────────────────────────────────────────────
@@ -220,27 +232,47 @@ public class RecommendationServiceImpl implements RecommendationService {
     public RecommendationResponse getPersonalizedFeed(String userId, int topN) {
         long tStart = System.nanoTime();
         Map<Long, Double> interactionWeightMap = new LinkedHashMap<>();
+
+        // Age-decayed copy of the same signals, used ONLY for the preferred-location
+        // vote in step 3.1. Deliberately separate from interactionWeightMap, which
+        // feeds the AI's CF matrix and stays on the raw intent scale.
+        Map<Long, Double> locationVoteWeights = new LinkedHashMap<>();
+        LocalDateTime now = LocalDateTime.now();
+
         List<SavedListing> savedListings = savedListingRepository.findByUserIdOrderByCreatedAtDesc(userId);
         long tAfterSaved = System.nanoTime();
 
-        List<Long> clickedListingIds = phoneClickDetailRepository.findListingIdsByUserId(userId);
+        // [listingId, lastClickedAt] rather than bare DISTINCT ids: the location
+        // vote needs a timestamp per listing to age it.
+        List<Object[]> clickRows = phoneClickDetailRepository.findListingIdsWithLastClickByUserId(userId);
+        List<Long> clickedListingIds = clickRows.stream()
+                .map(row -> (Long) row[0]).collect(Collectors.toList());
         long tAfterClicks = System.nanoTime();
 
         // IDs-only recency read (no full-DTO hydration): this path only needs the
-        // viewed listing IDs and their order below, so getRecentlyViewedIds skips
+        // viewed listing IDs, their order and their view timestamps, so this skips
         // the getDisplayingListingsByIds hydration of up to 20 listings that
         // getRecentlyViewed() would run.
-        List<Long> viewedListingIds = recentlyViewedService.getRecentlyViewedIds(userId);
+        LinkedHashMap<Long, Long> viewedWithTimestamps =
+                recentlyViewedService.getRecentlyViewedIdsWithTimestamps(userId);
+        List<Long> viewedListingIds = new ArrayList<>(viewedWithTimestamps.keySet());
         long tAfterViewed = System.nanoTime();
 
         for (SavedListing s : savedListings) {
-            interactionWeightMap.merge(s.getId().getListingId(), 3.0, Math::max);
+            Long lId = s.getId().getListingId();
+            interactionWeightMap.merge(lId, SAVE_WEIGHT, Math::max);
+            locationVoteWeights.merge(lId, SAVE_WEIGHT * recencyFactor(s.getCreatedAt(), now), Math::max);
         }
-        for (Long lId : clickedListingIds) {
-            interactionWeightMap.merge(lId, 2.5, Math::max);
+        for (Object[] row : clickRows) {
+            Long lId = (Long) row[0];
+            interactionWeightMap.merge(lId, PHONE_CLICK_WEIGHT, Math::max);
+            locationVoteWeights.merge(lId,
+                    PHONE_CLICK_WEIGHT * recencyFactor(toLocalDateTime(row[1]), now), Math::max);
         }
-        for (Long lId : viewedListingIds) {
-            interactionWeightMap.merge(lId, 1.0, Math::max);
+        for (Map.Entry<Long, Long> viewed : viewedWithTimestamps.entrySet()) {
+            interactionWeightMap.merge(viewed.getKey(), VIEW_WEIGHT, Math::max);
+            locationVoteWeights.merge(viewed.getKey(),
+                    VIEW_WEIGHT * recencyFactor(viewed.getValue(), now), Math::max);
         }
 
         boolean hasEnoughInteractions = !savedListings.isEmpty() || !clickedListingIds.isEmpty()
@@ -293,7 +325,7 @@ public class RecommendationServiceImpl implements RecommendationService {
         // ward=Tuyen Quang, a zone no listing can ever match. Everything downstream
         // (isDifferentFromPreferred, preferredMatchLevel, the preferred-side
         // fallback query) then treats the whole feed as out-of-zone.
-        String preferredProvinceCode = dominantValue(interactionFeatures,
+        String preferredProvinceCode = dominantValue(interactionFeatures, locationVoteWeights,
                 f -> "UNKNOWN".equals(f.getProvinceCode()) ? null : f.getProvinceCode());
 
         final String provinceScope = preferredProvinceCode;
@@ -303,11 +335,11 @@ public class RecommendationServiceImpl implements RecommendationService {
                         .filter(f -> provinceScope.equals(f.getProvinceCode()))
                         .collect(Collectors.toList());
 
-        String preferredWardCode = dominantValue(inPreferredProvince,
+        String preferredWardCode = dominantValue(inPreferredProvince, locationVoteWeights,
                 AIRecommendationRequest.ListingFeatureDto::getNewWardCode);
-        Integer preferredDistrictId = dominantValue(inPreferredProvince,
+        Integer preferredDistrictId = dominantValue(inPreferredProvince, locationVoteWeights,
                 AIRecommendationRequest.ListingFeatureDto::getDistrictId);
-        Integer preferredWardId = dominantValue(inPreferredProvince,
+        Integer preferredWardId = dominantValue(inPreferredProvince, locationVoteWeights,
                 AIRecommendationRequest.ListingFeatureDto::getWardId);
 
         // 3.1.2 Calculate condition counts for Discovery Shift triggering.
@@ -1049,43 +1081,102 @@ public class RecommendationServiceImpl implements RecommendationService {
      * @return 3 = ward, 2 = district, 1 = province, 0 = outside the discovery zone.
      */
     /**
-     * Most frequent non-null value across the interaction features, with ties
+     * Highest-scoring non-null value across the interaction features, with ties
      * broken in favour of the value the user has been browsing LONGER.
+     *
+     * <p>
+     * Each listing contributes its {@code weights} entry rather than a flat 1, so
+     * a save or a phone click outvotes a passing view, and a stale interaction
+     * outvotes nothing — see {@link #recencyFactor}. A listing missing from
+     * {@code weights} falls back to {@link #VIEW_WEIGHT} so it still counts.
      *
      * <p>
      * {@code features} arrives newest-first, so a larger first-occurrence index
      * means the value only shows up deeper in the history — that is the
      * established preference, not the place currently being explored. Breaking
-     * ties towards it keeps a 3-vs-3 split resolving to the old zone (which stays
+     * ties towards it keeps an even split resolving to the old zone (which stays
      * the preferred one, slots 1-7) and leaves the new zone as the discovery zone
      * (slots 8-10), instead of depending on hash order.
      */
     private <T> T dominantValue(List<AIRecommendationRequest.ListingFeatureDto> features,
+            Map<Long, Double> weights,
             java.util.function.Function<AIRecommendationRequest.ListingFeatureDto, T> extractor) {
-        Map<T, Long> counts = new LinkedHashMap<>();
+        Map<T, Double> scores = new LinkedHashMap<>();
         Map<T, Integer> firstIndex = new HashMap<>();
         for (int i = 0; i < features.size(); i++) {
-            T value = extractor.apply(features.get(i));
+            AIRecommendationRequest.ListingFeatureDto feature = features.get(i);
+            T value = extractor.apply(feature);
             if (value == null) {
                 continue;
             }
-            counts.merge(value, 1L, Long::sum);
+            Double weight = weights.get(feature.getListingId());
+            scores.merge(value, weight != null ? weight : VIEW_WEIGHT, Double::sum);
             firstIndex.putIfAbsent(value, i);
         }
 
         T best = null;
-        long bestCount = -1L;
+        double bestScore = Double.NEGATIVE_INFINITY;
         int bestIndex = -1;
-        for (Map.Entry<T, Long> entry : counts.entrySet()) {
+        for (Map.Entry<T, Double> entry : scores.entrySet()) {
             int index = firstIndex.get(entry.getKey());
-            if (entry.getValue() > bestCount
-                    || (entry.getValue() == bestCount && index > bestIndex)) {
+            double score = entry.getValue();
+            boolean tie = Math.abs(score - bestScore) < 1e-9;
+            if ((!tie && score > bestScore) || (tie && index > bestIndex)) {
                 best = entry.getKey();
-                bestCount = entry.getValue();
+                bestScore = score;
                 bestIndex = index;
             }
         }
         return best;
+    }
+
+    /**
+     * Exponential time decay for an interaction's influence on the preferred-location
+     * vote: {@code 0.5 ^ (ageDays / LOCATION_VOTE_HALF_LIFE_DAYS)}.
+     *
+     * <p>
+     * Saves and phone clicks are read from the user's FULL history while recently
+     * viewed listings are bounded by a 20-entry Redis window. Without decay that
+     * asymmetry lets a finished rental search outvote the current one indefinitely,
+     * freezing the preferred ward on an area the user has already moved on from.
+     */
+    private double recencyFactor(LocalDateTime interactedAt, LocalDateTime now) {
+        if (interactedAt == null) {
+            return 1.0;
+        }
+        double ageDays = Math.max(0.0, ChronoUnit.MINUTES.between(interactedAt, now) / (60.0 * 24.0));
+        return Math.pow(0.5, ageDays / LOCATION_VOTE_HALF_LIFE_DAYS);
+    }
+
+    /**
+     * Coerces the {@code MAX(clickedAt)} projection to {@link LocalDateTime}.
+     * Hibernate returns a LocalDateTime for an aggregate over a LocalDateTime
+     * attribute, but older/native paths can hand back a java.sql.Timestamp — an
+     * unchecked cast here would blow up the whole personalized feed, so an
+     * unexpected type degrades to "no decay" instead.
+     */
+    private LocalDateTime toLocalDateTime(Object value) {
+        if (value instanceof LocalDateTime) {
+            return (LocalDateTime) value;
+        }
+        if (value instanceof java.sql.Timestamp) {
+            return ((java.sql.Timestamp) value).toLocalDateTime();
+        }
+        if (value != null) {
+            log.warn("Unexpected clickedAt projection type {} — skipping recency decay for this interaction",
+                    value.getClass().getName());
+        }
+        return null;
+    }
+
+    /** {@link #recencyFactor(LocalDateTime, LocalDateTime)} for the epoch-millis view timestamps from Redis. */
+    private double recencyFactor(Long viewedAtEpochMillis, LocalDateTime now) {
+        if (viewedAtEpochMillis == null || viewedAtEpochMillis <= 0L) {
+            return 1.0;
+        }
+        LocalDateTime viewedAt = LocalDateTime.ofInstant(
+                java.time.Instant.ofEpochMilli(viewedAtEpochMillis), java.time.ZoneId.systemDefault());
+        return recencyFactor(viewedAt, now);
     }
 
     private int discoveryMatchLevel(Listing listing, String discoveryProvinceCode,

--- a/smart-rent/src/test/java/com/smartrent/service/recommendation/impl/RecommendationServiceImplTest.java
+++ b/smart-rent/src/test/java/com/smartrent/service/recommendation/impl/RecommendationServiceImplTest.java
@@ -81,10 +81,10 @@ public class RecommendationServiceImplTest {
         // If there are no user interactions, it should fall back to cold start feed
         when(savedListingRepository.findByUserIdOrderByCreatedAtDesc("user1"))
                 .thenReturn(Collections.emptyList());
-        when(phoneClickDetailRepository.findListingIdsByUserId("user1"))
+        when(phoneClickDetailRepository.findListingIdsWithLastClickByUserId("user1"))
                 .thenReturn(Collections.emptyList());
-        when(recentlyViewedService.getRecentlyViewedIds("user1"))
-                .thenReturn(Collections.emptyList());
+        when(recentlyViewedService.getRecentlyViewedIdsWithTimestamps("user1"))
+                .thenReturn(new java.util.LinkedHashMap<>());
 
         // For cold start
         Listing coldListing = new Listing();


### PR DESCRIPTION
The personalized feed picked the preferred ward by counting interacted listings, one flat vote each. Two problems compounded:

- A save (intent weight 3.0) and a passing view (1.0) were worth the same vote, even though interactionWeightMap already models that difference for the CF matrix sent to the AI service.
- Saves and phone clicks are read from the user's FULL history while views are capped at a 20-entry Redis window. A finished rental search therefore outvoted the current one indefinitely, freezing the preferred ward on an area the user had already moved on from.

dominantValue now sums a per-listing weight instead of a flat 1, where the weight is the interaction's intent strength decayed by 0.5^(ageDays/30). Renting is a bounded search — users find a place in ~2-4 weeks and stop, and their target area often changes by the time they return — so a 30-day half-life leaves a 6-month-old save at ~1.5% of its original vote.

The decayed weights live in a separate map from interactionWeightMap: the CF weights sent to the AI are deliberately unchanged, so AI scoring is untouched and only the location vote moves.

Timestamps for the two previously-untimed channels:
- getRecentlyViewedIdsWithTimestamps keeps the ZSET scores the IDs-only read was discarding.
- findListingIdsWithLastClickByUserId groups by listing and takes MAX(clickedAt), replacing the bare SELECT DISTINCT.

Verified end to end against the running stack (MySQL + Redis + AI service) over 7 seeded scenarios. Two flipped, both previously inverted:

- 15 saves + 8 clicks in ward A 180 days ago, 20 views in ward B today: was 7A+3B, now 7B+3A.
- 15 saves in ward A 7 days ago, 20 views in ward B today: was 7B+3A, now 7A+3B.

The discovery-shift slot design (7 preferred + 3 discovery, the 3-view / 2-save / 2-click trigger, the ward/district/province match levels) is unchanged.


Claude-Session: https://claude.ai/code/session_01UKkbSdD4SN1Mu8NW8xsyez