### PR TITLE
fix(membership): expire linked benefits when admin clears a membership

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/service/membership/impl/MembershipServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/membership/impl/MembershipServiceImpl.java
@@ -1267,7 +1267,23 @@ public class MembershipServiceImpl implements MembershipService {
         }
         active.forEach(um -> um.setStatus(MembershipStatus.EXPIRED));
         userMembershipRepository.saveAll(active);
-        log.info("Expired {} active membership(s) for user: {}", active.size(), userId);
+
+        // Every other place that retires a membership (upgrade, renewal lifecycle
+        // job) also expires its linked benefits — this one didn't, leaving orphaned
+        // rows with status=ACTIVE in user_membership_benefits. The quota queries now
+        // exclude them indirectly (they join back to the membership's own status),
+        // but leaving the benefit's own status stale is misleading for anything that
+        // reads it directly (admin views, history, future features) and just wrong
+        // data. Expire them explicitly, same as everywhere else.
+        List<UserMembershipBenefit> benefits = active.stream()
+                .map(UserMembership::getUserMembershipId)
+                .flatMap(id -> userBenefitRepository.findByUserMembershipUserMembershipId(id).stream())
+                .collect(Collectors.toList());
+        benefits.forEach(UserMembershipBenefit::expire);
+        userBenefitRepository.saveAll(benefits);
+
+        log.info("Expired {} active membership(s) and {} linked benefit(s) for user: {}",
+                active.size(), benefits.size(), userId);
     }
 
     // =====================================================


### PR DESCRIPTION
adminClearUserMembership flipped every ACTIVE UserMembership to EXPIRED but left their UserMembershipBenefit rows' own status column untouched (status stayed ACTIVE), unlike every other place that retires a membership (upgrade, renewal lifecycle job), which cascades the expiry to benefits too. The quota queries now exclude these indirectly via the join to the parent membership's status, but the benefit rows themselves still read ACTIVE — misleading for anything that reads benefit status directly, and just incorrect data. Expire them explicitly, same as everywhere else.