### PR TITLE
fix(saved-listings): trả đúng 409/404 như controller đã document

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/controller/SavedListingController.java
+++ b/smart-rent/src/main/java/com/smartrent/controller/SavedListingController.java
@@ -139,8 +139,8 @@ public class SavedListingController {
                             examples = @io.swagger.v3.oas.annotations.media.ExampleObject(
                                     value = """
                                             {
-                                              "code": "LISTING_ALREADY_SAVED",
-                                              "message": "Listing 123 is already saved by this user"
+                                              "code": "24002",
+                                              "message": "Tin này đã có trong danh sách yêu thích của bạn."
                                             }
                                             """
                             )
@@ -192,8 +192,8 @@ public class SavedListingController {
                             examples = @io.swagger.v3.oas.annotations.media.ExampleObject(
                                     value = """
                                             {
-                                              "code": "SAVED_LISTING_NOT_FOUND",
-                                              "message": "Saved listing not found for user and listing ID: 123"
+                                              "code": "24003",
+                                              "message": "Tin này không có trong danh sách yêu thích của bạn."
                                             }
                                             """
                             )

--- a/smart-rent/src/main/java/com/smartrent/infra/exception/model/DomainCode.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/exception/model/DomainCode.java
@@ -162,7 +162,14 @@ public enum DomainCode {
       "Người dùng chưa đủ điều kiện bị chặn đăng tin. Cần trên %d report đã được admin duyệt, hiện tại chỉ có %d."),
   //    Saved Listing Error 24xxx
   SAVED_LISTING_LIMIT_EXCEEDED("24001", HttpStatus.BAD_REQUEST,
-      "Bạn chỉ có thể lưu tối đa %d tin. Hãy bỏ lưu một tin để lưu tin khác.")
+      "Bạn chỉ có thể lưu tối đa %d tin. Hãy bỏ lưu một tin để lưu tin khác."),
+  // Saving twice / unsaving something that was never saved are both "the state
+  // you asked for is already the state you have" — a client (chatbot, double
+  // tap, retry) should be able to say so, not report a 500 Unknown error.
+  SAVED_LISTING_ALREADY_SAVED("24002", HttpStatus.CONFLICT,
+      "Tin này đã có trong danh sách yêu thích của bạn."),
+  SAVED_LISTING_NOT_SAVED("24003", HttpStatus.NOT_FOUND,
+      "Tin này không có trong danh sách yêu thích của bạn.")
   ;
 
   private final String value;

--- a/smart-rent/src/main/java/com/smartrent/service/listing/impl/SavedListingServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/listing/impl/SavedListingServiceImpl.java
@@ -65,7 +65,7 @@ public class SavedListingServiceImpl implements SavedListingService {
         
         // Check if already saved
         if (savedListingRepository.existsByIdUserIdAndIdListingId(userId, request.getListingId())) {
-            throw new RuntimeException("Listing is already saved by this user");
+            throw new DomainException(DomainCode.SAVED_LISTING_ALREADY_SAVED);
         }
 
         // Soft cap so a user's saved list can't grow unbounded. Reads the count
@@ -94,7 +94,7 @@ public class SavedListingServiceImpl implements SavedListingService {
         
         SavedListingId id = new SavedListingId(userId, listingId);
         if (!savedListingRepository.existsById(id)) {
-            throw new RuntimeException("Saved listing not found");
+            throw new DomainException(DomainCode.SAVED_LISTING_NOT_SAVED);
         }
         
         savedListingRepository.deleteByIdUserIdAndIdListingId(userId, listingId);

--- a/smart-rent/src/test/java/com/smartrent/service/listing/impl/SavedListingServiceImplTest.java
+++ b/smart-rent/src/test/java/com/smartrent/service/listing/impl/SavedListingServiceImplTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 
@@ -74,6 +75,36 @@ class SavedListingServiceImplTest {
 
         assertEquals(DomainCode.SAVED_LISTING_LIMIT_EXCEEDED, ex.getDomainCode());
         verify(savedListingRepository, never()).save(any());
+    }
+
+    /**
+     * Saving something already saved used to throw a bare RuntimeException,
+     * which GlobalExceptionHandler maps to UNKNOWN_ERROR / 500 — so a duplicate
+     * save (chatbot re-saving, double tap, retry) looked like a server crash
+     * even though the controller already documents a 409. Same for unsaving
+     * something that was never saved, documented as 404.
+     */
+    @Test
+    void saveListingThrowsConflictWhenAlreadySaved() {
+        SavedListingRequest request = SavedListingRequest.builder().listingId(999L).build();
+        when(savedListingRepository.existsByIdUserIdAndIdListingId(USER_ID, 999L)).thenReturn(true);
+
+        DomainException ex = assertThrows(DomainException.class, () -> service.saveListing(request));
+
+        assertEquals(DomainCode.SAVED_LISTING_ALREADY_SAVED, ex.getDomainCode());
+        assertEquals(HttpStatus.CONFLICT, ex.getDomainCode().getStatus());
+        verify(savedListingRepository, never()).save(any());
+    }
+
+    @Test
+    void unsaveListingThrowsNotFoundWhenNeverSaved() {
+        when(savedListingRepository.existsById(new SavedListingId(USER_ID, 999L))).thenReturn(false);
+
+        DomainException ex = assertThrows(DomainException.class, () -> service.unsaveListing(999L));
+
+        assertEquals(DomainCode.SAVED_LISTING_NOT_SAVED, ex.getDomainCode());
+        assertEquals(HttpStatus.NOT_FOUND, ex.getDomainCode().getStatus());
+        verify(savedListingRepository, never()).deleteByIdUserIdAndIdListingId(any(), any());
     }
 
     @Test


### PR DESCRIPTION
## Vấn đề

`SavedListingServiceImpl` ném `RuntimeException` trần cho 2 trường hợp:

```java
throw new RuntimeException("Listing is already saved by this user");
throw new RuntimeException("Saved listing not found");
```

`GlobalExceptionHandler` bắt `Exception.class` → map về `UNKNOWN_ERROR` / **500**. Nghĩa là lưu trùng một tin (chatbot lưu lại, user bấm 2 lần, retry) hiện ra như **server sập**.

Trong khi đó `SavedListingController` **đã document sẵn 409 và 404** cho đúng 2 case này trong Swagger — implementation chưa bao giờ trả về đúng thứ nó hứa. Ví dụ trong doc còn ghi `"code": "LISTING_ALREADY_SAVED"` / `"SAVED_LISTING_NOT_FOUND"`, hai tên không tồn tại trong `DomainCode`.

## Thay đổi

- `DomainCode`: thêm `SAVED_LISTING_ALREADY_SAVED("24002", CONFLICT)` và `SAVED_LISTING_NOT_SAVED("24003", NOT_FOUND)`, message tiếng Việt sẵn dùng để client hiển thị thẳng.
- 2 chỗ `RuntimeException` → `DomainException`.
- Sửa lại ví dụ Swagger cho khớp code thật.

Không đổi hành vi thành công, không đổi schema DB, không có migration.

## Kiểm chứng

```
./gradlew test --tests "*SavedListingServiceImplTest*"  → pass
```

Thêm 2 test: lưu trùng ném `SAVED_LISTING_ALREADY_SAVED` với status 409 và không gọi `save()`; bỏ lưu tin chưa lưu ném `SAVED_LISTING_NOT_SAVED` với status 404 và không gọi `delete`.

Đi kèm smartrent-ai #93 (chatbot đọc code này để trả lời "tin đã lưu trước đó rồi" thay vì báo lỗi). Bên AI đã handle cả trường hợp backend **chưa** deploy (vẫn match message cũ), nên 2 PR không bắt buộc lên cùng lúc.