### PR TITLE
fix(ai-moderation): duplicate check đọc location từ cột listing + siết notification

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/infra/repository/entity/Listing.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/entity/Listing.java
@@ -259,10 +259,12 @@ public class Listing {
 
     // Denormalized location keys copied from the referenced Address (fixed
     // reference data). Populated by updateSearchFields() on persist/update and
-    // backfilled in V97. These exist ONLY so the recommendation candidate
-    // queries can filter AND sort on listings alone (see idx_listings_reco_*),
-    // turning a cross-table filter+sort filesort into an index-ordered scan.
-    // Read the Address entity for canonical values; never write these directly.
+    // backfilled in V97. Originally added so the recommendation candidate
+    // queries could filter AND sort on listings alone (see idx_listings_reco_*),
+    // turning a cross-table filter+sort filesort into an index-ordered scan —
+    // and now also the only safe way to read a listing's location off a
+    // detached entity, since `address` is a LAZY proxy. Never write directly;
+    // updateSearchFields() owns them.
     @Column(name = "new_province_code", length = 10)
     String newProvinceCode;
 
@@ -470,6 +472,23 @@ public class Listing {
 
     public boolean isActive() {
         return !isExpiredListing() && (isAutoVerified() || isManuallyVerified());
+    }
+
+    /**
+     * Province code for AI duplicate detection: the post-reform code when the
+     * address has one, else the legacy province id as a string.
+     * <p>
+     * Reads the denormalized columns rather than the {@code address} proxy, so
+     * it works on a detached entity. The moderation sweep loads listings with a
+     * query that does not fetch the address and then hands them to a worker
+     * thread with no session — {@code getAddress()} there threw
+     * LazyInitializationException, which the duplicate check swallowed as PASS.
+     */
+    public String resolveProvinceCodeForAi() {
+        if (newProvinceCode != null) {
+            return newProvinceCode;
+        }
+        return legacyProvinceId != null ? String.valueOf(legacyProvinceId) : null;
     }
 
     @PrePersist

--- a/smart-rent/src/main/java/com/smartrent/service/ai/impl/AiListingReVerifyServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/ai/impl/AiListingReVerifyServiceImpl.java
@@ -36,10 +36,10 @@ public class AiListingReVerifyServiceImpl implements AiListingReVerifyService {
     public StoredAiModerationResponse reVerifyAndStore(Long listingId) {
         log.info("Admin-triggered AI re-verification for listing ID: {}", listingId);
 
-        // Fetch with address + amenities so the entity stays usable once detached:
-        // processSingleListing runs in its own (REQUIRES_NEW) transaction and reads
-        // listing.getAddress() for the duplicate check, so that association must be
-        // initialized here to avoid a LazyInitializationException.
+        // Fetch with amenities so the entity stays usable once detached:
+        // processSingleListing runs in its own (REQUIRES_NEW) transaction. The
+        // duplicate check no longer touches the address association — it reads
+        // the denormalized location columns off the listing itself.
         Listing listing = listingRepository.findByIdWithAmenities(listingId)
                 .orElseThrow(() -> new AppException(DomainCode.LISTING_NOT_FOUND));
 

--- a/smart-rent/src/main/java/com/smartrent/service/ai/impl/AiListingVerificationServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/ai/impl/AiListingVerificationServiceImpl.java
@@ -9,7 +9,6 @@ import com.smartrent.dto.response.StoredAiModerationResponse;
 import com.smartrent.infra.exception.AppException;
 import com.smartrent.infra.exception.model.DomainCode;
 import com.smartrent.infra.repository.ListingAiModerationRepository;
-import com.smartrent.infra.repository.entity.Address;
 import com.smartrent.infra.repository.entity.Listing;
 import com.smartrent.infra.repository.entity.ListingAiModeration;
 import com.smartrent.mapper.AiListingMapper;
@@ -289,13 +288,10 @@ public class AiListingVerificationServiceImpl implements AiListingVerificationSe
             .productType(listing.getProductType() != null ? listing.getProductType().name() : null)
             .imageUrls(request.getImages());
 
-        Address addr = listing.getAddress();
-        if (addr != null) {
-            String provinceCode = addr.getNewProvinceCode() != null
-                ? addr.getNewProvinceCode()
-                : (addr.getLegacyProvinceId() != null ? String.valueOf(addr.getLegacyProvinceId()) : null);
-            builder.provinceCode(provinceCode).districtId(addr.getLegacyDistrictId());
-        }
+        // Denormalized columns, not the LAZY address proxy — same reason as in
+        // AiModerationProcessorServiceImpl: this runs on detached entities.
+        builder.provinceCode(listing.resolveProvinceCodeForAi())
+            .districtId(listing.getLegacyDistrictId());
 
         return smartRentAiConnector.checkDuplicate(builder.build());
     }

--- a/smart-rent/src/main/java/com/smartrent/service/ai/impl/AiModerationProcessorServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/ai/impl/AiModerationProcessorServiceImpl.java
@@ -1,6 +1,7 @@
 package com.smartrent.service.ai.impl;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.smartrent.dto.request.AiListingVerificationRequest;
 import com.smartrent.dto.request.DuplicateCheckRequest;
@@ -18,6 +19,7 @@ import com.smartrent.service.ai.AiModerationProcessorService;
 import com.smartrent.service.notification.NotificationService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -37,6 +39,14 @@ public class AiModerationProcessorServiceImpl implements AiModerationProcessorSe
     private final SmartRentAiConnector smartRentAiConnector;
     private final ObjectMapper objectMapper;
     private final AiModerationExecutor aiModerationExecutor;
+
+    /** Page admins on the AI's low-confidence bucket too. Off: it is noise. */
+    @Value("${smartrent.ai.duplicate.notify-suspicious:false}")
+    private boolean notifySuspicious;
+
+    /** Similarity below this never pages admins, whatever the decision says. */
+    @Value("${smartrent.ai.duplicate.notify-min-score:0.85}")
+    private double notifyMinScore;
 
     /**
      * Pre-computes the AI analysis for a single listing and STORES it, in its own
@@ -104,6 +114,11 @@ public class AiModerationProcessorServiceImpl implements AiModerationProcessorSe
                 moderation.setVerificationStatus(VerificationStatus.UNDER_REVIEW);
             }
 
+            // Captured before the row is overwritten: it is how we tell a first
+            // detection from a re-analysis of a listing admins were already told
+            // about (re-verify button, retry, backstop sweep re-running).
+            String previousAiReason = moderation.getAiReason();
+
             try {
                 // Persist verification + duplicate result together so the review dialog can
                 // show image/video issues, violations, and any duplicate matches in one place.
@@ -122,9 +137,7 @@ public class AiModerationProcessorServiceImpl implements AiModerationProcessorSe
 
             // Duplicates are the one thing worth proactively alerting admins about, since
             // the listing would otherwise look unremarkable in the review queue.
-            if (duplicateResult != null
-                    && ("DUPLICATE".equals(duplicateResult.getDecision())
-                        || "SUSPICIOUS".equals(duplicateResult.getDecision()))) {
+            if (shouldNotifyDuplicate(listing, duplicateResult, previousAiReason)) {
                 log.info("Listing ID {} flagged as {} (score={}) — notifying admins.",
                         listing.getListingId(), duplicateResult.getDecision(), duplicateResult.getHighestScore());
                 sendAdminDuplicateNotification(listing, duplicateResult);
@@ -135,6 +148,74 @@ public class AiModerationProcessorServiceImpl implements AiModerationProcessorSe
             moderation.setRetryCount(moderation.getRetryCount() + 1);
             moderation.setVerificationStatus(VerificationStatus.PENDING); // revert for retry
             listingAiModerationRepository.save(moderation);
+        }
+    }
+
+    /**
+     * Whether this duplicate result is worth paging every admin about.
+     *
+     * <p>Every hit used to notify: both DUPLICATE and SUSPICIOUS, at any score,
+     * every time a listing was re-analysed, one notification row per admin. A
+     * backlog drained through the backstop sweep would bury the admin inbox in
+     * exactly the notifications they are least able to act on in bulk. Three
+     * gates, all defaulting to the quiet side:
+     *
+     * <ul>
+     *   <li>SUSPICIOUS is off by default — it is the AI's low-confidence bucket,
+     *       and it is already visible in the review dialog either way. Set
+     *       {@code AI_DUPLICATE_NOTIFY_SUSPICIOUS=true} to page on it too.</li>
+     *   <li>Below {@code AI_DUPLICATE_NOTIFY_MIN_SCORE} is off — a DUPLICATE
+     *       verdict scraping the decision threshold is not worth an alert.</li>
+     *   <li>A listing already reported as a duplicate is never reported twice.
+     *       Re-verify, retry and the sweep all re-run the check on listings the
+     *       admin has already been told about.</li>
+     * </ul>
+     *
+     * None of this hides anything: the full duplicate result is still stored on
+     * the moderation row and rendered in the review dialog. This only decides
+     * whether to interrupt an admin about it.
+     */
+    private boolean shouldNotifyDuplicate(Listing listing,
+                                          DuplicateCheckResponse duplicateResult,
+                                          String previousAiReason) {
+        if (duplicateResult == null) {
+            return false;
+        }
+        String decision = duplicateResult.getDecision();
+        boolean flagged = "DUPLICATE".equals(decision)
+                || (notifySuspicious && "SUSPICIOUS".equals(decision));
+        if (!flagged) {
+            return false;
+        }
+        if (duplicateResult.getHighestScore() < notifyMinScore) {
+            log.debug("Listing ID {} flagged as {} but score {} < {} — not notifying admins.",
+                    listing.getListingId(), decision, duplicateResult.getHighestScore(), notifyMinScore);
+            return false;
+        }
+        if (wasAlreadyReportedAsDuplicate(previousAiReason)) {
+            log.debug("Listing ID {} was already reported as a duplicate — not notifying admins again.",
+                    listing.getListingId());
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Reads the decision out of the previously stored aiReason JSON. Parse
+     * failures answer "not reported before", so a malformed old row costs a
+     * duplicate notification rather than a missed one.
+     */
+    private boolean wasAlreadyReportedAsDuplicate(String previousAiReason) {
+        if (previousAiReason == null || previousAiReason.isBlank()) {
+            return false;
+        }
+        try {
+            JsonNode decision = objectMapper.readTree(previousAiReason)
+                    .path("duplicateCheck").path("decision");
+            return "DUPLICATE".equals(decision.asText(null))
+                    || (notifySuspicious && "SUSPICIOUS".equals(decision.asText(null)));
+        } catch (JsonProcessingException e) {
+            return false;
         }
     }
 

--- a/smart-rent/src/main/java/com/smartrent/service/ai/impl/AiModerationProcessorServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/ai/impl/AiModerationProcessorServiceImpl.java
@@ -9,7 +9,6 @@ import com.smartrent.dto.response.DuplicateCheckResponse;
 import com.smartrent.enums.NotificationType;
 import com.smartrent.infra.connector.SmartRentAiConnector;
 import com.smartrent.infra.repository.ListingAiModerationRepository;
-import com.smartrent.infra.repository.entity.Address;
 import com.smartrent.infra.repository.entity.Listing;
 import com.smartrent.infra.repository.entity.ListingAiModeration;
 import com.smartrent.infra.repository.entity.enums.VerificationStatus;
@@ -175,13 +174,14 @@ public class AiModerationProcessorServiceImpl implements AiModerationProcessorSe
                     .productType(listing.getProductType() != null ? listing.getProductType().name() : null)
                     .imageUrls(request.getImages());
 
-            Address addr = listing.getAddress();
-            if (addr != null) {
-                String provinceCode = addr.getNewProvinceCode() != null
-                        ? addr.getNewProvinceCode()
-                        : (addr.getLegacyProvinceId() != null ? String.valueOf(addr.getLegacyProvinceId()) : null);
-                builder.provinceCode(provinceCode).districtId(addr.getLegacyDistrictId());
-            }
+            // Read location off the listing's own denormalized columns, not the
+            // LAZY address proxy: the reconciliation sweep fetches listings
+            // without the address association and processes them on the
+            // ai-mod-task pool, where touching the proxy threw
+            // LazyInitializationException — caught below and logged as
+            // "treating as PASS", i.e. duplicate detection silently disabled.
+            builder.provinceCode(listing.resolveProvinceCodeForAi())
+                    .districtId(listing.getLegacyDistrictId());
 
             return smartRentAiConnector.checkDuplicate(builder.build());
         } catch (Exception e) {

--- a/smart-rent/src/main/resources/application.yml
+++ b/smart-rent/src/main/resources/application.yml
@@ -570,6 +570,15 @@ smartrent:
         delay: ${AI_SCHEDULER_DELAY_MS:1800000}
         batch-size: ${AI_SCHEDULER_BATCH_SIZE:10}
       url: ${AI_VERIFICATION_URL:http://localhost:8000/ai/verify-listing}
+      # Which duplicate hits interrupt an admin. The full result is stored and
+      # shown in the review dialog regardless — these only gate the push
+      # notification, which fans out to EVERY admin. Draining a backlog through
+      # the backstop sweep would otherwise bury the inbox in low-confidence
+      # flags nobody can action in bulk. A listing already reported as a
+      # duplicate is never reported again (re-verify / retry / sweep re-runs).
+      duplicate:
+        notify-suspicious: ${AI_DUPLICATE_NOTIFY_SUSPICIOUS:false}
+        notify-min-score: ${AI_DUPLICATE_NOTIFY_MIN_SCORE:0.85}
       timeout-seconds: ${AI_VERIFICATION_TIMEOUT:90}
       max-retry-attempts: ${AI_VERIFICATION_MAX_RETRY:3}
       retry-backoff-seconds: ${AI_VERIFICATION_RETRY_BACKOFF:2}

--- a/smart-rent/src/test/java/com/smartrent/service/ai/impl/AiModerationDuplicateCheckLocationTest.java
+++ b/smart-rent/src/test/java/com/smartrent/service/ai/impl/AiModerationDuplicateCheckLocationTest.java
@@ -1,0 +1,133 @@
+package com.smartrent.service.ai.impl;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.smartrent.dto.request.AiListingVerificationRequest;
+import com.smartrent.dto.request.DuplicateCheckRequest;
+import com.smartrent.dto.response.AiListingVerificationResponse;
+import com.smartrent.dto.response.DuplicateCheckResponse;
+import com.smartrent.infra.connector.SmartRentAiConnector;
+import com.smartrent.infra.repository.ListingAiModerationRepository;
+import com.smartrent.infra.repository.entity.Listing;
+import com.smartrent.infra.repository.entity.ListingAiModeration;
+import com.smartrent.service.ai.AiListingVerificationService;
+import com.smartrent.service.ai.AiModerationExecutor;
+import com.smartrent.service.notification.NotificationService;
+import org.hibernate.LazyInitializationException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * The reconciliation sweep loads listings with a query that does not fetch the
+ * address association and then processes them on the {@code ai-mod-task} pool,
+ * with no session bound to that thread. Reading {@code listing.getAddress()}
+ * for the duplicate check therefore threw LazyInitializationException, which
+ * runDuplicateCheck catches and logs as "treating as PASS" — duplicate
+ * detection was silently off for every listing that came through the sweep.
+ *
+ * <p>Location now comes from the listing's own denormalized columns (V97), so
+ * no session is needed. This test proves it by making the address proxy throw.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class AiModerationDuplicateCheckLocationTest {
+
+    @Mock
+    ListingAiModerationRepository listingAiModerationRepository;
+
+    @Mock
+    AiListingVerificationService aiVerificationService;
+
+    @Mock
+    NotificationService notificationService;
+
+    @Mock
+    SmartRentAiConnector smartRentAiConnector;
+
+    @Mock
+    AiModerationExecutor aiModerationExecutor;
+
+    ObjectMapper objectMapper = new ObjectMapper();
+
+    @InjectMocks
+    AiModerationProcessorServiceImpl service;
+
+    private AiModerationProcessorServiceImpl newService() {
+        return new AiModerationProcessorServiceImpl(
+                listingAiModerationRepository,
+                aiVerificationService,
+                notificationService,
+                smartRentAiConnector,
+                objectMapper,
+                aiModerationExecutor);
+    }
+
+    @Test
+    void duplicateCheckReadsLocationWithoutTouchingTheAddressProxy() {
+        // A detached listing: the address proxy blows up exactly like it does on
+        // the ai-mod-task thread, but the denormalized columns are populated.
+        Listing listing = new Listing() {
+            @Override
+            public com.smartrent.infra.repository.entity.Address getAddress() {
+                throw new LazyInitializationException(
+                        "Could not initialize proxy [Address#508468] - no session");
+            }
+        };
+        listing.setListingId(716923L);
+        listing.setTitle("Cho thuê phòng");
+        listing.setNewProvinceCode("79");
+        listing.setLegacyDistrictId(760);
+
+        when(aiModerationExecutor.taskPool()).thenReturn(Runnable::run);
+        when(aiVerificationService.buildVerificationRequest(anyLong()))
+                .thenReturn(AiListingVerificationRequest.builder().title("Cho thuê phòng").build());
+        when(aiVerificationService.verifyListing(any(AiListingVerificationRequest.class)))
+                .thenReturn(AiListingVerificationResponse.builder().score(0.9).build());
+        when(smartRentAiConnector.checkDuplicate(any()))
+                .thenReturn(DuplicateCheckResponse.builder().decision("UNIQUE").build());
+
+        newService().processSingleListing(listing, ListingAiModeration.builder()
+                .listingId(716923L)
+                .retryCount(0)
+                .build());
+
+        ArgumentCaptor<DuplicateCheckRequest> sent =
+                ArgumentCaptor.forClass(DuplicateCheckRequest.class);
+        verify(smartRentAiConnector).checkDuplicate(sent.capture());
+        assertEquals("79", sent.getValue().getProvinceCode());
+        assertEquals(760, sent.getValue().getDistrictId());
+    }
+
+    @Test
+    void provinceCodeFallsBackToTheLegacyIdWhenThereIsNoNewCode() {
+        Listing listing = new Listing();
+        listing.setLegacyProvinceId(79);
+
+        assertEquals("79", listing.resolveProvinceCodeForAi());
+    }
+
+    @Test
+    void provinceCodePrefersTheNewCode() {
+        Listing listing = new Listing();
+        listing.setNewProvinceCode("79");
+        listing.setLegacyProvinceId(1);
+
+        assertEquals("79", listing.resolveProvinceCodeForAi());
+    }
+
+    @Test
+    void provinceCodeIsNullWhenTheListingHasNoLocationAtAll() {
+        assertEquals(null, new Listing().resolveProvinceCodeForAi());
+    }
+}

--- a/smart-rent/src/test/java/com/smartrent/service/ai/impl/AiModerationDuplicateNotificationTest.java
+++ b/smart-rent/src/test/java/com/smartrent/service/ai/impl/AiModerationDuplicateNotificationTest.java
@@ -1,0 +1,165 @@
+package com.smartrent.service.ai.impl;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.smartrent.dto.request.AiListingVerificationRequest;
+import com.smartrent.dto.response.AiListingVerificationResponse;
+import com.smartrent.dto.response.DuplicateCheckResponse;
+import com.smartrent.enums.NotificationType;
+import com.smartrent.infra.connector.SmartRentAiConnector;
+import com.smartrent.infra.repository.ListingAiModerationRepository;
+import com.smartrent.infra.repository.entity.Listing;
+import com.smartrent.infra.repository.entity.ListingAiModeration;
+import com.smartrent.service.ai.AiListingVerificationService;
+import com.smartrent.service.ai.AiModerationExecutor;
+import com.smartrent.service.notification.NotificationService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * A duplicate hit fans out a notification to EVERY admin. Before this, every
+ * hit qualified: DUPLICATE and SUSPICIOUS alike, at any similarity score, and
+ * again on every re-analysis of the same listing. Draining a backlog through
+ * the backstop sweep would bury the admin inbox in flags nobody can action in
+ * bulk — so the alert is gated, while the full result stays on the moderation
+ * row for the review dialog either way.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class AiModerationDuplicateNotificationTest {
+
+    private static final long LISTING_ID = 716923L;
+
+    @Mock
+    ListingAiModerationRepository listingAiModerationRepository;
+
+    @Mock
+    AiListingVerificationService aiVerificationService;
+
+    @Mock
+    NotificationService notificationService;
+
+    @Mock
+    SmartRentAiConnector smartRentAiConnector;
+
+    @Mock
+    AiModerationExecutor aiModerationExecutor;
+
+    ObjectMapper objectMapper = new ObjectMapper();
+
+    AiModerationProcessorServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new AiModerationProcessorServiceImpl(
+                listingAiModerationRepository,
+                aiVerificationService,
+                notificationService,
+                smartRentAiConnector,
+                objectMapper,
+                aiModerationExecutor);
+        // @Value defaults are not applied when the bean is built by hand.
+        ReflectionTestUtils.setField(service, "notifySuspicious", false);
+        ReflectionTestUtils.setField(service, "notifyMinScore", 0.85);
+
+        when(aiModerationExecutor.taskPool()).thenReturn(Runnable::run);
+        when(aiVerificationService.buildVerificationRequest(anyLong()))
+                .thenReturn(AiListingVerificationRequest.builder().title("Cho thuê phòng").build());
+        when(aiVerificationService.verifyListing(any(AiListingVerificationRequest.class)))
+                .thenReturn(AiListingVerificationResponse.builder().score(0.9).build());
+    }
+
+    private void run(String decision, double score, String previousAiReason) {
+        when(smartRentAiConnector.checkDuplicate(any())).thenReturn(
+                DuplicateCheckResponse.builder().decision(decision).highestScore(score).build());
+
+        Listing listing = new Listing();
+        listing.setListingId(LISTING_ID);
+        listing.setTitle("Cho thuê phòng");
+
+        service.processSingleListing(listing, ListingAiModeration.builder()
+                .listingId(LISTING_ID)
+                .retryCount(0)
+                .aiReason(previousAiReason)
+                .build());
+    }
+
+    private void verifyNotified(int times) {
+        verify(notificationService, times(times)).sendToAllAdmins(
+                eq(NotificationType.LISTING_DUPLICATE_DETECTED),
+                anyString(), anyString(), anyLong(), anyString());
+    }
+
+    @Test
+    void confidentDuplicateStillNotifies() {
+        run("DUPLICATE", 0.95, null);
+        verifyNotified(1);
+    }
+
+    @Test
+    void suspiciousIsSilentByDefault() {
+        run("SUSPICIOUS", 0.99, null);
+        verifyNotified(0);
+    }
+
+    @Test
+    void suspiciousNotifiesWhenTheFlagIsTurnedOn() {
+        ReflectionTestUtils.setField(service, "notifySuspicious", true);
+        run("SUSPICIOUS", 0.99, null);
+        verifyNotified(1);
+    }
+
+    @Test
+    void duplicateBelowTheScoreThresholdIsSilent() {
+        run("DUPLICATE", 0.70, null);
+        verifyNotified(0);
+    }
+
+    @Test
+    void aListingAlreadyReportedIsNotReportedAgain() {
+        // The state a re-verify / retry / sweep re-run starts from.
+        run("DUPLICATE", 0.95, "{\"duplicateCheck\":{\"decision\":\"DUPLICATE\"}}");
+        verifyNotified(0);
+    }
+
+    @Test
+    void aListingThatOnlyPassedBeforeIsReportedOnTheFirstDuplicateHit() {
+        run("DUPLICATE", 0.95, "{\"duplicateCheck\":{\"decision\":\"PASS\"}}");
+        verifyNotified(1);
+    }
+
+    @Test
+    void unparseableOldReasonErrsTowardsNotifying() {
+        run("DUPLICATE", 0.95, "not json at all");
+        verifyNotified(1);
+    }
+
+    @Test
+    void passNeverNotifies() {
+        run("PASS", 0.99, null);
+        verifyNotified(0);
+    }
+
+    @Test
+    void theResultIsStoredEvenWhenTheAlertIsSuppressed() {
+        // Suppressing the notification must not suppress the evidence — the
+        // review dialog still needs to show why the listing was flagged.
+        run("SUSPICIOUS", 0.99, null);
+        verifyNotified(0);
+        verify(listingAiModerationRepository).save(org.mockito.ArgumentMatchers.argThat(
+                saved -> saved.getAiReason() != null && saved.getAiReason().contains("SUSPICIOUS")));
+    }
+}


### PR DESCRIPTION
## Triệu chứng

```
WARN Duplicate check failed for listing ID 716923 (treating as PASS):
     Could not initialize proxy [Address#508468] - no session
```

Nhìn như warning lẻ, thực chất là **chống trùng tin bị bỏ qua** cho mọi tin dính lỗi này.

## Nguyên nhân

`runDuplicateCheck` chạy trong `CompletableFuture.supplyAsync(..., taskPool())` — tức là trên thread `ai-mod-task`, **không có Hibernate session**. Nó đọc `listing.getAddress()` (LAZY proxy) để lấy `provinceCode`/`districtId` → `LazyInitializationException` → rơi vào `catch (Exception e)` bao ngoài → log *"treating as PASS"*.

Tin nào dính phụ thuộc vào việc entity có được nạp sẵn `address` hay không:

| Đường vào | `address` fetch sẵn? |
|---|---|
| Queue (`AiAnalysisWorker` → `findByIdWithAmenities`) | Có (`LEFT JOIN FETCH l.address`) |
| Re-verify thủ công (cùng query) | Có |
| Backstop sweep (`findListingsNeedingAiVerification`) | **Không** |

> **Đính chính:** bản mô tả đầu tiên của PR này khẳng định thủ phạm là backstop sweep. Chưa kiểm chứng được — `AI_SCHEDULER_ENABLED` mặc định `false` và repo deploy không set nó, nên nhiều khả năng sweep đang **tắt** trên prod và log kia đến từ đường khác (vd bản build đang chạy có `findByIdWithAmenities` chưa kèm `JOIN FETCH l.address`). Không xác định được đường chính xác từ code. **Fix không phụ thuộc vào điều đó** — bỏ hẳn việc chạm proxy thì cả 3 đường đều miễn nhiễm.

## Commit 1 — bỏ phụ thuộc vào Address

Listing đã mang sẵn `new_province_code` / `legacy_province_id` / `legacy_district_id` **denormalized** (V97, đồng bộ bởi `@PrePersist`/`@PreUpdate`). Không cần join, không cần session.

- Thêm `Listing.resolveProvinceCodeForAi()` (new code → fallback legacy id).
- Dùng ở **cả 2** call site — `AiModerationProcessorServiceImpl` và `AiListingVerificationServiceImpl` có block giống hệt, bug tồn tại 2 bản.
- Bỏ comment đã sai ở `AiListingReVerifyServiceImpl`.

## Commit 2 — siết notification

Một tin bị flag sẽ đẩy notification tới **mọi admin**, và trước đây *mọi* hit đều đủ điều kiện: cả `DUPLICATE` lẫn `SUSPICIOUS`, ở bất kỳ score nào, và **lặp lại mỗi lần tin được phân tích lại**. Giờ duplicate check thực sự chạy, nếu drain một backlog qua sweep thì inbox admin sẽ ngập.

3 cửa, đều mặc định về phía im lặng:

- `SUSPICIOUS` không còn báo (`AI_DUPLICATE_NOTIFY_SUSPICIOUS=true` để bật lại) — đây là nhóm AI ít tự tin, và vẫn hiện trong dialog duyệt.
- Score dưới `AI_DUPLICATE_NOTIFY_MIN_SCORE` (mặc định `0.85`) không báo.
- Tin **đã từng** được báo trùng thì không báo lại — đọc từ `aiReason` đã lưu, **không cần migration**.

Không giấu gì cả: kết quả duplicate đầy đủ vẫn được lưu trên moderation row và render trong dialog duyệt. 3 cửa này chỉ quyết định **có làm phiền admin hay không**.

## Kiểm chứng

```
./gradlew test --tests "*AiModerationDuplicate*"
  AiModerationDuplicateCheckLocationTest   → 4 tests, 0 failures
  AiModerationDuplicateNotificationTest    → 9 tests, 0 failures
```

Test location dựng một `Listing` mà `getAddress()` **ném thẳng `LazyInitializationException`**, assert request gửi sang AI vẫn có `provinceCode=79`, `districtId=760`.

Cả hai bộ đều **kiểm tra ngược**: tạm khôi phục code cũ → location test đỏ 1/4, notification test đỏ 4/9; khôi phục fix → xanh lại. Test bắt bug thật, không pass suông.