### PR TITLE
fix: stop dropping distinct users' phone clicks and fix click history…

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/infra/repository/PhoneClickDetailRepository.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/PhoneClickDetailRepository.java
@@ -170,9 +170,6 @@ public interface PhoneClickDetailRepository extends JpaRepository<PhoneClickDeta
     boolean existsByUser_UserIdAndListing_ListingIdAndClickedAtAfter(
             String userId, Long listingId, LocalDateTime since);
 
-    boolean existsByIpAddressAndListing_ListingIdAndClickedAtAfter(
-            String ipAddress, Long listingId, LocalDateTime since);
-
     long countByListing_ListingIdAndClickedAtAfter(Long listingId, LocalDateTime since);
 
     @Query("SELECT CAST(pc.clickedAt AS LocalDate) AS clickDate, COUNT(pc) AS cnt " +

--- a/smart-rent/src/main/java/com/smartrent/service/phoneclickdetail/impl/PhoneClickDetailServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/phoneclickdetail/impl/PhoneClickDetailServiceImpl.java
@@ -26,6 +26,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -75,15 +76,6 @@ public class PhoneClickDetailServiceImpl implements PhoneClickDetailService {
 
         boolean duplicateByUser = phoneClickDetailRepository
                 .existsByUser_UserIdAndListing_ListingIdAndClickedAtAfter(userId, request.getListingId(), tenMinutesAgo);
-
-        if (!duplicateByUser && ipAddress != null) {
-            boolean duplicateByIp = phoneClickDetailRepository
-                    .existsByIpAddressAndListing_ListingIdAndClickedAtAfter(ipAddress, request.getListingId(), tenMinutesAgo);
-            if (duplicateByIp) {
-                log.info("Duplicate click from IP {} on listing {} within 10 minutes, ignoring", ipAddress, request.getListingId());
-                return buildSpamResponse(listing, user);
-            }
-        }
 
         if (duplicateByUser) {
             log.info("Duplicate click from user {} on listing {} within 10 minutes, ignoring", userId, request.getListingId());
@@ -436,6 +428,7 @@ public class PhoneClickDetailServiceImpl implements PhoneClickDetailService {
                                 .clickCount(clicks.size())
                                 .build();
                     })
+                    .sorted(Comparator.comparing(ListingClickInfo::getClickedAt).reversed())
                     .collect(Collectors.toList());
 
             // Build user response


### PR DESCRIPTION
… order

IP-scoped dedup in trackPhoneClick discarded a legitimately new click whenever any user shared an IP/NAT with a recent clicker on the same listing, while returning a fake success response so the drop was invisible to the caller. Keep only the per-user 10-minute dedup.

Also sort clickedListings by clickedAt descending in buildUsersWhoClickedResponse — it was built from an unordered HashMap grouping, so the frontend's "most recent click = index 0" assumption wasn't guaranteed.