### PR TITLE
feat(listings): add price-comparables aggregate endpoint

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/controller/PriceComparablesController.java
+++ b/smart-rent/src/main/java/com/smartrent/controller/PriceComparablesController.java
@@ -1,0 +1,46 @@
+package com.smartrent.controller;
+
+import com.smartrent.dto.request.PriceComparablesRequest;
+import com.smartrent.dto.response.ApiResponse;
+import com.smartrent.dto.response.PriceComparablesResponse;
+import com.smartrent.service.predictor.PriceComparablesService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/v1/listings")
+@Tag(name = "Listings - Price Comparables",
+     description = "Aggregate price statistics over comparable listings, for AI price prediction.")
+@RequiredArgsConstructor
+public class PriceComparablesController {
+
+    private final PriceComparablesService priceComparablesService;
+
+    @PostMapping("/price-comparables")
+    @Operation(
+        summary = "[PUBLIC API] Aggregate price statistics of comparable listings near a point",
+        description = """
+            **PUBLIC API - Không cần authentication**
+
+            Trả về thống kê giá (min / p25 / median / p75 / max / avg / giá trung vị theo m²)
+            của các tin đăng tương tự quanh một toạ độ, đã lọc đúng theo loại BĐS, loại giao dịch,
+            đơn vị giá, khoảng diện tích và bán kính. Chỉ tính trên tin đã verify, chưa hết hạn,
+            không nháp/shadow.
+
+            Khác `POST /search`: endpoint này KHÔNG phân trang và KHÔNG trả listing card — nó chạy
+            một truy vấn aggregate (bounding-box + Haversine) và tính percentile server-side, để
+            AI định giá dùng trực tiếp các con số ổn định thay vì tự cộng trừ trên tin thô.
+            """
+    )
+    public ApiResponse<PriceComparablesResponse> getPriceComparables(
+            @Valid @RequestBody PriceComparablesRequest request) {
+        PriceComparablesResponse response = priceComparablesService.getComparables(request);
+        return ApiResponse.<PriceComparablesResponse>builder().data(response).build();
+    }
+}

--- a/smart-rent/src/main/java/com/smartrent/dto/request/PriceComparablesRequest.java
+++ b/smart-rent/src/main/java/com/smartrent/dto/request/PriceComparablesRequest.java
@@ -1,0 +1,63 @@
+package com.smartrent.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * Criteria for the price-comparables aggregate query. Unlike the open
+ * {@code /v1/listings/search} filter, this is a purpose-built, geo-radius query:
+ * the caller (the AI price-prediction agent) picks the criteria, and the backend
+ * returns deterministic price statistics computed in SQL/Java — never a paginated
+ * page of listing cards for the model to eyeball and total up by hand.
+ */
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "Criteria for the price-comparables aggregate query")
+public class PriceComparablesRequest {
+
+    @NotNull(message = "latitude is required")
+    @DecimalMin(value = "-90.0") @DecimalMax(value = "90.0")
+    @Schema(description = "Center latitude of the search radius", example = "21.064731")
+    Double latitude;
+
+    @NotNull(message = "longitude is required")
+    @DecimalMin(value = "-180.0") @DecimalMax(value = "180.0")
+    @Schema(description = "Center longitude of the search radius", example = "105.8346522")
+    Double longitude;
+
+    @Schema(description = "Search radius in kilometers (default 2, max 20)", example = "2.0")
+    Double radiusKm;
+
+    @NotBlank(message = "productType is required")
+    @Schema(description = "Property type", example = "ROOM",
+            allowableValues = {"ROOM", "APARTMENT", "HOUSE", "OFFICE", "STUDIO", "STORE"})
+    String productType;
+
+    @Schema(description = "Listing type (default RENT)", example = "RENT",
+            allowableValues = {"RENT", "SALE", "SHARE"})
+    String listingType;
+
+    @Schema(description = "Price unit to compare within (default MONTH)", example = "MONTH",
+            allowableValues = {"MONTH", "DAY", "YEAR"})
+    String priceUnit;
+
+    @Schema(description = "Minimum comparable area in m² (optional)", example = "38.5")
+    Float minArea;
+
+    @Schema(description = "Maximum comparable area in m² (optional)", example = "71.5")
+    Float maxArea;
+
+    @Schema(description = "Max comparables to sample, nearest first (default 100, max 200)", example = "100")
+    Integer limit;
+}

--- a/smart-rent/src/main/java/com/smartrent/dto/response/PriceComparablesResponse.java
+++ b/smart-rent/src/main/java/com/smartrent/dto/response/PriceComparablesResponse.java
@@ -1,0 +1,47 @@
+package com.smartrent.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Deterministic price statistics over the comparable listings that matched the
+ * requested geo/type criteria. All figures are computed server-side (SQL filter
+ * + Java percentiles) so the numbers are stable and reproducible — the caller
+ * consumes them directly instead of asking an LLM to total up raw listings.
+ */
+@Getter
+@Setter
+@Builder
+@Schema(description = "Aggregate price statistics over comparable listings")
+public class PriceComparablesResponse {
+
+    @Schema(description = "Number of comparable listings the statistics are based on", example = "42")
+    Integer sampleSize;
+
+    @Schema(description = "Cheapest comparable price (VND)", example = "3200000")
+    Long min;
+
+    @Schema(description = "25th percentile price (VND) — robust lower bound", example = "4100000")
+    Long p25;
+
+    @Schema(description = "Median price (VND)", example = "4800000")
+    Long median;
+
+    @Schema(description = "75th percentile price (VND) — robust upper bound", example = "5600000")
+    Long p75;
+
+    @Schema(description = "Most expensive comparable price (VND)", example = "9000000")
+    Long max;
+
+    @Schema(description = "Mean price (VND)", example = "4900000")
+    Long avg;
+
+    @Schema(description = "Median price per m² across the comparables (VND/m²)", example = "125000")
+    Long pricePerSqmMedian;
+
+    @Schema(description = "Currency code", example = "VND")
+    @Builder.Default
+    String currency = "VND";
+}

--- a/smart-rent/src/main/java/com/smartrent/infra/repository/ListingRepository.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/ListingRepository.java
@@ -1045,4 +1045,63 @@ public interface ListingRepository extends JpaRepository<Listing, Long>, JpaSpec
         @Param("categoryId")    Long    categoryId,
         @Param("lim")           int     limit
     );
+
+    /**
+     * Comparable rental prices near a point, for the price-comparables aggregate
+     * endpoint. Returns raw {@code [price, area]} tuples for publicly-visible,
+     * verified, non-expired listings of the exact requested
+     * (listing_type, product_type, price_unit) segment, restricted to a latitude/
+     * longitude bounding box (cheap index range scan) and then refined by
+     * Haversine distance, nearest first.
+     *
+     * <p>The bounding box (minLat/maxLat/minLng/maxLng) is computed by the service
+     * from the center + radius so the leading equality columns and the latitude
+     * range column of {@code idx_listings_price_comps} do the heavy lifting; the
+     * Haversine term only refines/orders the already-narrow candidate set.
+     * Percentiles are computed in Java from these tuples — kept out of SQL because
+     * MySQL has no first-class percentile aggregate and the sampled set is small.
+     *
+     * @return rows of {@code [price (DECIMAL), area (FLOAT)]}, nearest first
+     */
+    @Query(nativeQuery = true, value = """
+        SELECT   l.price,
+                 l.area
+        FROM     listings l
+        WHERE    l.latitude  BETWEEN :minLat AND :maxLat
+          AND    l.longitude BETWEEN :minLng AND :maxLng
+          AND    l.listing_type = :listingType
+          AND    l.product_type = :productType
+          AND    l.price_unit   = :priceUnit
+          AND    l.is_draft  = false
+          AND    l.is_shadow = false
+          AND    l.verified  = true
+          AND    l.expired   = false
+          AND    l.price > 0
+          AND    (:minArea IS NULL OR l.area >= :minArea)
+          AND    (:maxArea IS NULL OR l.area <= :maxArea)
+          AND    (6371 * ACOS(LEAST(1, GREATEST(-1,
+                     COS(RADIANS(:lat)) * COS(RADIANS(l.latitude)) *
+                     COS(RADIANS(l.longitude) - RADIANS(:lng)) +
+                     SIN(RADIANS(:lat)) * SIN(RADIANS(l.latitude)))))) <= :radiusKm
+        ORDER BY (6371 * ACOS(LEAST(1, GREATEST(-1,
+                     COS(RADIANS(:lat)) * COS(RADIANS(l.latitude)) *
+                     COS(RADIANS(l.longitude) - RADIANS(:lng)) +
+                     SIN(RADIANS(:lat)) * SIN(RADIANS(l.latitude)))))) ASC
+        LIMIT    :lim
+        """)
+    List<Object[]> findPriceComparables(
+        @Param("lat")         double  lat,
+        @Param("lng")         double  lng,
+        @Param("minLat")      double  minLat,
+        @Param("maxLat")      double  maxLat,
+        @Param("minLng")      double  minLng,
+        @Param("maxLng")      double  maxLng,
+        @Param("radiusKm")    double  radiusKm,
+        @Param("listingType") String  listingType,
+        @Param("productType") String  productType,
+        @Param("priceUnit")   String  priceUnit,
+        @Param("minArea")     Float   minArea,
+        @Param("maxArea")     Float   maxArea,
+        @Param("lim")         int     limit
+    );
 }

--- a/smart-rent/src/main/java/com/smartrent/service/predictor/PriceComparablesService.java
+++ b/smart-rent/src/main/java/com/smartrent/service/predictor/PriceComparablesService.java
@@ -1,0 +1,15 @@
+package com.smartrent.service.predictor;
+
+import com.smartrent.dto.request.PriceComparablesRequest;
+import com.smartrent.dto.response.PriceComparablesResponse;
+
+/**
+ * Computes deterministic price statistics over comparable listings near a point.
+ * Backs the price-comparables endpoint used by the AI price-prediction agent so
+ * the price range comes from real market data aggregated in code, not from an
+ * LLM totalling up raw listings.
+ */
+public interface PriceComparablesService {
+
+    PriceComparablesResponse getComparables(PriceComparablesRequest request);
+}

--- a/smart-rent/src/main/java/com/smartrent/service/predictor/impl/PriceComparablesServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/predictor/impl/PriceComparablesServiceImpl.java
@@ -1,0 +1,131 @@
+package com.smartrent.service.predictor.impl;
+
+import com.smartrent.dto.request.PriceComparablesRequest;
+import com.smartrent.dto.response.PriceComparablesResponse;
+import com.smartrent.infra.repository.ListingRepository;
+import com.smartrent.service.predictor.PriceComparablesService;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.FieldDefaults;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
+public class PriceComparablesServiceImpl implements PriceComparablesService {
+
+    static final double DEFAULT_RADIUS_KM = 2.0;
+    static final double MAX_RADIUS_KM = 20.0;
+    static final int DEFAULT_LIMIT = 100;
+    static final int MAX_LIMIT = 200;
+    // 1 degree of latitude ≈ 111.32 km everywhere; longitude shrinks by cos(lat).
+    static final double KM_PER_DEGREE_LAT = 111.32;
+
+    ListingRepository listingRepository;
+
+    @Override
+    public PriceComparablesResponse getComparables(PriceComparablesRequest request) {
+        double lat = request.getLatitude();
+        double lng = request.getLongitude();
+        double radiusKm = clamp(
+                request.getRadiusKm() != null ? request.getRadiusKm() : DEFAULT_RADIUS_KM,
+                0.1, MAX_RADIUS_KM);
+        int limit = request.getLimit() != null
+                ? Math.min(Math.max(request.getLimit(), 1), MAX_LIMIT)
+                : DEFAULT_LIMIT;
+        String listingType = request.getListingType() != null ? request.getListingType() : "RENT";
+        String priceUnit = request.getPriceUnit() != null ? request.getPriceUnit() : "MONTH";
+
+        // Bounding box around the center so MySQL can range-scan the latitude
+        // index column instead of evaluating Haversine over the whole table.
+        double latDelta = radiusKm / KM_PER_DEGREE_LAT;
+        double lngDelta = radiusKm / (KM_PER_DEGREE_LAT * Math.max(0.01, Math.cos(Math.toRadians(lat))));
+
+        List<Object[]> rows = listingRepository.findPriceComparables(
+                lat, lng,
+                lat - latDelta, lat + latDelta,
+                lng - lngDelta, lng + lngDelta,
+                radiusKm,
+                listingType,
+                request.getProductType(),
+                priceUnit,
+                request.getMinArea(),
+                request.getMaxArea(),
+                limit);
+
+        List<Long> prices = new ArrayList<>(rows.size());
+        List<Long> pricePerSqm = new ArrayList<>(rows.size());
+        for (Object[] row : rows) {
+            if (row[0] == null) {
+                continue;
+            }
+            long price = ((BigDecimal) row[0]).longValue();
+            if (price <= 0) {
+                continue;
+            }
+            prices.add(price);
+            Float area = row[1] != null ? ((Number) row[1]).floatValue() : null;
+            if (area != null && area > 0) {
+                pricePerSqm.add(Math.round((double) price / area));
+            }
+        }
+
+        if (prices.isEmpty()) {
+            log.info("price-comparables: no matches for productType={} within {}km of ({},{})",
+                    request.getProductType(), radiusKm, lat, lng);
+            return PriceComparablesResponse.builder()
+                    .sampleSize(0)
+                    .currency("VND")
+                    .build();
+        }
+
+        prices.sort(null);
+        pricePerSqm.sort(null);
+
+        return PriceComparablesResponse.builder()
+                .sampleSize(prices.size())
+                .min(prices.get(0))
+                .p25(percentile(prices, 0.25))
+                .median(percentile(prices, 0.50))
+                .p75(percentile(prices, 0.75))
+                .max(prices.get(prices.size() - 1))
+                .avg(mean(prices))
+                .pricePerSqmMedian(pricePerSqm.isEmpty() ? null : percentile(pricePerSqm, 0.50))
+                .currency("VND")
+                .build();
+    }
+
+    /** Linear-interpolated percentile over an already-sorted, non-empty list. */
+    static Long percentile(List<Long> sorted, double q) {
+        int n = sorted.size();
+        if (n == 1) {
+            return sorted.get(0);
+        }
+        double pos = q * (n - 1);
+        int lower = (int) Math.floor(pos);
+        int upper = (int) Math.ceil(pos);
+        if (lower == upper) {
+            return sorted.get(lower);
+        }
+        double frac = pos - lower;
+        return Math.round(sorted.get(lower) * (1 - frac) + sorted.get(upper) * frac);
+    }
+
+    static Long mean(List<Long> values) {
+        long sum = 0;
+        for (long v : values) {
+            sum += v;
+        }
+        return Math.round((double) sum / values.size());
+    }
+
+    static double clamp(double value, double min, double max) {
+        return Math.max(min, Math.min(max, value));
+    }
+}

--- a/smart-rent/src/main/resources/application-local.yaml
+++ b/smart-rent/src/main/resources/application-local.yaml
@@ -72,6 +72,7 @@ application:
         - "/v1/listings/search"
         - "/v1/listings/search/cursor"
         - "/v1/listings/map-bounds"
+        - "/v1/listings/price-comparables"
 # Enable debug logging for authentication
 logging:
   level:

--- a/smart-rent/src/main/resources/application.yml
+++ b/smart-rent/src/main/resources/application.yml
@@ -250,6 +250,7 @@ application:
         - "/v1/listings/stats/provinces"
         - "/v1/listings/stats/categories"
         - "/v1/listings/map-bounds"
+        - "/v1/listings/price-comparables"
         - "/v1/listings/search-suggestions/click"
         - "/v1/views"
         # AI chat streaming is optional-auth (see OPTIONAL_AUTH_POST_PATTERNS):

--- a/smart-rent/src/main/resources/db/migration/V118__Add_price_comparables_index.sql
+++ b/smart-rent/src/main/resources/db/migration/V118__Add_price_comparables_index.sql
@@ -1,0 +1,13 @@
+-- Index supporting the price-comparables aggregate endpoint
+-- (POST /v1/listings/price-comparables).
+--
+-- The query filters an exact (listing_type, product_type, price_unit) segment
+-- down to only publicly-visible, verified, non-expired rows, then range-scans a
+-- latitude bounding box and refines by Haversine distance. Leading equality
+-- columns first, latitude as the single range column, then longitude/area/price
+-- as a covering suffix so the aggregate reads price+area straight from the index
+-- without a table lookup — same philosophy as idx_listings_map_bounds.
+CREATE INDEX idx_listings_price_comps
+    ON listings (listing_type, product_type, price_unit,
+                 is_shadow, is_draft, verified, expired,
+                 latitude, longitude, area, price);

--- a/smart-rent/src/test/java/com/smartrent/service/predictor/PriceComparablesServiceImplTest.java
+++ b/smart-rent/src/test/java/com/smartrent/service/predictor/PriceComparablesServiceImplTest.java
@@ -1,0 +1,100 @@
+package com.smartrent.service.predictor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import com.smartrent.dto.request.PriceComparablesRequest;
+import com.smartrent.dto.response.PriceComparablesResponse;
+import com.smartrent.infra.repository.ListingRepository;
+import com.smartrent.service.predictor.impl.PriceComparablesServiceImpl;
+import java.math.BigDecimal;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PriceComparablesServiceImplTest {
+
+  @Mock ListingRepository listingRepository;
+
+  @InjectMocks PriceComparablesServiceImpl service;
+
+  private static Object[] row(long price, float area) {
+    return new Object[] {BigDecimal.valueOf(price), area};
+  }
+
+  private PriceComparablesRequest request() {
+    return PriceComparablesRequest.builder()
+        .latitude(21.0)
+        .longitude(105.8)
+        .radiusKm(2.0)
+        .productType("ROOM")
+        .build();
+  }
+
+  @Test
+  void computesPercentilesFromComparables() {
+    // Prices 1..5 million; median = 3M, p25 = 2M, p75 = 4M.
+    when(listingRepository.findPriceComparables(
+            anyDouble(), anyDouble(), anyDouble(), anyDouble(), anyDouble(), anyDouble(),
+            anyDouble(), eq("RENT"), eq("ROOM"), eq("MONTH"), any(), any(), anyInt()))
+        .thenReturn(List.of(
+            row(1_000_000, 20f),
+            row(2_000_000, 20f),
+            row(3_000_000, 20f),
+            row(4_000_000, 20f),
+            row(5_000_000, 20f)));
+
+    PriceComparablesResponse res = service.getComparables(request());
+
+    assertThat(res.getSampleSize()).isEqualTo(5);
+    assertThat(res.getMin()).isEqualTo(1_000_000);
+    assertThat(res.getP25()).isEqualTo(2_000_000);
+    assertThat(res.getMedian()).isEqualTo(3_000_000);
+    assertThat(res.getP75()).isEqualTo(4_000_000);
+    assertThat(res.getMax()).isEqualTo(5_000_000);
+    assertThat(res.getAvg()).isEqualTo(3_000_000);
+    // 3M / 20m² = 150k per m²
+    assertThat(res.getPricePerSqmMedian()).isEqualTo(150_000);
+  }
+
+  @Test
+  void returnsEmptyStatsWhenNoComparables() {
+    when(listingRepository.findPriceComparables(
+            anyDouble(), anyDouble(), anyDouble(), anyDouble(), anyDouble(), anyDouble(),
+            anyDouble(), any(), any(), any(), any(), any(), anyInt()))
+        .thenReturn(List.of());
+
+    PriceComparablesResponse res = service.getComparables(request());
+
+    assertThat(res.getSampleSize()).isZero();
+    assertThat(res.getMin()).isNull();
+    assertThat(res.getP75()).isNull();
+    assertThat(res.getCurrency()).isEqualTo("VND");
+  }
+
+  @Test
+  void skipsRowsWithNullOrZeroAreaForPerSqmButKeepsThemForPrice() {
+    when(listingRepository.findPriceComparables(
+            anyDouble(), anyDouble(), anyDouble(), anyDouble(), anyDouble(), anyDouble(),
+            anyDouble(), any(), any(), any(), any(), any(), anyInt()))
+        .thenReturn(java.util.Arrays.asList(
+            new Object[] {BigDecimal.valueOf(2_000_000), null},
+            row(4_000_000, 0f),
+            row(6_000_000, 30f)));
+
+    PriceComparablesResponse res = service.getComparables(request());
+
+    assertThat(res.getSampleSize()).isEqualTo(3);
+    assertThat(res.getMedian()).isEqualTo(4_000_000);
+    // Only the 30m² row yields a per-m² figure: 6M / 30 = 200k
+    assertThat(res.getPricePerSqmMedian()).isEqualTo(200_000);
+  }
+}


### PR DESCRIPTION
Add POST /v1/listings/price-comparables: a purpose-built geo-radius query that returns deterministic price statistics (min/p25/median/p75/max/avg + median price/m²) computed in SQL/Java over comparable listings, for the AI price-prediction agent.

Replaces the previous flow where the agent hit the open /search API (whose propertyType/area/radius params it mismatched, so results were unfiltered) and then had the LLM total up the prices by hand — which produced degenerate ranges like min == max.

- bounding-box + Haversine filter, nearest-first, capped sample
- new composite/covering index idx_listings_price_comps (V118)
- percentiles computed in Java (MySQL has no first-class percentile agg)
- public endpoint (whitelisted like /search, /map-bounds)