### PR TITLE
fix(membership): guard completeMembershipUpgrade against duplicate IP…

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/infra/repository/UserMembershipRepository.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/UserMembershipRepository.java
@@ -39,6 +39,11 @@ public interface UserMembershipRepository extends JpaRepository<UserMembership, 
 
     boolean existsByUserIdAndStatus(String userId, MembershipStatus status);
 
+    // Idempotency guard for completeMembershipUpgrade — a payment webhook retry
+    // (IPN redelivery) re-running that method with the same transaction must not
+    // create a second upgraded slot + grant its benefits a second time.
+    Optional<UserMembership> findByUpgradedFromMembershipId(Long upgradedFromMembershipId);
+
     // Returns true when the user has ANY non-expired ACTIVE slot (current or queued).
     // Used as purchase guard — prevents buying a new membership when one already exists.
     @Query("SELECT COUNT(um) > 0 FROM user_memberships um WHERE um.userId = :userId AND um.status = 'ACTIVE' AND um.endDate > :now")

--- a/smart-rent/src/main/java/com/smartrent/service/membership/impl/MembershipServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/membership/impl/MembershipServiceImpl.java
@@ -969,6 +969,20 @@ public class MembershipServiceImpl implements MembershipService {
             throw new RuntimeException("Previous membership ID not found in transaction");
         }
 
+        // Idempotency guard: payment webhooks (SePay/VNPay IPN) can redeliver the same
+        // notification, and this method has no other way to tell a retry apart from the
+        // first call — transaction.isCompleted() stays true forever. Without this, a
+        // redelivered IPN would expire the old slot again (harmless) but ALSO create a
+        // second new membership and grant its benefits a second time, stacking the push/
+        // post quota on top of what the first (legitimate) completion already granted.
+        Optional<UserMembership> alreadyUpgraded = userMembershipRepository
+                .findByUpgradedFromMembershipId(previousMembershipId);
+        if (alreadyUpgraded.isPresent()) {
+            log.warn("Upgrade for transaction {} already completed (previous membership {} already upgraded to {}) - skipping duplicate completion",
+                    transactionId, previousMembershipId, alreadyUpgraded.get().getUserMembershipId());
+            return mapToUserMembershipResponse(alreadyUpgraded.get());
+        }
+
         UserMembership oldMembership = userMembershipRepository.findById(previousMembershipId)
                 .orElseThrow(() -> new RuntimeException("Previous membership not found: " + previousMembershipId));
 


### PR DESCRIPTION
…N delivery

completeMembershipUpgrade only checked transaction.isCompleted() (which never flips back) before expiring the old slot's benefits and granting a brand-new membership + benefits for the target package. Payment gateways (SePay/VNPay) redeliver IPN callbacks on ack timeouts, and a redelivered upgrade completion would create a second UserMembership and grant its benefits again — stacking the new package's push/post quota on top of what the first (legitimate) completion already granted, on top of whatever was left on the old package. Bail out early (return the already-created membership) when a membership already records this previous slot as its upgrade source.