### PR TITLE
fix(quota): make push quota match the package the user actually bought

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/infra/repository/UserMembershipRepository.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/UserMembershipRepository.java
@@ -20,11 +20,21 @@ public interface UserMembershipRepository extends JpaRepository<UserMembership, 
     List<UserMembership> findByUserIdAndStatus(String userId, MembershipStatus status);
 
     // Returns the membership the user is actively using right now (startDate in the past, not yet expired).
-    @Query("SELECT um FROM user_memberships um WHERE um.userId = :userId AND um.status = 'ACTIVE' AND um.startDate <= :now AND um.endDate > :now ORDER BY um.endDate DESC")
+    // LIMIT 1 is not cosmetic: an Optional-returning query that matches more than one row throws
+    // IncorrectResultSizeDataAccessException, and legacy accounts DO have several overlapping ACTIVE
+    // slots (stacked purchases from before completeMembershipPurchase started retiring the old one).
+    // Those accounts are exactly the ones the quota scoping is meant to rescue, so this must degrade
+    // to "pick the latest-ending slot", not blow up. Ties broken by id so the choice is stable
+    // between calls — the availability read and the consume path have to land on the same row.
+    @Query(value = "SELECT um.* FROM user_memberships um WHERE um.user_id = :userId AND um.status = 'ACTIVE' " +
+            "AND um.start_date <= :now AND um.end_date > :now " +
+            "ORDER BY um.end_date DESC, um.user_membership_id DESC LIMIT 1", nativeQuery = true)
     Optional<UserMembership> findActiveUserMembership(@Param("userId") String userId, @Param("now") LocalDateTime now);
 
     // Returns the next queued membership (startDate in the future, still ACTIVE status).
-    @Query("SELECT um FROM user_memberships um WHERE um.userId = :userId AND um.status = 'ACTIVE' AND um.startDate > :now ORDER BY um.startDate ASC")
+    @Query(value = "SELECT um.* FROM user_memberships um WHERE um.user_id = :userId AND um.status = 'ACTIVE' " +
+            "AND um.start_date > :now " +
+            "ORDER BY um.start_date ASC, um.user_membership_id ASC LIMIT 1", nativeQuery = true)
     Optional<UserMembership> findQueuedMembership(@Param("userId") String userId, @Param("now") LocalDateTime now);
 
     // Returns current (non-queued) ACTIVE memberships whose endDate has passed — used by the lifecycle job.

--- a/smart-rent/src/main/java/com/smartrent/service/membership/impl/MembershipServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/membership/impl/MembershipServiceImpl.java
@@ -1272,32 +1272,34 @@ public class MembershipServiceImpl implements MembershipService {
     @Override
     @Transactional
     public void adminClearUserMembership(String userId) {
-        log.info("Admin clearing all active memberships for user: {}", userId);
-        List<UserMembership> active = userMembershipRepository
-                .findByUserIdAndStatus(userId, MembershipStatus.ACTIVE);
-        if (active.isEmpty()) {
-            log.info("No active memberships found for user: {}", userId);
-            return;
-        }
-        active.forEach(um -> um.setStatus(MembershipStatus.EXPIRED));
-        userMembershipRepository.saveAll(active);
+        log.info("Admin clearing all memberships and quota for user: {}", userId);
 
-        // Every other place that retires a membership (upgrade, renewal lifecycle
-        // job) also expires its linked benefits — this one didn't, leaving orphaned
-        // rows with status=ACTIVE in user_membership_benefits. The quota queries now
-        // exclude them indirectly (they join back to the membership's own status),
-        // but leaving the benefit's own status stale is misleading for anything that
-        // reads it directly (admin views, history, future features) and just wrong
-        // data. Expire them explicitly, same as everywhere else.
-        List<UserMembershipBenefit> benefits = active.stream()
-                .map(UserMembership::getUserMembershipId)
-                .flatMap(id -> userBenefitRepository.findByUserMembershipUserMembershipId(id).stream())
+        // "Clear this user's membership" has to leave the account with nothing left to
+        // spend, so it works on two axes instead of one:
+        //
+        //  - every membership row that is still live, not just status=ACTIVE ones whose
+        //    window contains now. A queued slot from a chained renewal is also ACTIVE
+        //    (it just starts later), and would otherwise survive the clear and hand the
+        //    user a fresh package the moment the lifecycle job promoted it.
+        //  - every ACTIVE benefit row owned by the user, keyed off user_id rather than
+        //    walked from the memberships retired in this call. Older paths retired a
+        //    membership without cascading to its benefits, so accounts carry orphaned
+        //    ACTIVE push/post rows whose parent membership is long expired; scoping the
+        //    cleanup to the memberships we just touched would step right over them and
+        //    leave the stale push quota the clear was called to get rid of.
+        List<UserMembership> memberships = userMembershipRepository.findByUserId(userId).stream()
+                .filter(um -> um.getStatus() == MembershipStatus.ACTIVE)
                 .collect(Collectors.toList());
+        memberships.forEach(um -> um.setStatus(MembershipStatus.EXPIRED));
+        userMembershipRepository.saveAll(memberships);
+
+        List<UserMembershipBenefit> benefits = userBenefitRepository
+                .findByUserIdAndStatus(userId, BenefitStatus.ACTIVE);
         benefits.forEach(UserMembershipBenefit::expire);
         userBenefitRepository.saveAll(benefits);
 
-        log.info("Expired {} active membership(s) and {} linked benefit(s) for user: {}",
-                active.size(), benefits.size(), userId);
+        log.info("Cleared {} membership(s) and {} benefit(s) for user: {}",
+                memberships.size(), benefits.size(), userId);
     }
 
     // =====================================================

--- a/smart-rent/src/main/resources/db/migration/V119__Collapse_stacked_active_memberships.sql
+++ b/smart-rent/src/main/resources/db/migration/V119__Collapse_stacked_active_memberships.sql
@@ -1,0 +1,52 @@
+-- V119: one user, one current membership.
+--
+-- Until completeMembershipPurchase started retiring whatever was already active, a
+-- redelivered payment webhook (or any purchase that slipped past the "already has a
+-- membership" guard) created ANOTHER ACTIVE user_memberships row overlapping the old
+-- one. The quota reads summed every overlapping slot, so a STANDARD seller whose
+-- package grants 20 pushes/month was told they had 200 — 10 stacked slots' worth —
+-- and each push decremented that inflated pool instead of their real 20.
+--
+-- The service layer no longer sums across slots (it reads the single current slot), but
+-- the duplicate rows themselves are still there: they keep every ACTIVE-membership
+-- count, admin dashboard and history view wrong, and they make "which slot is current"
+-- depend on query ordering. Collapse them here so the data says what the code now
+-- assumes.
+--
+-- Scope: only slots whose window contains NOW (start_date <= now < end_date). Queued
+-- slots (start_date in the future, created by a chained renewal) are legitimate and are
+-- left alone. Per user the slot ending LAST wins — same ordering as
+-- findActiveUserMembership (end_date DESC, user_membership_id DESC) — so the row this
+-- keeps is the row the application was already going to serve. The forfeited quota on
+-- the losing slots is intentional: it was never sold.
+
+-- 1. Retire every currently-active slot that isn't the user's latest-ending one.
+UPDATE user_memberships um
+JOIN (
+    SELECT a.user_id, MAX(a.user_membership_id) AS keep_id
+    FROM user_memberships a
+    JOIN (
+        SELECT user_id, MAX(end_date) AS max_end
+        FROM user_memberships
+        WHERE status = 'ACTIVE' AND start_date <= NOW() AND end_date > NOW()
+        GROUP BY user_id
+        HAVING COUNT(*) > 1
+    ) latest ON latest.user_id = a.user_id AND latest.max_end = a.end_date
+    WHERE a.status = 'ACTIVE' AND a.start_date <= NOW() AND a.end_date > NOW()
+    GROUP BY a.user_id
+) keeper ON keeper.user_id = um.user_id
+SET um.status = 'EXPIRED'
+WHERE um.status = 'ACTIVE'
+  AND um.start_date <= NOW()
+  AND um.end_date > NOW()
+  AND um.user_membership_id <> keeper.keep_id;
+
+-- 2. Expire the benefit rows hanging off any membership that is no longer ACTIVE —
+--    the slots just retired above, plus any older orphans left behind by paths that
+--    used to expire the membership without cascading to its benefits. A benefit whose
+--    membership is gone must never read as ACTIVE.
+UPDATE user_membership_benefits umb
+JOIN user_memberships um ON um.user_membership_id = umb.user_membership_id
+SET umb.status = 'EXPIRED'
+WHERE umb.status = 'ACTIVE'
+  AND um.status <> 'ACTIVE';


### PR DESCRIPTION
check/PUSH reported totalGranted=200 for a STANDARD seller whose package grants 20 pushes/month, and each push decremented that inflated pool. The 200 is ten stacked ACTIVE user_memberships rows summed together: before completeMembershipPurchase started retiring the previous slot, a redelivered payment webhook created another overlapping ACTIVE membership every time, and the quota queries summed across all of them.

Reading from the single current slot (already on this branch) fixes the arithmetic but not the rows underneath it, and on those accounts it cannot even run: findActiveUserMembership returns Optional from a query that matches several rows, which throws IncorrectResultSizeDataAccessException for exactly the users the fix targets. Both single-slot lookups now LIMIT 1 with a stable tiebreak, so the availability read and the consume path always land on the same row.

V119 then collapses the legacy duplicates: per user, the currently-active slot ending last wins (same ordering the repository uses), the rest are expired along with their benefits. Queued slots from chained renewals are untouched. Forfeiting the duplicates' quota is the point — it was never sold.

adminClearUserMembership also has to leave nothing spendable behind, so it now retires queued slots too and expires every ACTIVE benefit row owned by the user rather than only those reachable from the memberships it just touched, which used to step over orphaned push quota whose parent membership had already expired.