### PR TITLE
fix(media): stop orphan-cleanup from deleting news images

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/infra/repository/MediaRepository.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/MediaRepository.java
@@ -62,9 +62,14 @@ public interface MediaRepository extends JpaRepository<Media, Long> {
      * Find orphan media (ACTIVE media without listing after expiry time).
      * Avatar uploads live under users/{userId}/avatar/... and stay listing-less forever, so
      * they must be excluded or the cron would delete every user's avatar 24h after upload.
+     * Admin-uploaded media (adminId set) is excluded for the same reason: it backs news
+     * thumbnails and content images, which the news row references by URL string rather than
+     * a Media FK, so this listing-FK-based sweep can't tell they are in use and would delete
+     * the R2 objects 24h after a post is published.
      */
     @Query("SELECT m FROM media m WHERE m.status = 'ACTIVE' " +
            "AND m.listing IS NULL " +
+           "AND m.adminId IS NULL " +
            "AND m.sourceType = 'UPLOAD' " +
            "AND (m.storageKey IS NULL OR " +
            "     (m.storageKey NOT LIKE 'users/%/avatar/%' AND m.storageKey NOT LIKE 'users/%/broker/%')) " +


### PR DESCRIPTION
## Triệu chứng
Ảnh tin tức 404 sau khi đăng, ví dụ:
`https://pub-444e165e…r2.dev/media/d8340b23…/8d32ba83….jpg` → **404**

## Root cause (đã trace toàn bộ luồng)
Không phải lỗi ghép URL — URL đúng bucket, đúng key. Object **bị cron xoá**.

- Ảnh news upload qua admin → `generateGenericStorageKey(adminId,…)` → key `media/{adminId}/…`, media record `adminId` set, **`listing = null`**.
- `News` entity **không có FK tới Media** — `thumbnailUrl` là `String`, ảnh nội dung nằm trong `content` HTML dưới dạng `<img src>`. `createNews`/`updateNews` chỉ `setThumbnailUrl(...)`, **không gắn media vào đâu**.
- Cron [`findOrphanActiveMedia`](../blob/main/smart-rent/src/main/java/com/smartrent/infra/repository/MediaRepository.java) quét & **xoá khỏi R2** mọi media `ACTIVE + UPLOAD + listing IS NULL + >24h`, chỉ chừa `users/%/avatar/%` và `users/%/broker/%`.

→ Ảnh news khớp toàn bộ điều kiện → bị xoá sau 24h. `confirmUpload` (HeadObject) chứng minh object **từng tồn tại** lúc đăng; endpoint r2.dev trả trang 404 chuẩn của R2 (không phải bucket sai/tắt public).

## Fix
Thêm `AND m.adminId IS NULL` vào query — loại admin-uploaded media khỏi sweep, đúng như avatar/broker (đều được tham chiếu bằng URL string chứ không FK). Pre-upload của user (userId set) vẫn được dọn bình thường.

## ⚠️ Lưu ý vận hành
Ảnh **đã bị xoá thì mất hẳn trên R2**, không khôi phục được — sau khi deploy phải **upload lại** ảnh cho các bài cũ bị ảnh hưởng.

## Test
Không thêm test tự động: repo **chưa có JPA/Spring-context test harness chạy được** (`@SpringBootTest` duy nhất đang bị comment; datasource H2 test không dựng nổi schema entity vốn MySQL-specific → `@DataJpaTest` fail ở bước tạo bảng). Fix được verify bằng: (1) trace luồng create/update news (không hề gắn Media record); (2) `compileJava`/`compileTestJava` OK; (3) full `./gradlew test` — **BUILD SUCCESSFUL**, không regression.