### PR TITLE
fix(membership): make admin clear wipe a user's membership data outright

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/controller/AdminMembershipController.java
+++ b/smart-rent/src/main/java/com/smartrent/controller/AdminMembershipController.java
@@ -111,7 +111,7 @@ public class AdminMembershipController {
         // Triggered from the Users management page (SA, UA), not the membership
         // package screen — so it follows user-management write access.
         @PreAuthorize("hasAnyAuthority('ROLE_SA', 'ROLE_UA')")
-        @Operation(summary = "Clear user active memberships (Admin)", description = "Expires all ACTIVE membership records for a user. Use this to fix duplicate-active-membership issues.")
+        @Operation(summary = "Clear user memberships (Admin)", description = "Deletes every membership record and every membership benefit (post/push quota) belonging to a user, resetting the account to 'never bought a package'. Payment transactions are kept. Use this to fix duplicate-active-membership and accumulated-quota issues.")
         public void clearUserMembership(
                         @Parameter(description = "User ID", required = true) @PathVariable String userId) {
                 log.info("Admin clearing memberships for user: {}", userId);

--- a/smart-rent/src/main/java/com/smartrent/infra/repository/UserMembershipBenefitRepository.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/UserMembershipBenefitRepository.java
@@ -69,5 +69,12 @@ public interface UserMembershipBenefitRepository extends JpaRepository<UserMembe
     Integer getTotalUsedQuota(@Param("userId") String userId, @Param("benefitType") BenefitType benefitType, @Param("now") LocalDateTime now);
 
     List<UserMembershipBenefit> findByUserMembershipUserMembershipId(Long userMembershipId);
+
+    // Admin reset: wipe every benefit row the user owns, whatever its status and
+    // whatever state its parent membership is in. Bulk delete rather than the derived
+    // load-then-delete so a long-lived account with hundreds of rows is one statement.
+    @Modifying
+    @Query("DELETE FROM user_membership_benefits umb WHERE umb.userId = :userId")
+    int deleteByUserId(@Param("userId") String userId);
 }
 

--- a/smart-rent/src/main/java/com/smartrent/infra/repository/UserMembershipRepository.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/UserMembershipRepository.java
@@ -49,6 +49,13 @@ public interface UserMembershipRepository extends JpaRepository<UserMembership, 
 
     boolean existsByUserIdAndStatus(String userId, MembershipStatus status);
 
+    // Admin reset: wipe every membership row the user owns, in any status. Call after
+    // deleting their benefit rows — the self-referencing upgraded_from_membership_id FK
+    // is ON DELETE SET NULL, but user_membership_benefits still points here.
+    @Modifying
+    @Query("DELETE FROM user_memberships um WHERE um.userId = :userId")
+    int deleteByUserId(@Param("userId") String userId);
+
     // Idempotency guard for completeMembershipUpgrade — a payment webhook retry
     // (IPN redelivery) re-running that method with the same transaction must not
     // create a second upgraded slot + grant its benefits a second time.

--- a/smart-rent/src/main/java/com/smartrent/service/membership/impl/MembershipServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/membership/impl/MembershipServiceImpl.java
@@ -1272,34 +1272,27 @@ public class MembershipServiceImpl implements MembershipService {
     @Override
     @Transactional
     public void adminClearUserMembership(String userId) {
-        log.info("Admin clearing all memberships and quota for user: {}", userId);
+        log.info("Admin clearing all membership data for user: {}", userId);
 
-        // "Clear this user's membership" has to leave the account with nothing left to
-        // spend, so it works on two axes instead of one:
+        // This endpoint exists to put an account back to "never bought anything", so it
+        // deletes every membership row and every benefit row the user owns rather than
+        // flipping statuses.
         //
-        //  - every membership row that is still live, not just status=ACTIVE ones whose
-        //    window contains now. A queued slot from a chained renewal is also ACTIVE
-        //    (it just starts later), and would otherwise survive the clear and hand the
-        //    user a fresh package the moment the lifecycle job promoted it.
-        //  - every ACTIVE benefit row owned by the user, keyed off user_id rather than
-        //    walked from the memberships retired in this call. Older paths retired a
-        //    membership without cascading to its benefits, so accounts carry orphaned
-        //    ACTIVE push/post rows whose parent membership is long expired; scoping the
-        //    cleanup to the memberships we just touched would step right over them and
-        //    leave the stale push quota the clear was called to get rid of.
-        List<UserMembership> memberships = userMembershipRepository.findByUserId(userId).stream()
-                .filter(um -> um.getStatus() == MembershipStatus.ACTIVE)
-                .collect(Collectors.toList());
-        memberships.forEach(um -> um.setStatus(MembershipStatus.EXPIRED));
-        userMembershipRepository.saveAll(memberships);
+        // Marking them EXPIRED is not enough. The rows that make quota accumulate are
+        // precisely the ones a status flip leaves behind: benefit rows whose parent
+        // membership was retired long ago but which stayed status=ACTIVE themselves
+        // (older code paths retired the membership without cascading), and memberships
+        // in every non-ACTIVE state that still anchor those rows. Any read that forgets
+        // one of the two status predicates starts summing them again, and the next
+        // purchase lands on top of that pile instead of on a clean slate.
+        //
+        // Transactions are deliberately untouched — they are the payment record, not
+        // entitlement, and deleting them would rewrite revenue history.
+        int benefitsDeleted = userBenefitRepository.deleteByUserId(userId);
+        int membershipsDeleted = userMembershipRepository.deleteByUserId(userId);
 
-        List<UserMembershipBenefit> benefits = userBenefitRepository
-                .findByUserIdAndStatus(userId, BenefitStatus.ACTIVE);
-        benefits.forEach(UserMembershipBenefit::expire);
-        userBenefitRepository.saveAll(benefits);
-
-        log.info("Cleared {} membership(s) and {} benefit(s) for user: {}",
-                memberships.size(), benefits.size(), userId);
+        log.info("Deleted {} membership(s) and {} benefit(s) for user: {}",
+                membershipsDeleted, benefitsDeleted, userId);
     }
 
     // =====================================================


### PR DESCRIPTION
The clear endpoint only flipped ACTIVE memberships to EXPIRED, which reads as "cleared" the moment you call it — /quotas/check/PUSH returns 0 because every quota query joins back to um.status='ACTIVE'. But the rows are all still there, and the ones left behind are exactly the ones that make quota accumulate: benefit rows that stayed status=ACTIVE while their parent membership was retired without a cascade, hanging off memberships in every non-ACTIVE state. Buy a package after that and the seller is back to a summed total (220 granted against a package that grants 20) with pushes decrementing an old row while the card in /memberships/my-membership still shows 20 unused.

Delete both tables' rows for the user instead. An account that "never bought a package" cannot have quota reappear from anywhere, whichever read path is asking. Transactions stay — they are the payment record, not entitlement, and removing them would rewrite revenue history.

Bulk deletes rather than derived load-then-delete: these accounts are the ones carrying hundreds of rows. Benefits go first; user_membership_benefits still FKs to user_memberships (the self-referencing upgraded_from FK is ON DELETE SET NULL and needs no ordering).