### PR TITLE
fix(membership): stop completeMembershipPurchase from stacking active…

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/service/membership/impl/MembershipServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/membership/impl/MembershipServiceImpl.java
@@ -386,16 +386,30 @@ public class MembershipServiceImpl implements MembershipService {
         MembershipPackage membershipPackage = membershipPackageRepository.findById(membershipId)
                 .orElseThrow(MembershipPackageNotFoundException::new);
 
-        // Check if user already has an active membership
-        boolean hasActiveMembership = userMembershipRepository.hasActiveMembership(
-                transaction.getUserId(),
-                LocalDateTime.now()
-        );
+        // initiateMembershipPurchase already blocks starting a fresh purchase while
+        // one is active (users are supposed to use upgrade/renewal instead), so
+        // reaching this with an active membership means something slipped past that
+        // guard (e.g. a delayed webhook redelivery outside the dedup check above, or
+        // an admin/test tool completing a transaction directly). This used to just
+        // log a warning and activate the new membership anyway, letting both grant
+        // their benefits — every purchase attempt kept stacking quota on top of
+        // whatever was already active, unbounded. Expire whatever's currently active
+        // (and its benefits, same cascade as adminClearUserMembership) first so at
+        // most one membership is ever contributing quota.
+        List<UserMembership> currentlyActive = userMembershipRepository
+                .findByUserIdAndStatus(transaction.getUserId(), MembershipStatus.ACTIVE);
+        if (!currentlyActive.isEmpty()) {
+            log.warn("User {} already has {} active membership(s) when completing a new purchase - expiring them before activating the new one",
+                    transaction.getUserId(), currentlyActive.size());
+            currentlyActive.forEach(um -> um.setStatus(MembershipStatus.EXPIRED));
+            userMembershipRepository.saveAll(currentlyActive);
 
-        if (hasActiveMembership) {
-            log.warn("User {} already has an active membership, but proceeding with new purchase", transaction.getUserId());
-            // Optionally: expire the old membership or extend it
-            // For now, we'll allow multiple active memberships (they can stack)
+            List<UserMembershipBenefit> staleBenefits = currentlyActive.stream()
+                    .map(UserMembership::getUserMembershipId)
+                    .flatMap(id -> userBenefitRepository.findByUserMembershipUserMembershipId(id).stream())
+                    .collect(Collectors.toList());
+            staleBenefits.forEach(UserMembershipBenefit::expire);
+            userBenefitRepository.saveAll(staleBenefits);
         }
 
         // Calculate dates


### PR DESCRIPTION
… memberships

Found the actual source of the continuous accumulation: this method detected an already-active membership and explicitly proceeded anyway ("For now, we'll allow multiple active memberships (they can stack)"), granting the new package's full benefit quantity on top of whatever the existing active membership(s) already granted. Every completed purchase while one was still active piled its quota on top of the last, unbounded — exactly the "mua gói vẫn cộng dồn liên tục" behavior being reported. initiateMembershipPurchase already blocks starting a fresh purchase while one is active, so hitting this path means either a delayed webhook redelivery outside the 5-minute dedup check above, or a completion triggered directly (e.g. admin/test tooling). Either way, expire the existing active membership(s) and their benefits (same cascade as adminClearUserMembership) before activating the new one, so at most one membership is ever contributing quota.