### PR TITLE
fix(listing): default useMembershipQuota to false on draft creation

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/service/listing/impl/ListingServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/listing/impl/ListingServiceImpl.java
@@ -1338,7 +1338,7 @@ public class ListingServiceImpl implements ListingService {
                 .internetPrice(request.getInternetPrice())
                 .serviceFee(request.getServiceFee())
                 .durationDays(request.getDurationDays())
-                .useMembershipQuota(request.getUseMembershipQuota())
+                .useMembershipQuota(request.getUseMembershipQuota() != null ? request.getUseMembershipQuota() : false)
                 .build();
 
         // Extract address fields if provided (support BOTH legacy AND new structures)


### PR DESCRIPTION
DraftListingRequest documents all fields as optional for auto-save, but createDraftListing forwarded a possibly-null useMembershipQuota straight to ListingDraft, which Hibernate then inserts as an explicit NULL against the NOT NULL DEFAULT FALSE column - bypassing the DB default and throwing a constraint violation. Mirrors the existing null-coalescing already used in ListingMapperImpl for real listings.