### PR TITLE
fix(quota): scope push-quota availability/consumption to the current …

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/infra/repository/UserMembershipBenefitRepository.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/UserMembershipBenefitRepository.java
@@ -24,10 +24,26 @@ public interface UserMembershipBenefitRepository extends JpaRepository<UserMembe
 
     List<UserMembershipBenefit> findByUserIdAndBenefitTypeAndStatus(String userId, BenefitType benefitType, BenefitStatus status);
 
-    @Query("SELECT umb FROM user_membership_benefits umb WHERE umb.userId = :userId AND umb.benefitType = :benefitType AND umb.status = 'ACTIVE' AND umb.expiresAt > :now AND umb.quantityUsed < umb.totalQuantity ORDER BY umb.expiresAt ASC")
+    // Scoped to the user's CURRENT membership slot (same predicate as
+    // UserMembershipRepository.findActiveUserMembership) — mapToUserMembershipResponse
+    // only ever renders benefits for that one slot, so consumption/availability
+    // must agree with it. Without this join, a benefit row that belongs to a
+    // queued/upgraded/renewed slot (never shown on the seller's benefit card)
+    // could still be picked up and silently decremented here, making a push
+    // look like it "used quota" while the visible counter never moves.
+    @Query("SELECT umb FROM user_membership_benefits umb JOIN umb.userMembership um " +
+            "WHERE umb.userId = :userId AND umb.benefitType = :benefitType AND umb.status = 'ACTIVE' " +
+            "AND umb.expiresAt > :now AND umb.quantityUsed < umb.totalQuantity " +
+            "AND um.status = 'ACTIVE' AND um.startDate <= :now AND um.endDate > :now " +
+            "ORDER BY umb.expiresAt ASC")
     List<UserMembershipBenefit> findAvailableBenefits(@Param("userId") String userId, @Param("benefitType") BenefitType benefitType, @Param("now") LocalDateTime now);
 
-    @Query(value = "SELECT * FROM user_membership_benefits umb WHERE umb.user_id = :userId AND umb.benefit_type = :benefitType AND umb.status = 'ACTIVE' AND umb.expires_at > :now AND umb.quantity_used < umb.total_quantity ORDER BY umb.expires_at ASC LIMIT 1", nativeQuery = true)
+    @Query(value = "SELECT umb.* FROM user_membership_benefits umb " +
+            "JOIN user_memberships um ON um.user_membership_id = umb.user_membership_id " +
+            "WHERE umb.user_id = :userId AND umb.benefit_type = :benefitType AND umb.status = 'ACTIVE' " +
+            "AND umb.expires_at > :now AND umb.quantity_used < umb.total_quantity " +
+            "AND um.status = 'ACTIVE' AND um.start_date <= :now AND um.end_date > :now " +
+            "ORDER BY umb.expires_at ASC LIMIT 1", nativeQuery = true)
     Optional<UserMembershipBenefit> findFirstAvailableBenefit(@Param("userId") String userId, @Param("benefitType") String benefitType, @Param("now") LocalDateTime now);
 
     @Query("SELECT umb FROM user_membership_benefits umb WHERE umb.status = 'ACTIVE' AND umb.expiresAt <= :now")
@@ -37,13 +53,19 @@ public interface UserMembershipBenefitRepository extends JpaRepository<UserMembe
     @Query("UPDATE user_membership_benefits umb SET umb.status = 'EXPIRED' WHERE umb.status = 'ACTIVE' AND umb.expiresAt <= :now")
     int expireOldBenefits(@Param("now") LocalDateTime now);
 
-    @Query("SELECT SUM(umb.totalQuantity - umb.quantityUsed) FROM user_membership_benefits umb WHERE umb.userId = :userId AND umb.benefitType = :benefitType AND umb.status = 'ACTIVE' AND umb.expiresAt > :now")
+    @Query("SELECT SUM(umb.totalQuantity - umb.quantityUsed) FROM user_membership_benefits umb JOIN umb.userMembership um " +
+            "WHERE umb.userId = :userId AND umb.benefitType = :benefitType AND umb.status = 'ACTIVE' AND umb.expiresAt > :now " +
+            "AND um.status = 'ACTIVE' AND um.startDate <= :now AND um.endDate > :now")
     Integer getTotalAvailableQuota(@Param("userId") String userId, @Param("benefitType") BenefitType benefitType, @Param("now") LocalDateTime now);
 
-    @Query("SELECT SUM(umb.totalQuantity) FROM user_membership_benefits umb WHERE umb.userId = :userId AND umb.benefitType = :benefitType AND umb.status = 'ACTIVE' AND umb.expiresAt > :now")
+    @Query("SELECT SUM(umb.totalQuantity) FROM user_membership_benefits umb JOIN umb.userMembership um " +
+            "WHERE umb.userId = :userId AND umb.benefitType = :benefitType AND umb.status = 'ACTIVE' AND umb.expiresAt > :now " +
+            "AND um.status = 'ACTIVE' AND um.startDate <= :now AND um.endDate > :now")
     Integer getTotalGrantedQuota(@Param("userId") String userId, @Param("benefitType") BenefitType benefitType, @Param("now") LocalDateTime now);
 
-    @Query("SELECT SUM(umb.quantityUsed) FROM user_membership_benefits umb WHERE umb.userId = :userId AND umb.benefitType = :benefitType AND umb.status = 'ACTIVE' AND umb.expiresAt > :now")
+    @Query("SELECT SUM(umb.quantityUsed) FROM user_membership_benefits umb JOIN umb.userMembership um " +
+            "WHERE umb.userId = :userId AND umb.benefitType = :benefitType AND umb.status = 'ACTIVE' AND umb.expiresAt > :now " +
+            "AND um.status = 'ACTIVE' AND um.startDate <= :now AND um.endDate > :now")
     Integer getTotalUsedQuota(@Param("userId") String userId, @Param("benefitType") BenefitType benefitType, @Param("now") LocalDateTime now);
 
     List<UserMembershipBenefit> findByUserMembershipUserMembershipId(Long userMembershipId);


### PR DESCRIPTION
…membership slot

checkQuotaAvailability/consumeQuota (backing PushServiceImpl and the push-quota FE display) looked up UserMembershipBenefit rows by userId + benefitType only, with no link back to a specific UserMembership. The seller-facing benefit card, though, only ever renders the CURRENT slot's benefits (mapToUserMembershipResponse scopes by userMembershipId). Any benefit row belonging to a queued/upgraded/ renewed slot could still be matched and silently decremented by findFirstAvailableBenefit's "first available, any slot" ordering, making a push report success via quota while the counter the seller actually sees never moves. Join to user_memberships and require the same current-slot predicate used everywhere else (status=ACTIVE, startDate<=now<endDate) so consumption always lines up with what's displayed.