### PR TITLE
perf(map-bounds): snap viewport to zoom grid to raise cache hit-rate

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/controller/ListingSearchController.java
+++ b/smart-rent/src/main/java/com/smartrent/controller/ListingSearchController.java
@@ -6,6 +6,7 @@ import com.smartrent.dto.response.ListingCardListResponse;
 import com.smartrent.dto.response.*;
 import com.smartrent.service.listing.ListingService;
 import com.smartrent.service.discovery.SearchSuggestionService;
+import com.smartrent.util.MapBoundsGrid;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -466,7 +467,13 @@ public class ListingSearchController {
     )
     public ApiResponse<MapListingsResponse> getListingsByMapBounds(
             @Valid @RequestBody MapBoundsRequest request) {
-        MapListingsResponse response = listingService.getListingsByMapBounds(request);
+        // Snap the viewport to a zoom grid BEFORE the @Cacheable service boundary
+        // (its key is derived from these bounds). Different users browsing the same
+        // area collapse onto shared grid cells, so the first load of a popular
+        // viewport becomes a cache hit instead of a fresh geo query. The snapped
+        // cell contains the requested one; the map filters pins client-side.
+        MapListingsResponse response =
+                listingService.getListingsByMapBounds(MapBoundsGrid.snap(request));
         return ApiResponse.<MapListingsResponse>builder().data(response).build();
     }
 }

--- a/smart-rent/src/main/java/com/smartrent/util/MapBoundsGrid.java
+++ b/smart-rent/src/main/java/com/smartrent/util/MapBoundsGrid.java
@@ -1,0 +1,85 @@
+package com.smartrent.util;
+
+import com.smartrent.dto.request.MapBoundsRequest;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+/**
+ * Snaps a map-bounds viewport to a fixed, zoom-dependent grid so overlapping
+ * viewports collapse to a single {@code listing.map} cache key.
+ *
+ * <p>The frontend rounds the raw bbox to 4 decimals (~11m) before sending, but
+ * that key still depends on each user's exact map centre (their GPS location)
+ * and screen pixel span, so two people browsing the same area almost never share
+ * a key — the cross-user hit rate is ~0 and every first load re-runs the geo
+ * query. Snapping each corner to a global grid whose cell size is a function of
+ * <em>zoom only</em> makes all viewers at the same zoom land on the same grid
+ * lines, so their viewports share one cached entry.
+ *
+ * <p>SW floors down and NE ceils up, so the snapped cell always <b>contains</b>
+ * the requested viewport: the cached result is a superset and the frontend
+ * filters client-side to the true viewport, so nothing in view is ever missing.
+ * The step halves each zoom level (Web-Mercator tiles do the same), so a
+ * zoomed-in viewport is never expanded by more than a fraction of itself.
+ */
+public final class MapBoundsGrid {
+
+    private MapBoundsGrid() {}
+
+    // Scale kept on the computed step + snapped corners. 12 dp is far finer than
+    // the ~11m the frontend already quantizes to, and — crucially — is fixed, so
+    // the same (zoom, cell) always yields the same BigDecimal and therefore the
+    // same cache-key string.
+    private static final int GRID_SCALE = 12;
+    private static final BigDecimal FULL_LNG_SPAN = BigDecimal.valueOf(360);
+
+    /**
+     * @return a copy of {@code request} with its bbox snapped to the zoom grid;
+     *         the same instance untouched when it carries no zoom (nothing to
+     *         grid against).
+     */
+    public static MapBoundsRequest snap(MapBoundsRequest request) {
+        if (request == null || request.getZoom() == null) {
+            return request;
+        }
+
+        BigDecimal step = stepForZoom(request.getZoom());
+
+        return MapBoundsRequest.builder()
+                .swLat(floorToStep(request.getSwLat(), step))
+                .swLng(floorToStep(request.getSwLng(), step))
+                .neLat(ceilToStep(request.getNeLat(), step))
+                .neLng(ceilToStep(request.getNeLng(), step))
+                .zoom(request.getZoom())
+                .limit(request.getLimit())
+                .verifiedOnly(request.getVerifiedOnly())
+                .categoryId(request.getCategoryId())
+                .vipType(request.getVipType())
+                .build();
+    }
+
+    // Grid cell size in degrees = 360 / 2^(zoom+2), i.e. a quarter of a
+    // Web-Mercator tile's longitude span at this zoom. Same latitude step is
+    // reused: at Vietnam's latitudes a degree of lat and lng are close enough
+    // that a shared step keeps cells roughly square, and it keeps the grid math
+    // trivial.
+    private static BigDecimal stepForZoom(int zoom) {
+        BigDecimal divisor = BigDecimal.valueOf(2).pow(zoom + 2);
+        return FULL_LNG_SPAN.divide(divisor, GRID_SCALE, RoundingMode.HALF_UP);
+    }
+
+    private static BigDecimal floorToStep(BigDecimal value, BigDecimal step) {
+        if (value == null) {
+            return null;
+        }
+        return value.divide(step, 0, RoundingMode.FLOOR).multiply(step);
+    }
+
+    private static BigDecimal ceilToStep(BigDecimal value, BigDecimal step) {
+        if (value == null) {
+            return null;
+        }
+        return value.divide(step, 0, RoundingMode.CEILING).multiply(step);
+    }
+}

--- a/smart-rent/src/test/java/com/smartrent/util/MapBoundsGridTest.java
+++ b/smart-rent/src/test/java/com/smartrent/util/MapBoundsGridTest.java
@@ -1,0 +1,129 @@
+package com.smartrent.util;
+
+import com.smartrent.dto.request.MapBoundsRequest;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * {@link MapBoundsGrid} snaps a map-bounds viewport to a fixed, zoom-dependent
+ * grid before it is used as the {@code listing.map} Redis cache key + geo query
+ * bbox. The point is hit-rate: two users browsing the same area at the same zoom
+ * (whose exact viewports never match to 4 decimals) must collapse to ONE cache
+ * entry instead of each re-running the geo query. The snapped region must still
+ * fully contain the requested one so the cached result is correct for it.
+ */
+class MapBoundsGridTest {
+
+    private static final BigDecimal TWO = BigDecimal.valueOf(2);
+
+    private MapBoundsRequest.MapBoundsRequestBuilder base() {
+        return MapBoundsRequest.builder()
+                .swLat(new BigDecimal("10.7900"))
+                .swLng(new BigDecimal("106.7000"))
+                .neLat(new BigDecimal("10.8000"))
+                .neLng(new BigDecimal("106.7100"))
+                .zoom(14)
+                .limit(200)
+                .verifiedOnly(true)
+                .categoryId(3L)
+                .vipType("GOLD");
+    }
+
+    private static BigDecimal midpoint(BigDecimal a, BigDecimal b) {
+        return a.add(b).divide(TWO, 12, RoundingMode.HALF_UP);
+    }
+
+    /** Correctness: the snapped region must never be smaller than what was asked. */
+    @Test
+    void snap_expandsRegionToContainOriginal() {
+        MapBoundsRequest r = base().build();
+
+        MapBoundsRequest s = MapBoundsGrid.snap(r);
+
+        assertTrue(s.getSwLat().compareTo(r.getSwLat()) <= 0, "snapped SW lat must floor below request");
+        assertTrue(s.getSwLng().compareTo(r.getSwLng()) <= 0, "snapped SW lng must floor below request");
+        assertTrue(s.getNeLat().compareTo(r.getNeLat()) >= 0, "snapped NE lat must ceil above request");
+        assertTrue(s.getNeLng().compareTo(r.getNeLng()) >= 0, "snapped NE lng must ceil above request");
+    }
+
+    /**
+     * The core hit-rate behavior: a second viewport that pans within the same
+     * grid cell (distinct raw coordinates) snaps to the SAME cache key. Built by
+     * nudging each corner to the midpoint between the request and its own snapped
+     * grid line — provably still inside the same cell — so the test is robust to
+     * where the grid lines actually fall.
+     */
+    @Test
+    void snap_collapsesSubCellPanToSameCacheKey() {
+        MapBoundsRequest a = base().build();
+        MapBoundsRequest snappedA = MapBoundsGrid.snap(a);
+
+        MapBoundsRequest b = base()
+                .swLat(midpoint(snappedA.getSwLat(), a.getSwLat()))
+                .swLng(midpoint(snappedA.getSwLng(), a.getSwLng()))
+                .neLat(midpoint(a.getNeLat(), snappedA.getNeLat()))
+                .neLng(midpoint(a.getNeLng(), snappedA.getNeLng()))
+                .build();
+
+        // Precondition: a and b are genuinely different raw viewports.
+        assertNotEquals(CacheKeyBuilder.mapBoundsKey(a), CacheKeyBuilder.mapBoundsKey(b));
+
+        // ...yet after snapping they share one cache entry.
+        assertEquals(
+                CacheKeyBuilder.mapBoundsKey(MapBoundsGrid.snap(a)),
+                CacheKeyBuilder.mapBoundsKey(MapBoundsGrid.snap(b)));
+    }
+
+    /**
+     * The grid must tighten as zoom increases, otherwise zoomed-in viewports
+     * would over-expand (querying far more than the user sees) and the cap could
+     * drop pins actually in view. Same raw box → smaller snapped span at higher
+     * zoom.
+     */
+    @Test
+    void snap_gridIsFinerAtHigherZoom() {
+        MapBoundsRequest coarse = base().zoom(10).build();
+        MapBoundsRequest fine = base().zoom(18).build();
+
+        BigDecimal coarseSpan = spanLng(MapBoundsGrid.snap(coarse));
+        BigDecimal fineSpan = spanLng(MapBoundsGrid.snap(fine));
+
+        assertTrue(fineSpan.compareTo(coarseSpan) < 0,
+                "higher zoom must snap to a tighter grid (smaller span): fine=" + fineSpan + " coarse=" + coarseSpan);
+    }
+
+    private static BigDecimal spanLng(MapBoundsRequest r) {
+        return r.getNeLng().subtract(r.getSwLng());
+    }
+
+    /** Snapping only touches geometry; every filter/limit/zoom field is carried through. */
+    @Test
+    void snap_preservesNonGeoFields() {
+        MapBoundsRequest r = base().build();
+
+        MapBoundsRequest s = MapBoundsGrid.snap(r);
+
+        assertEquals(r.getZoom(), s.getZoom());
+        assertEquals(r.getLimit(), s.getLimit());
+        assertEquals(r.getVerifiedOnly(), s.getVerifiedOnly());
+        assertEquals(r.getCategoryId(), s.getCategoryId());
+        assertEquals(r.getVipType(), s.getVipType());
+    }
+
+    /** Defensive: a request without zoom can't be gridded, so it passes through untouched. */
+    @Test
+    void snap_withoutZoom_returnsUnchanged() {
+        MapBoundsRequest r = base().zoom(null).build();
+
+        MapBoundsRequest s = MapBoundsGrid.snap(r);
+
+        assertEquals(r.getSwLat(), s.getSwLat());
+        assertEquals(r.getNeLng(), s.getNeLng());
+    }
+}


### PR DESCRIPTION
## Vấn đề
`POST /v1/listings/map-bounds` có `@Cacheable` (TTL 1 phút) nhưng key là **bounding box chính xác 4 chữ số thập phân** (`CacheKeyBuilder.mapBoundsKey`). Key này phụ thuộc tâm bản đồ (GPS từng người) + kích thước pixel màn hình + zoom → hai người xem cùng khu vực gần như không bao giờ trùng key. Hit-rate cross-user ≈ 0, nên **lần load đầu của mỗi người luôn trượt cache** và phải chạy lại geo query — đây là nguyên nhân "request đầu chậm".

## Cách sửa
`MapBoundsGrid.snap()` snap SW xuống / NE lên một lưới chỉ phụ thuộc **zoom**: `step = 360 / 2^(zoom+2)` (~quarter-tile Web-Mercator). Mọi người ở cùng zoom snap về cùng đường lưới → viewport chồng lấn gộp về **một** cache entry, nên người thứ 2+ vào khu vực phổ biến (VD trung tâm HCM/HN) được cache hit.

- Snap thực hiện ở **controller, trước** ranh giới `@Cacheable` (nơi key được tính) → key **và** query bbox dùng chung vùng đã snap, không lệch key/data.
- Vùng snap luôn **chứa** vùng yêu cầu (SW floor, NE ceil); FE vốn lọc pin client-side theo viewport thật nên kết quả (superset) vẫn đúng; nothing-in-view bị thiếu.
- Lưới nhỏ dần theo zoom nên viewport zoom sâu không bị nới rộng quá mức.

## Test (TDD)
`MapBoundsGridTest` (5 test, viết trước — thấy RED rồi mới implement):
- vùng snap chứa vùng gốc (correctness)
- pan trong cùng cell → **cùng cache key** (hành vi cốt lõi)
- lưới mịn hơn khi zoom cao
- giữ nguyên limit/filter/zoom
- không có zoom → passthrough

`./gradlew test` (toàn bộ): ✅ BUILD SUCCESSFUL.

## Ghi chú
Đây là 1 trong 2 fix cho "xem nhà trọ qua bản đồ chậm ở request đầu". Phần còn lại (FE hoãn fetch đầu, bỏ query zoom-12 lãng phí) ở PR frontend riêng.