### PR TITLE
fix(ai): re-queue AI moderation when an owner edits a listing

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/service/ai/impl/AiModerationProcessorServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/ai/impl/AiModerationProcessorServiceImpl.java
@@ -116,6 +116,16 @@ public class AiModerationProcessorServiceImpl implements AiModerationProcessorSe
                 log.warn("Failed to serialize AI moderation result for listing ID: {}", listing.getListingId(), e);
             }
 
+            // The owner may have edited the listing while this analysis was running. That
+            // edit resets the row to PENDING and re-queues it, so this verdict now describes
+            // content that no longer exists — writing it would both show the admin a stale
+            // result and make the re-queued delivery skip as "already computed".
+            if (wasResetWhileRunning(listing.getListingId())) {
+                log.info("Listing ID {} was edited during AI analysis — discarding stale result, "
+                        + "the re-queued analysis will replace it", listing.getListingId());
+                return;
+            }
+
             listingAiModerationRepository.save(moderation);
 
             log.info("Stored AI analysis for listing ID: {} (aiSuggestion: {}) — awaiting admin review",
@@ -137,6 +147,18 @@ public class AiModerationProcessorServiceImpl implements AiModerationProcessorSe
             moderation.setVerificationStatus(VerificationStatus.PENDING); // revert for retry
             listingAiModerationRepository.save(moderation);
         }
+    }
+
+    /**
+     * True when the stored row went back to PENDING after this run claimed it as
+     * IN_PROGRESS — i.e. an owner edit or resubmit invalidated the content this
+     * analysis was computed from. Read fresh from the DB: the {@code moderation}
+     * handed to us is the pre-claim, detached copy.
+     */
+    private boolean wasResetWhileRunning(Long listingId) {
+        return listingAiModerationRepository.findById(listingId)
+                .map(current -> current.getVerificationStatus() == VerificationStatus.PENDING)
+                .orElse(false);
     }
 
     private void sendAdminDuplicateNotification(Listing listing, DuplicateCheckResponse duplicateResult) {

--- a/smart-rent/src/main/java/com/smartrent/service/listing/impl/ListingServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/listing/impl/ListingServiceImpl.java
@@ -720,6 +720,13 @@ public class ListingServiceImpl implements ListingService {
                 || modStatus == ModerationStatus.REMOVED) {
             throw new DomainException(DomainCode.UPDATE_NOT_ALLOWED);
         }
+
+        // Snapshot exactly what the AI is shown (see AiListingMapperImpl) so an edit that
+        // touches nothing it moderates — expiry date, vipType — costs no AI spend.
+        ModeratedContent contentBeforeEdit = ModeratedContent.of(existing);
+        boolean mediaChanged = false;
+        boolean amenitiesChanged = false;
+
         // Update fields from request (null-safe for partial update)
         if (request.getTitle() != null) existing.setTitle(request.getTitle());
         if (request.getDescription() != null) existing.setDescription(request.getDescription());
@@ -761,6 +768,10 @@ public class ListingServiceImpl implements ListingService {
             // Unlink existing media (set listing to null)
             List<Media> existingMedia = mediaRepository.findByListing_ListingIdAndStatusOrderBySortOrderAsc(
                     id, Media.MediaStatus.ACTIVE);
+            Set<Long> currentMediaIds = existingMedia.stream()
+                    .map(Media::getMediaId)
+                    .collect(Collectors.toSet());
+            mediaChanged = !currentMediaIds.equals(request.getMediaIds());
             for (Media media : existingMedia) {
                 media.setListing(null);
                 mediaRepository.save(media);
@@ -777,23 +788,40 @@ public class ListingServiceImpl implements ListingService {
         // Handle amenity update if provided (empty set clears all amenities)
         if (request.getAmenityIds() != null) {
             log.info("Updating amenities for listing {}: {} amenities", id, request.getAmenityIds().size());
+            Set<Long> currentAmenityIds = existing.getAmenities() == null
+                    ? Collections.emptySet()
+                    : existing.getAmenities().stream()
+                            .map(Amenity::getAmenityId)
+                            .collect(Collectors.toSet());
+            amenitiesChanged = !currentAmenityIds.equals(request.getAmenityIds());
             linkAmenitiesToListing(existing, request.getAmenityIds());
         }
 
+        boolean contentChanged = mediaChanged || amenitiesChanged
+                || !ModeratedContent.of(existing).equals(contentBeforeEdit);
+
         // An approved listing edited by the owner must go back through review
-        boolean sentBackToReview = existing.getModerationStatus() == ModerationStatus.APPROVED;
+        boolean sentBackToReview = contentChanged
+                && existing.getModerationStatus() == ModerationStatus.APPROVED;
         if (sentBackToReview) {
             existing.setVerified(false);
             existing.setIsVerify(true);
             existing.setModerationStatus(ModerationStatus.PENDING_REVIEW);
+        }
+        if (contentChanged) {
             // The stored AI analysis describes the *pre-edit* content. Reset the record so
             // the worker re-analyses instead of skipping it as already-computed — otherwise
             // the review dialog would show a stale verdict for content that has changed.
+            // Applies to a listing still waiting in the queue too: it was edited under an
+            // analysis the admin has not looked at yet.
             resetAiModerationForReanalysis(existing.getListingId());
         }
 
         Listing saved = listingRepository.save(existing);
-        if (sentBackToReview) {
+        // REVISION_REQUIRED is deliberately not re-queued here — the worker only analyses
+        // PENDING_REVIEW/RESUBMITTED, and the owner still has to resubmit explicitly. The
+        // reset above is what makes that resubmit analyse the edited content.
+        if (contentChanged && awaitingAiAnalysis(saved.getModerationStatus())) {
             queueAiAnalysis(saved);
         }
         boolean priceChanged = request.getPrice() != null
@@ -805,6 +833,53 @@ public class ListingServiceImpl implements ListingService {
         com.smartrent.dto.response.UserCreationResponse user = buildUserResponse(saved.getUserId());
         com.smartrent.dto.response.AddressResponse addressResponse = buildAddressResponse(saved.getAddress());
         return listingMapper.toResponse(saved, user, addressResponse);
+    }
+
+    /**
+     * States in which the AI queue worker will actually analyse a listing — mirrors
+     * {@code AiAnalysisWorker.needsAnalysis}. Queueing anything else is wasted work.
+     */
+    private static boolean awaitingAiAnalysis(ModerationStatus status) {
+        return status == null
+                || status == ModerationStatus.PENDING_REVIEW
+                || status == ModerationStatus.RESUBMITTED;
+    }
+
+    /**
+     * The slice of a listing the AI actually moderates — mirrors what
+     * {@code AiListingMapperImpl} puts in the verification request (media and amenities
+     * are compared separately, from the request). Snapshotted before an owner edit and
+     * compared after, so a stored verdict is only invalidated when the content it
+     * describes really changed.
+     */
+    private record ModeratedContent(
+            String title, String description, BigDecimal price, Listing.PriceUnit priceUnit,
+            Listing.ListingType listingType, Listing.ProductType productType, Float area,
+            Integer bedrooms, Integer bathrooms, Integer roomCapacity,
+            Listing.Direction direction, Listing.Furnishing furnishing,
+            String waterPrice, String electricityPrice, String internetPrice, String serviceFee) {
+
+        static ModeratedContent of(Listing listing) {
+            return new ModeratedContent(
+                    listing.getTitle(),
+                    listing.getDescription(),
+                    // stripTrailingZeros: BigDecimal.equals is scale-sensitive, so 5000
+                    // vs 5000.00 would otherwise read as a price change
+                    listing.getPrice() != null ? listing.getPrice().stripTrailingZeros() : null,
+                    listing.getPriceUnit(),
+                    listing.getListingType(),
+                    listing.getProductType(),
+                    listing.getArea(),
+                    listing.getBedrooms(),
+                    listing.getBathrooms(),
+                    listing.getRoomCapacity(),
+                    listing.getDirection(),
+                    listing.getFurnishing(),
+                    listing.getWaterPrice(),
+                    listing.getElectricityPrice(),
+                    listing.getInternetPrice(),
+                    listing.getServiceFee());
+        }
     }
 
     /**

--- a/smart-rent/src/test/java/com/smartrent/service/ai/AiModerationProcessorServiceImplTest.java
+++ b/smart-rent/src/test/java/com/smartrent/service/ai/AiModerationProcessorServiceImplTest.java
@@ -1,0 +1,111 @@
+package com.smartrent.service.ai;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.smartrent.dto.request.AiListingVerificationRequest;
+import com.smartrent.dto.response.AiListingVerificationResponse;
+import com.smartrent.infra.connector.SmartRentAiConnector;
+import com.smartrent.infra.repository.ListingAiModerationRepository;
+import com.smartrent.infra.repository.entity.Listing;
+import com.smartrent.infra.repository.entity.ListingAiModeration;
+import com.smartrent.infra.repository.entity.enums.VerificationStatus;
+import com.smartrent.service.ai.impl.AiModerationProcessorServiceImpl;
+import com.smartrent.service.notification.NotificationService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * The analysis runs for ~30s off the request thread, which is plenty of time for the
+ * owner to edit the listing underneath it. The edit resets the moderation row to
+ * PENDING and re-queues it, so the in-flight verdict must not be written back.
+ */
+@ExtendWith(MockitoExtension.class)
+class AiModerationProcessorServiceImplTest {
+
+    private static final Long LISTING_ID = 7L;
+
+    @Mock
+    ListingAiModerationRepository listingAiModerationRepository;
+
+    @Mock
+    AiListingVerificationService aiVerificationService;
+
+    @Mock
+    NotificationService notificationService;
+
+    @Mock
+    SmartRentAiConnector smartRentAiConnector;
+
+    @Spy
+    ObjectMapper objectMapper = new ObjectMapper();
+
+    @Mock
+    AiModerationExecutor aiModerationExecutor;
+
+    @InjectMocks
+    AiModerationProcessorServiceImpl service;
+
+    Listing listing;
+    ListingAiModeration claimed;
+
+    @BeforeEach
+    void setUp() {
+        listing = Listing.builder().listingId(LISTING_ID).title("Phòng trọ").build();
+        // What AiAnalysisWorker hands over: the row it just claimed, now detached.
+        claimed = ListingAiModeration.builder()
+                .listingId(LISTING_ID)
+                .verificationStatus(VerificationStatus.IN_PROGRESS)
+                .retryCount(0)
+                .manualOverride(false)
+                .build();
+
+        // Run the verify/duplicate fan-out on the calling thread.
+        when(aiModerationExecutor.taskPool()).thenReturn(Runnable::run);
+        when(aiVerificationService.buildVerificationRequest(LISTING_ID))
+                .thenReturn(AiListingVerificationRequest.builder().title("Phòng trọ").build());
+        when(aiVerificationService.verifyListing(any(AiListingVerificationRequest.class)))
+                .thenReturn(AiListingVerificationResponse.builder()
+                        .score(0.9)
+                        .suggestedStatus("APPROVED")
+                        .build());
+    }
+
+    @Test
+    void storesTheVerdictWhenTheListingWasNotTouched() {
+        when(listingAiModerationRepository.findById(LISTING_ID))
+                .thenReturn(Optional.of(claimed));
+
+        service.processSingleListing(listing, claimed);
+
+        verify(listingAiModerationRepository).save(claimed);
+    }
+
+    @Test
+    void discardsTheVerdictWhenTheListingWasEditedMidAnalysis() {
+        // The owner's edit committed while the AI was running: row is back to PENDING.
+        when(listingAiModerationRepository.findById(LISTING_ID))
+                .thenReturn(Optional.of(ListingAiModeration.builder()
+                        .listingId(LISTING_ID)
+                        .verificationStatus(VerificationStatus.PENDING)
+                        .retryCount(0)
+                        .manualOverride(false)
+                        .build()));
+
+        service.processSingleListing(listing, claimed);
+
+        // Writing it would both show the admin a verdict for content that no longer
+        // exists and make the re-queued delivery skip as "already computed".
+        verify(listingAiModerationRepository, never()).save(any());
+    }
+}

--- a/smart-rent/src/test/java/com/smartrent/service/listing/impl/ListingServiceImplUpdateReviewQueueTest.java
+++ b/smart-rent/src/test/java/com/smartrent/service/listing/impl/ListingServiceImplUpdateReviewQueueTest.java
@@ -1,0 +1,172 @@
+package com.smartrent.service.listing.impl;
+
+import com.smartrent.dto.request.ListingRequest;
+import com.smartrent.enums.ModerationStatus;
+import com.smartrent.event.ListingSubmittedEvent;
+import com.smartrent.infra.repository.ListingAiModerationRepository;
+import com.smartrent.infra.repository.ListingRepository;
+import com.smartrent.infra.repository.UserRepository;
+import com.smartrent.infra.repository.entity.Listing;
+import com.smartrent.infra.repository.entity.ListingAiModeration;
+import com.smartrent.infra.repository.entity.enums.VerificationStatus;
+import com.smartrent.mapper.ListingMapper;
+import com.smartrent.mapper.UserMapper;
+import com.smartrent.service.pricing.PricingHistoryService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * An owner edit must invalidate the stored AI verdict and put the listing back on the
+ * AI queue — the verdict describes the pre-edit content, and the admin review dialog
+ * would otherwise show it against content that has since changed.
+ */
+@ExtendWith(MockitoExtension.class)
+class ListingServiceImplUpdateReviewQueueTest {
+
+    private static final Long LISTING_ID = 42L;
+    private static final String USER_ID = "user-1";
+
+    @Mock
+    ListingRepository listingRepository;
+
+    @Mock
+    ListingAiModerationRepository listingAiModerationRepository;
+
+    @Mock
+    ApplicationEventPublisher eventPublisher;
+
+    @Mock
+    ListingMapper listingMapper;
+
+    @Mock
+    PricingHistoryService pricingHistoryService;
+
+    /** Only reached while building the response — mocked so updateListing doesn't NPE. */
+    @Mock
+    UserRepository userRepository;
+
+    @Mock
+    UserMapper userMapper;
+
+    @InjectMocks
+    ListingServiceImpl service;
+
+    private Listing existingListing(ModerationStatus status) {
+        return Listing.builder()
+                .listingId(LISTING_ID)
+                .userId(USER_ID)
+                .title("Phòng trọ Cầu Giấy")
+                .description("Phòng sạch sẽ, đầy đủ nội thất")
+                .price(BigDecimal.valueOf(3_000_000))
+                .priceUnit(Listing.PriceUnit.MONTH)
+                .area(25f)
+                .moderationStatus(status)
+                .verified(status == ModerationStatus.APPROVED)
+                .isVerify(status != ModerationStatus.APPROVED)
+                .build();
+    }
+
+    private Listing whenUpdating(Listing existing) {
+        when(listingRepository.findById(LISTING_ID)).thenReturn(Optional.of(existing));
+        when(listingRepository.save(any(Listing.class))).thenAnswer(inv -> inv.getArgument(0));
+        return existing;
+    }
+
+    private ListingAiModeration storedVerdict() {
+        ListingAiModeration moderation = ListingAiModeration.builder()
+                .listingId(LISTING_ID)
+                .verificationStatus(VerificationStatus.VERIFIED)
+                .retryCount(2)
+                .manualOverride(true)
+                .build();
+        when(listingAiModerationRepository.findById(LISTING_ID)).thenReturn(Optional.of(moderation));
+        return moderation;
+    }
+
+    @Test
+    void editingAListingAlreadyWaitingInTheQueueReQueuesIt() {
+        Listing existing = whenUpdating(existingListing(ModerationStatus.PENDING_REVIEW));
+        ListingAiModeration moderation = storedVerdict();
+
+        service.updateListing(LISTING_ID, ListingRequest.builder()
+                .title("Phòng trọ Cầu Giấy - giá mới").build(), USER_ID);
+
+        // Analysis already stored for the old title: reset it, or the worker skips the
+        // listing as already-computed and the admin reviews a stale verdict.
+        assertEquals(VerificationStatus.PENDING, moderation.getVerificationStatus());
+        assertEquals(0, moderation.getRetryCount());
+        verify(listingAiModerationRepository).save(moderation);
+        verify(eventPublisher).publishEvent(new ListingSubmittedEvent(LISTING_ID));
+        // Still awaiting review — an edit does not move it out of the queue.
+        assertEquals(ModerationStatus.PENDING_REVIEW, existing.getModerationStatus());
+    }
+
+    @Test
+    void editingAResubmittedListingReQueuesIt() {
+        Listing existing = whenUpdating(existingListing(ModerationStatus.RESUBMITTED));
+        storedVerdict();
+
+        service.updateListing(LISTING_ID, ListingRequest.builder()
+                .description("Mô tả đã sửa lại").build(), USER_ID);
+
+        verify(eventPublisher).publishEvent(new ListingSubmittedEvent(LISTING_ID));
+        assertEquals(ModerationStatus.RESUBMITTED, existing.getModerationStatus());
+    }
+
+    @Test
+    void editingAnApprovedListingSendsItBackToReviewAndReQueuesIt() {
+        Listing existing = whenUpdating(existingListing(ModerationStatus.APPROVED));
+        storedVerdict();
+
+        service.updateListing(LISTING_ID, ListingRequest.builder()
+                .price(BigDecimal.valueOf(4_000_000)).build(), USER_ID);
+
+        assertEquals(ModerationStatus.PENDING_REVIEW, existing.getModerationStatus());
+        assertEquals(Boolean.FALSE, existing.getVerified());
+        verify(eventPublisher).publishEvent(new ListingSubmittedEvent(LISTING_ID));
+    }
+
+    @Test
+    void editingARevisionRequiredListingResetsTheVerdictButDoesNotQueue() {
+        Listing existing = whenUpdating(existingListing(ModerationStatus.REVISION_REQUIRED));
+        ListingAiModeration moderation = storedVerdict();
+
+        service.updateListing(LISTING_ID, ListingRequest.builder()
+                .title("Đã sửa theo yêu cầu").build(), USER_ID);
+
+        // The worker ignores REVISION_REQUIRED — the owner still has to resubmit. Resetting
+        // here is what makes that resubmit analyse the edited content.
+        assertEquals(VerificationStatus.PENDING, moderation.getVerificationStatus());
+        verify(eventPublisher, never()).publishEvent(any(ListingSubmittedEvent.class));
+    }
+
+    @Test
+    void anEditThatChangesNothingTheAiSeesDoesNotReQueue() {
+        Listing existing = whenUpdating(existingListing(ModerationStatus.PENDING_REVIEW));
+
+        // Same values re-sent plus a field the AI is never shown: no new AI spend.
+        service.updateListing(LISTING_ID, ListingRequest.builder()
+                .title("Phòng trọ Cầu Giấy")
+                .price(BigDecimal.valueOf(3_000_000))
+                .expiryDate(LocalDateTime.now().plusDays(30))
+                .build(), USER_ID);
+
+        verify(listingAiModerationRepository, never()).save(any());
+        verify(eventPublisher, never()).publishEvent(any(ListingSubmittedEvent.class));
+        assertEquals(ModerationStatus.PENDING_REVIEW, existing.getModerationStatus());
+    }
+}


### PR DESCRIPTION
A generic edit (PUT /v1/listings/{id}) only put the listing back on the AI queue when it was APPROVED. Editing a listing that was still waiting in the review queue left the stored analysis untouched, so the admin review dialog showed a verdict computed from the pre-edit content — and the worker skipped the listing as already-computed.

updateListing now snapshots the slice of the listing the AI is actually shown (mirrors AiListingMapperImpl) plus media/amenity ids, and on a real change resets listing_ai_moderation to PENDING and re-queues. Edits to fields the AI never sees (expiry date, vipType) and no-op re-submits of the same values do not trigger a re-analysis, so no AI spend is added. REVISION_REQUIRED is reset but not queued: the worker ignores that state and the owner still has to resubmit explicitly.

Also closes the race the re-queue exposes — the analysis runs ~30s, so an edit can land mid-run. The processor now re-reads the row before storing and drops the verdict if the row went back to PENDING underneath it, which would otherwise overwrite the reset and make the re-queued delivery skip.