### PR TITLE
fix(membership): stop renewal from granting quota twice per payment

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/infra/repository/UserMembershipRepository.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/UserMembershipRepository.java
@@ -61,6 +61,10 @@ public interface UserMembershipRepository extends JpaRepository<UserMembership, 
     // create a second upgraded slot + grant its benefits a second time.
     Optional<UserMembership> findByUpgradedFromMembershipId(Long upgradedFromMembershipId);
 
+    // Same guard, expressed as identity rather than inference, for every completion
+    // path: purchase, upgrade and renewal all record the transaction they came from.
+    Optional<UserMembership> findByCreatedFromTransactionId(String createdFromTransactionId);
+
     // Returns true when the user has ANY non-expired ACTIVE slot (current or queued).
     // Used as purchase guard — prevents buying a new membership when one already exists.
     @Query("SELECT COUNT(um) > 0 FROM user_memberships um WHERE um.userId = :userId AND um.status = 'ACTIVE' AND um.endDate > :now")

--- a/smart-rent/src/main/java/com/smartrent/infra/repository/entity/UserMembership.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/entity/UserMembership.java
@@ -62,6 +62,16 @@ public class UserMembership {
     @Column(name = "upgraded_from_membership_id")
     Long upgradedFromMembershipId;
 
+    /**
+     * Transaction this membership was created from. Unique in the database, so a
+     * redelivered payment webhook cannot produce a second membership (and a second
+     * benefit grant) for a payment that was already honoured. Null for rows created
+     * before this column existed and for slots the lifecycle job promotes, which have
+     * no transaction of their own.
+     */
+    @Column(name = "created_from_transaction_id", length = 36)
+    String createdFromTransactionId;
+
     @OneToMany(mappedBy = "userMembership", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     List<UserMembershipBenefit> benefits;
 

--- a/smart-rent/src/main/java/com/smartrent/service/membership/impl/MembershipServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/membership/impl/MembershipServiceImpl.java
@@ -274,6 +274,7 @@ public class MembershipServiceImpl implements MembershipService {
                 .durationDays(durationDays)
                 .status(MembershipStatus.ACTIVE)
                 .totalPaid(membershipPackage.getSalePrice())
+                .createdFromTransactionId(transaction.getTransactionId())
                 .build();
 
         userMembership = userMembershipRepository.save(userMembership);
@@ -362,12 +363,13 @@ public class MembershipServiceImpl implements MembershipService {
         }
 
         // Check if membership already created for this transaction (idempotency)
-        // This prevents duplicate memberships when both callback and IPN are processed
-        Optional<UserMembership> existingMembership = userMembershipRepository.findByUserId(transaction.getUserId())
-                .stream()
-                .filter(um -> um.getCreatedAt().isAfter(transaction.getCreatedAt().minusMinutes(5)))
-                .filter(um -> um.getStatus() == MembershipStatus.ACTIVE)
-                .findFirst();
+        // This prevents duplicate memberships when both callback and IPN are processed.
+        // Matched on the transaction that created the membership rather than the old
+        // "any ACTIVE membership created within 5 minutes of this transaction" window,
+        // which both over- and under-matched: it claimed an unrelated membership that
+        // happened to land in the window, and let a webhook redelivered later through.
+        Optional<UserMembership> existingMembership =
+                userMembershipRepository.findByCreatedFromTransactionId(transactionId);
 
         if (existingMembership.isPresent()) {
             log.info("Membership already created for transaction: {}, returning existing membership", transactionId);
@@ -426,6 +428,7 @@ public class MembershipServiceImpl implements MembershipService {
                 .durationDays(durationDays)
                 .status(MembershipStatus.ACTIVE)
                 .totalPaid(membershipPackage.getSalePrice())
+                .createdFromTransactionId(transactionId)
                 .build();
 
         userMembership = userMembershipRepository.save(userMembership);
@@ -990,7 +993,8 @@ public class MembershipServiceImpl implements MembershipService {
         // second new membership and grant its benefits a second time, stacking the push/
         // post quota on top of what the first (legitimate) completion already granted.
         Optional<UserMembership> alreadyUpgraded = userMembershipRepository
-                .findByUpgradedFromMembershipId(previousMembershipId);
+                .findByCreatedFromTransactionId(transactionId)
+                .or(() -> userMembershipRepository.findByUpgradedFromMembershipId(previousMembershipId));
         if (alreadyUpgraded.isPresent()) {
             log.warn("Upgrade for transaction {} already completed (previous membership {} already upgraded to {}) - skipping duplicate completion",
                     transactionId, previousMembershipId, alreadyUpgraded.get().getUserMembershipId());
@@ -1039,6 +1043,7 @@ public class MembershipServiceImpl implements MembershipService {
                 .status(MembershipStatus.ACTIVE)
                 .totalPaid(transaction.getAmount())
                 .upgradedFromMembershipId(previousMembershipId)
+                .createdFromTransactionId(transactionId)
                 .build();
 
         newMembership = userMembershipRepository.save(newMembership);
@@ -1227,6 +1232,20 @@ public class MembershipServiceImpl implements MembershipService {
             throw new RuntimeException("Transaction is not a membership renewal: " + transactionId);
         }
 
+        // Idempotency guard. This path had none at all, and it is reachable twice for a
+        // single payment (provider callback + SePay webhook, which retries until it gets
+        // a 200). Each extra run chained another membership off the same previous slot;
+        // when the renewal started immediately rather than being queued, it also granted
+        // that package's post/push benefits again — quota accumulating on a user who paid
+        // once.
+        Optional<UserMembership> alreadyRenewed =
+                userMembershipRepository.findByCreatedFromTransactionId(transactionId);
+        if (alreadyRenewed.isPresent()) {
+            log.warn("Renewal for transaction {} already completed (membership {}) - skipping duplicate completion",
+                    transactionId, alreadyRenewed.get().getUserMembershipId());
+            return mapToUserMembershipResponse(alreadyRenewed.get());
+        }
+
         Long membershipId = Long.parseLong(transaction.getReferenceId());
         MembershipPackage pkg = membershipPackageRepository.findById(membershipId)
                 .orElseThrow(MembershipPackageNotFoundException::new);
@@ -1236,11 +1255,26 @@ public class MembershipServiceImpl implements MembershipService {
                 ? userMembershipRepository.findById(previousMembershipId).orElse(null)
                 : null;
 
-        // Chain from previous endDate if it hasn't expired yet; otherwise start from now
+        // Chain onto the end of the user's existing timeline, not just onto the slot the
+        // transaction names. initiateMembershipRenewal rejects a second renewal while a
+        // queued slot exists, but that check runs at initiate: two renewals started
+        // before either payment lands both pass it, and both name the same current slot
+        // as `previous`. Chaining from `previous` alone would then give them identical
+        // start/end dates — two memberships live at once, which is the state the quota
+        // reads have to defend against. Starting from the latest endDate the user holds
+        // queues the second renewal behind the first instead, so the paid time is kept
+        // and the timeline stays a line.
         LocalDateTime now = LocalDateTime.now();
-        LocalDateTime startDate = (previous != null && previous.getEndDate().isAfter(now))
-                ? previous.getEndDate()
-                : now;
+        LocalDateTime timelineEnd = userMembershipRepository
+                .findByUserIdAndStatus(transaction.getUserId(), MembershipStatus.ACTIVE)
+                .stream()
+                .map(UserMembership::getEndDate)
+                .max(LocalDateTime::compareTo)
+                .orElse(null);
+        if (timelineEnd == null && previous != null) {
+            timelineEnd = previous.getEndDate();
+        }
+        LocalDateTime startDate = (timelineEnd != null && timelineEnd.isAfter(now)) ? timelineEnd : now;
         LocalDateTime endDate = startDate.plusMonths(pkg.getDurationMonths());
         int durationDays = pkg.getDurationMonths() * 30;
 
@@ -1252,6 +1286,7 @@ public class MembershipServiceImpl implements MembershipService {
                 .durationDays(durationDays)
                 .status(MembershipStatus.ACTIVE)
                 .totalPaid(transaction.getAmount())
+                .createdFromTransactionId(transactionId)
                 .build();
 
         renewed = userMembershipRepository.save(renewed);

--- a/smart-rent/src/main/resources/db/migration/V120__Link_user_memberships_to_source_transaction.sql
+++ b/smart-rent/src/main/resources/db/migration/V120__Link_user_memberships_to_source_transaction.sql
@@ -1,0 +1,32 @@
+-- V120: one paid transaction can create at most one membership.
+--
+-- Payment completion is reachable from two IPN endpoints (the generic provider callback
+-- and the SePay webhook), and SePay retries until it gets a 200 — so every
+-- complete*Membership* method must expect to run more than once for the same
+-- transaction. Each one guarded itself differently, and one didn't guard at all:
+--
+--   purchase — "is there an ACTIVE membership created within 5 minutes of this
+--              transaction?", which is a heuristic, not an identity check: it also
+--              matches an unrelated membership that happens to fall in the window,
+--              and misses the retry that arrives after it.
+--   upgrade  — keyed off upgraded_from_membership_id. Correct, but only because
+--              upgrades happen to record their predecessor.
+--   renewal  — nothing. A redelivered webhook created a second renewed membership
+--              chained from the same slot and, when the renewal started immediately,
+--              granted its post/push benefits a second time. That is the quota
+--              accumulation seen on /quotas/check.
+--
+-- Record which transaction produced a membership and make the database enforce
+-- uniqueness, so the guard is the same fact in all three flows and a concurrent
+-- double-delivery can't slip between a check and an insert.
+--
+-- Nullable + non-unique-safe for history: existing rows keep NULL, and MySQL allows
+-- many NULLs in a UNIQUE index. Memberships created by the lifecycle job (a queued slot
+-- being promoted) legitimately have no transaction of their own.
+
+ALTER TABLE user_memberships
+ADD COLUMN created_from_transaction_id VARCHAR(36) NULL
+COMMENT 'Transaction that created this membership; NULL for rows predating V120 or created by the lifecycle job';
+
+CREATE UNIQUE INDEX uk_user_membership_source_transaction
+ON user_memberships(created_from_transaction_id);


### PR DESCRIPTION
Payment completion is reachable from two IPN endpoints, and SePay retries its webhook until it gets a 200, so every complete*Membership* method runs more than once for a single payment. Purchase and upgrade each guarded against that; renewal did not guard at all. A redelivered webhook chained a second membership off the same previous slot and — when the renewal started immediately instead of being queued — granted that package's post/push benefits again. One payment, two grants, and the totals keep climbing from there.

The guards that did exist were also inference rather than identity: purchase matched "any ACTIVE membership created within 5 minutes of this transaction", which claims an unrelated membership landing in that window and misses a redelivery arriving after it. Record the transaction each membership was created from, put a unique index on it (V120), and let all three paths ask the same question. The index means a concurrent double-delivery can't slip between the check and the insert either.

Renewal also chained purely from the slot named in the transaction. Two renewals started before either payment lands both pass the initiate-time "only one queued slot" check and both name the current slot as previous, so they were handed identical start/end dates — two live memberships, exactly the state the quota reads are trying to defend against. Chain from the latest endDate the user holds instead, which queues the second renewal behind the first and keeps the paid time.