### PR TITLE
fix(news): transliterate Vietnamese diacritics in slug instead of stripping them

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/service/news/impl/NewsServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/news/impl/NewsServiceImpl.java
@@ -26,6 +26,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
+import java.text.Normalizer;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -392,10 +393,18 @@ public class NewsServiceImpl implements NewsService {
     }
 
     /**
-     * Generate URL-friendly slug from title
+     * Generate URL-friendly slug from title.
+     * <p>
+     * Vietnamese diacritics are transliterated to ASCII (NFD decomposition then
+     * combining-mark removal) rather than stripped, so "Bất động sản" yields
+     * "bat-dong-san" instead of the unreadable "bt-ng-sn". {@code đ}/{@code Đ}
+     * have no NFD decomposition and are handled explicitly.
      */
-    private String generateSlug(String title) {
-        return title.toLowerCase()
+    String generateSlug(String title) {
+        return Normalizer.normalize(title, Normalizer.Form.NFD)
+                .replaceAll("\\p{M}+", "")
+                .toLowerCase()
+                .replace("đ", "d")
                 .replaceAll("[^a-z0-9\\s-]", "")
                 .replaceAll("\\s+", "-")
                 .replaceAll("-+", "-")

--- a/smart-rent/src/test/java/com/smartrent/service/news/impl/NewsServiceImplSlugTest.java
+++ b/smart-rent/src/test/java/com/smartrent/service/news/impl/NewsServiceImplSlugTest.java
@@ -1,0 +1,35 @@
+package com.smartrent.service.news.impl;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * News slugs used to be generated with {@code replaceAll("[^a-z0-9\\s-]", "")},
+ * which stripped every Vietnamese diacritic character (and {@code đ}) outright,
+ * so "Bất động sản..." became the unreadable "bt-ng-sn...". Locks in that the
+ * generator transliterates Vietnamese to ASCII instead of deleting it.
+ */
+class NewsServiceImplSlugTest {
+
+    private final NewsServiceImpl service = new NewsServiceImpl(null, null, null);
+
+    @Test
+    void transliteratesVietnameseDiacriticsToAsciiInsteadOfStrippingThem() {
+        String title = "Bất động sản năm 2026: Đầu tư bằng kiến thức, không phải cảm xúc";
+
+        assertEquals(
+                "bat-dong-san-nam-2026-dau-tu-bang-kien-thuc-khong-phai-cam-xuc",
+                service.generateSlug(title));
+    }
+
+    @Test
+    void mapsDStrokeAndCollapsesPunctuationAndEdgeSeparators() {
+        // "đ"/"Đ" have no NFD decomposition; punctuation becomes stripped and
+        // surrounding whitespace must collapse to a single "-" with no leading
+        // or trailing separator.
+        assertEquals(
+                "dong-nai-quy-i-2026",
+                service.generateSlug("  Đồng Nai:  Quý I / 2026!  "));
+    }
+}


### PR DESCRIPTION
## Vấn đề
URL bài tin tiếng Việt bị hỏng slug. Ví dụ trên prod:

> `Bất động sản năm 2026: Đầu tư bằng kiến thức, không phải cảm xúc`
> → `/news/bt-ng-sn-nm-2026-u-t-bng-kin-thc-khng-phi-cm-xc` 

## Root cause
Ban đầu tưởng là bug frontend, nhưng FE (`react-slugify`) **đã sinh slug đúng**:
```
bat-dong-san-nam-2026-dau-tu-bang-kien-thuc-khong-phai-cam-xuc
```
Thủ phạm là backend: `NewsServiceImpl.generateSlug()` **bỏ qua slug FE gửi lên** và tự sinh lại từ title bằng:
```java
title.toLowerCase().replaceAll("[^a-z0-9\s-]", "") ...
```
Regex này **xoá sạch** mọi ký tự ngoài `a-z0-9` — tức toàn bộ ký tự tiếng Việt có dấu và cả `đ` — thay vì chuyển sang ASCII. Cả `createNews` lẫn `updateNews` đều regenerate từ title nên slug FE gửi luôn bị ghi đè.

## Fix
Chuẩn hoá NFD → xoá combining marks → map `đ`/`Đ` (không decompose theo NFD) → giữ nguyên chuỗi lowercase/hyphenate cũ:
```java
Normalizer.normalize(title, Normalizer.Form.NFD)
        .replaceAll("\p{M}+", "")
        .toLowerCase()
        .replace("đ", "d")
        .replaceAll("[^a-z0-9\s-]", "")
        ...
```

## Test
`NewsServiceImplSlugTest` (mới) — verify RED→GREEN:
- Reproduce đúng title prod → ra slug đúng.
- Edge case: `đ`/`Đ`, dấu câu, khoảng trắng thừa, gạch nối đầu/cuối.

`generateSlug` được nới từ `private` → package-private để unit test gọi trực tiếp.

## Lưu ý
- Các bài **đã tồn tại** vẫn giữ slug cũ trên DB cho tới khi được sửa title (lúc đó regenerate). Chưa backfill (đổi slug bài cũ sẽ làm hỏng link đã share). Nói nếu muốn migrate.