### PR TITLE
perf(map-bounds): ship only what the map draws, and no owner contact details

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/dto/response/ListingCardResponse.java
+++ b/smart-rent/src/main/java/com/smartrent/dto/response/ListingCardResponse.java
@@ -45,6 +45,14 @@ public class ListingCardResponse {
     List<MediaCard> media;
     UserCard user;
 
+    /**
+     * Number of ACTIVE image media on the listing, independent of how many
+     * entries {@link #media} actually carries. Cards render one thumbnail plus a
+     * "N photos" badge, so a caller that trims {@code media} down to the
+     * thumbnail (the map-bounds path) can still show the real count.
+     */
+    Integer imageCount;
+
     @Getter
     @Builder
     @NoArgsConstructor

--- a/smart-rent/src/main/java/com/smartrent/mapper/impl/ListingMapperImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/mapper/impl/ListingMapperImpl.java
@@ -181,6 +181,12 @@ public class ListingMapperImpl implements ListingMapper {
                     .collect(Collectors.toList());
         }
 
+        // Counted from the mapped cards (already ACTIVE-filtered) so it stays in
+        // step with `media` even when a caller later trims that list.
+        int imageCount = mediaCards == null ? 0 : (int) mediaCards.stream()
+                .filter(m -> Media.MediaType.IMAGE.name().equals(m.getMediaType()))
+                .count();
+
         ListingCardResponse.AddressCard addressCard = null;
         if (address != null) {
             addressCard = ListingCardResponse.AddressCard.builder()
@@ -224,6 +230,7 @@ public class ListingMapperImpl implements ListingMapper {
                 .postDate(entity.getPostDate())
                 .address(addressCard)
                 .media(mediaCards)
+                .imageCount(imageCount)
                 .user(userCard)
                 .build();
     }

--- a/smart-rent/src/main/java/com/smartrent/service/listing/impl/ListingServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/listing/impl/ListingServiceImpl.java
@@ -3402,7 +3402,17 @@ public class ListingServiceImpl implements ListingService {
         // description body. Drop it on this path (up to 500 listings per call)
         // so full descriptions don't inflate the payload; the other
         // batchMapCardListings callers keep theirs untouched.
-        listings.forEach(card -> card.setDescription(null));
+        //
+        // Same reasoning for the other two trims below. This response carries up
+        // to 500 cards and is public + unauthenticated, so anything the map does
+        // not draw is pure weight (and, for the contact fields, pure exposure).
+        // The search/homepage cards keep both — their carousel needs every image
+        // and they are shaped by the same DTO.
+        listings.forEach(card -> {
+            card.setDescription(null);
+            card.setMedia(thumbnailOnly(card.getMedia()));
+            card.setUser(withoutContactDetails(card.getUser()));
+        });
 
         // Build bounds info
         com.smartrent.dto.response.MapListingsResponse.MapBoundsInfo boundsInfo =
@@ -3428,5 +3438,58 @@ public class ListingServiceImpl implements ListingService {
                 listings.size(), page.getTotalElements());
 
         return response;
+    }
+
+    /**
+     * Reduces a card's media list to the single entry the map card actually
+     * draws — its thumbnail. A listing routinely carries 5-6 images, none of
+     * which the map renders beyond the first, and the count behind the
+     * "N photos" badge survives in {@code imageCount}.
+     *
+     * <p>Picks the first IMAGE rather than the first entry outright: the list is
+     * ordered primary-first then by sortOrder regardless of type, so a listing
+     * whose primary media is a video would otherwise be left with no thumbnail
+     * at all. Falls back to the first entry when there is no image.
+     *
+     * <p>Returns a plain {@link ArrayList} — this response is cached in Redis
+     * with default typing enabled, and the JDK's immutable list classes are not
+     * publicly constructible on the way back out.
+     */
+    private static List<ListingCardResponse.MediaCard> thumbnailOnly(
+            List<ListingCardResponse.MediaCard> media) {
+        if (media == null || media.size() <= 1) {
+            return media;
+        }
+        ListingCardResponse.MediaCard thumbnail = media.stream()
+                .filter(m -> Media.MediaType.IMAGE.name().equals(m.getMediaType()))
+                .findFirst()
+                .orElse(media.get(0));
+        List<ListingCardResponse.MediaCard> trimmed = new ArrayList<>(1);
+        trimmed.add(thumbnail);
+        return trimmed;
+    }
+
+    /**
+     * Copies a card's owner block without {@code email} and
+     * {@code contactPhoneNumber}. The map card shows a name, avatar and broker
+     * badge only, while {@code POST /v1/listings/map-bounds} is public and
+     * unauthenticated — so shipping those two fields handed anyone the contact
+     * details of up to 500 landlords per request for nothing in return.
+     * {@code contactPhoneVerified} stays: it is the trust badge, not the number.
+     */
+    private static ListingCardResponse.UserCard withoutContactDetails(
+            ListingCardResponse.UserCard user) {
+        if (user == null) {
+            return null;
+        }
+        return ListingCardResponse.UserCard.builder()
+                .userId(user.getUserId())
+                .firstName(user.getFirstName())
+                .lastName(user.getLastName())
+                .contactPhoneVerified(user.getContactPhoneVerified())
+                .avatarUrl(user.getAvatarUrl())
+                .isBroker(user.getIsBroker())
+                .brokerVerificationStatus(user.getBrokerVerificationStatus())
+                .build();
     }
 }

--- a/smart-rent/src/test/java/com/smartrent/service/listing/impl/ListingServiceImplMapBoundsTest.java
+++ b/smart-rent/src/test/java/com/smartrent/service/listing/impl/ListingServiceImplMapBoundsTest.java
@@ -17,9 +17,11 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 
 import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.Mockito.never;
@@ -91,5 +93,92 @@ class ListingServiceImplMapBoundsTest {
         // address lazy and caused the N+1) must not be used on the map path.
         verify(listingRepository).findByIdsWithMediaAndAddress(anyCollection());
         verify(listingRepository, never()).findByIdsWithMedia(anyCollection());
+    }
+
+    /**
+     * The map draws one thumbnail per pin and a "N photos" badge, so shipping
+     * every image URL for up to 500 cards is dead weight. Media must be trimmed
+     * to the first IMAGE while imageCount keeps the real total for the badge.
+     */
+    @Test
+    void mapBoundsTrimsMediaToTheThumbnailAndKeepsTheImageCount() {
+        MapListingsResponse response = runMapBounds(ListingCardResponse.builder()
+                .listingId(1L)
+                .imageCount(6)
+                .media(new ArrayList<>(List.of(
+                        mediaCard("VIDEO", "https://cdn/clip.mp4"),
+                        mediaCard("IMAGE", "https://cdn/first.jpg"),
+                        mediaCard("IMAGE", "https://cdn/second.jpg"))))
+                .build());
+
+        List<ListingCardResponse.MediaCard> media = response.getListings().get(0).getMedia();
+        assertEquals(1, media.size());
+        // The first IMAGE, not the first entry -- a listing whose primary media
+        // is a video must still come back with a usable thumbnail.
+        assertEquals("https://cdn/first.jpg", media.get(0).getUrl());
+        assertEquals(6, response.getListings().get(0).getImageCount());
+    }
+
+    /**
+     * POST /v1/listings/map-bounds is public and unauthenticated, so the owner
+     * contact fields must not ride along on up to 500 cards per request. The
+     * name/avatar/broker badge the card actually renders stays.
+     */
+    @Test
+    void mapBoundsStripsOwnerContactDetails() {
+        MapListingsResponse response = runMapBounds(ListingCardResponse.builder()
+                .listingId(1L)
+                .user(ListingCardResponse.UserCard.builder()
+                        .userId("u1")
+                        .firstName("Minh")
+                        .email("owner@example.com")
+                        .contactPhoneNumber("0900000000")
+                        .contactPhoneVerified(true)
+                        .isBroker(true)
+                        .build())
+                .build());
+
+        ListingCardResponse.UserCard user = response.getListings().get(0).getUser();
+        assertNull(user.getEmail());
+        assertNull(user.getContactPhoneNumber());
+        assertEquals("Minh", user.getFirstName());
+        assertEquals(Boolean.TRUE, user.getContactPhoneVerified());
+        assertEquals(Boolean.TRUE, user.getIsBroker());
+    }
+
+    /** The description body is never rendered on the map. */
+    @Test
+    void mapBoundsDropsTheDescription() {
+        MapListingsResponse response = runMapBounds(ListingCardResponse.builder()
+                .listingId(1L)
+                .description("A very long description body")
+                .build());
+
+        assertNull(response.getListings().get(0).getDescription());
+    }
+
+    private static ListingCardResponse.MediaCard mediaCard(String type, String url) {
+        return ListingCardResponse.MediaCard.builder().mediaType(type).url(url).build();
+    }
+
+    /** Drives getListingsByMapBounds with a single stubbed card. */
+    private MapListingsResponse runMapBounds(ListingCardResponse card) {
+        Listing listing = Listing.builder().listingId(1L).build();
+
+        when(listingQueryService.queryByMapBounds(
+                any(), any(), any(), any(), any(), any(), any(), any()))
+                .thenReturn(new PageImpl<>(List.of(listing), Pageable.unpaged(), 1));
+        when(listingRepository.findByIdsWithMediaAndAddress(anyCollection()))
+                .thenReturn(List.of(listing));
+        when(listingMapper.toCardResponse(any(), any(), any())).thenReturn(card);
+
+        return service.getListingsByMapBounds(MapBoundsRequest.builder()
+                .neLat(BigDecimal.valueOf(10.823))
+                .neLng(BigDecimal.valueOf(106.701))
+                .swLat(BigDecimal.valueOf(10.705))
+                .swLng(BigDecimal.valueOf(106.590))
+                .zoom(14)
+                .limit(100)
+                .build());
     }
 }


### PR DESCRIPTION
## Vì sao

`POST /v1/listings/map-bounds` trả tới **500 card/request** và nằm trong danh sách `permitAll` (public, không cần auth). Mọi field map không vẽ đều là payload thừa — riêng 2 field liên hệ thì còn là lộ thông tin.

Trace lại flow map thì phần query đã tối ưu rồi (FORCE INDEX ~70ms, batch media+address, bỏ join amenities, cache Redis 1m). Phần còn lại nằm ở kích thước payload.

## Thay đổi

Thêm 2 phép cắt trên path map, đi cùng `setDescription(null)` đã có sẵn:

**1. `media` → chỉ giữ ảnh đầu tiên**

Card map chỉ render 1 thumbnail + badge "N ảnh", trong khi mỗi tin thường có 5-6 ảnh — tất cả đều được serialize cho từng pin. Badge vẫn chạy nhờ field mới `imageCount` trên card DTO (set cho mọi caller, additive).

Chọn **ảnh IMAGE đầu tiên** chứ không phải phần tử đầu tiên: list sắp xếp primary-first bất kể loại media, nên tin có video làm primary sẽ mất thumbnail nếu cắt thô.

**2. `email` + `contactPhoneNumber` của chủ tin → bỏ**

Card map chỉ hiện tên, avatar và badge môi giới. Hai field kia cho phép bất kỳ ai không đăng nhập lấy thông tin liên hệ của tới 500 chủ nhà mỗi request. `contactPhoneVerified` giữ lại — đó là badge tin cậy, không phải số điện thoại.

## Phạm vi

Cả hai đều **chỉ áp dụng cho path map**, có chủ đích. `propertyCard` ở search/homepage dùng chung `ListingCardResponse` nhưng carousel của nó **có** render toàn bộ ảnh + video, nên cắt ở đó sẽ hỏng giao diện. `my-listings` dùng DTO khác nên không bị ảnh hưởng.

Đã kiểm tra chéo consumer: không component FE nào (`mapPropertyCard`, `propertyCard`, `listing-card`, compare bar/table) đọc `user.email` hay `user.contactPhoneNumber` từ card; smartrent-ai lấy 2 field này từ `get_user_profile` (có token), không phải từ card; admin dùng DTO listing riêng.

`ArrayList` được dùng thay vì `List.of` vì response này cache trong Redis với default typing bật, các lớp immutable list của JDK không construct lại được lúc deserialize.

## Kiểm chứng

- `./gradlew test` — **110 test, 0 fail**
- 3 test mới trong `ListingServiceImplMapBoundsTest` khoá lại: trim thumbnail + giữ `imageCount`, bỏ contact detail nhưng giữ tên/badge, và drop description

## Cần đi kèm

FE PR bổ sung `imageCount ?? images.length` cho badge ảnh — nên **merge FE trước** (nó backward-compatible, tự fallback khi chưa có `imageCount`).