### PR TITLE
fix(db): unbreak startup — two migrations both claimed version 118

### DIFF
--- a/smart-rent/src/main/resources/db/migration/V121__Add_pending_transaction_to_listing_drafts.sql
+++ b/smart-rent/src/main/resources/db/migration/V121__Add_pending_transaction_to_listing_drafts.sql
@@ -1,4 +1,12 @@
--- V118: remember which payment a draft is currently waiting on.
+-- V121: remember which payment a draft is currently waiting on.
+--
+-- Was authored as V118 on a branch cut before V118__Add_price_comparables_index landed
+-- on main, and merged after it. Two files claiming version 118 is a hard Flyway
+-- resolution error ("Found more than one migration with version 118") — not something
+-- validate-on-migrate: false relaxes — so the application refused to start from the
+-- moment both were on main, and every deploy since has kept serving the previous image.
+-- Renumbered above the already-applied 118 rather than renumbering that one, which is
+-- recorded in flyway_schema_history on every environment that booted before this broke.
 --
 -- publishDraft deliberately keeps the draft alive while a payment is pending, so an
 -- abandoned payment doesn't lose the user's work. But nothing stopped the same draft


### PR DESCRIPTION
V118__Add_pending_transaction_to_listing_drafts was branched before V118__Add_price_comparables_index reached main and merged after it, so main has carried two files at version 118 since 2026-07-23. Flyway rejects that while resolving migrations, before any of the relaxed settings apply — the context fails, the container never comes up, and Dokploy keeps the previous image serving. Every merge since then has built, "deployed", and changed nothing in production.

That is why the push-quota fixes look inert against api.thuenhatro.net: /quotas/check/PUSH still climbs 20 per purchase because the running image predates them, not because the scoping is wrong.

Renumbered the newcomer to V121. The price-comparables one keeps 118 since it is already recorded in flyway_schema_history wherever the app booted before this landed; renumbering that one instead would orphan the applied row.