### PR TITLE
feat(contact): authenticated contact-reveal endpoint + audit log (V122)

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/controller/ContactRevealController.java
+++ b/smart-rent/src/main/java/com/smartrent/controller/ContactRevealController.java
@@ -1,0 +1,88 @@
+package com.smartrent.controller;
+
+import com.smartrent.dto.request.RevealContactRequest;
+import com.smartrent.dto.response.ApiResponse;
+import com.smartrent.dto.response.RevealContactResponse;
+import com.smartrent.service.contactreveal.ContactRevealService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.FieldDefaults;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/v1/users")
+@RequiredArgsConstructor
+@FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
+@Slf4j
+@Tag(
+        name = "Contact Reveal",
+        description = "Authenticated reveal + audit of a seller's contact details (phone / email / zalo)."
+)
+public class ContactRevealController {
+
+    ContactRevealService contactRevealService;
+
+    @PostMapping("/{sellerUserId}/reveal-contact")
+    @Operation(
+            summary = "Reveal a seller's contact and log the access",
+            description = """
+                    Requires authentication. Records who revealed which seller's contact
+                    (phone / email / zalo), optionally from which listing, and returns the
+                    seller's contact details. Anonymous callers receive 401.
+                    """,
+            security = @SecurityRequirement(name = "Bearer Authentication")
+    )
+    public ApiResponse<RevealContactResponse> revealContact(
+            @PathVariable String sellerUserId,
+            @Valid @RequestBody RevealContactRequest request,
+            HttpServletRequest httpRequest
+    ) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String viewerUserId = authentication == null ? null : authentication.getName();
+        if (viewerUserId == null) {
+            throw new IllegalStateException("User is not authenticated");
+        }
+
+        String ipAddress = extractIpAddress(httpRequest);
+        String userAgent = httpRequest.getHeader("User-Agent");
+
+        RevealContactResponse response = contactRevealService.revealContact(
+                sellerUserId, request, viewerUserId, ipAddress, userAgent);
+
+        return ApiResponse.<RevealContactResponse>builder()
+                .code("999999")
+                .data(response)
+                .build();
+    }
+
+    private String extractIpAddress(HttpServletRequest request) {
+        String ipAddress = request.getHeader("X-Forwarded-For");
+
+        if (ipAddress == null || ipAddress.isEmpty() || "unknown".equalsIgnoreCase(ipAddress)) {
+            ipAddress = request.getHeader("X-Real-IP");
+        }
+
+        if (ipAddress == null || ipAddress.isEmpty() || "unknown".equalsIgnoreCase(ipAddress)) {
+            ipAddress = request.getRemoteAddr();
+        }
+
+        // X-Forwarded-For can contain multiple IPs, take the first one
+        if (ipAddress != null && ipAddress.contains(",")) {
+            ipAddress = ipAddress.split(",")[0].trim();
+        }
+
+        return ipAddress;
+    }
+}

--- a/smart-rent/src/main/java/com/smartrent/dto/request/RevealContactRequest.java
+++ b/smart-rent/src/main/java/com/smartrent/dto/request/RevealContactRequest.java
@@ -1,0 +1,28 @@
+package com.smartrent.dto.request;
+
+import com.smartrent.enums.ContactRevealChannel;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.FieldDefaults;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class RevealContactRequest {
+
+    @NotNull(message = "Channel is required")
+    @Schema(description = "Which contact channel is being revealed", example = "PHONE")
+    ContactRevealChannel channel;
+
+    @Schema(description = "Optional listing the reveal happened from", example = "123")
+    Long listingId;
+}

--- a/smart-rent/src/main/java/com/smartrent/dto/response/RevealContactResponse.java
+++ b/smart-rent/src/main/java/com/smartrent/dto/response/RevealContactResponse.java
@@ -1,0 +1,27 @@
+package com.smartrent.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.smartrent.enums.ContactRevealChannel;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.FieldDefaults;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@FieldDefaults(level = AccessLevel.PRIVATE)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class RevealContactResponse {
+
+    String contactName;
+    String phoneNumber;
+    String email;
+    String zaloLink;
+    ContactRevealChannel channel;
+}

--- a/smart-rent/src/main/java/com/smartrent/enums/ContactRevealChannel.java
+++ b/smart-rent/src/main/java/com/smartrent/enums/ContactRevealChannel.java
@@ -1,0 +1,11 @@
+package com.smartrent.enums;
+
+/**
+ * The contact channel a viewer revealed for a seller. Persisted as a string on
+ * {@code contact_reveal_log.channel} and echoed back on the reveal response.
+ */
+public enum ContactRevealChannel {
+    PHONE,
+    EMAIL,
+    ZALO
+}

--- a/smart-rent/src/main/java/com/smartrent/infra/repository/ContactRevealLogRepository.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/ContactRevealLogRepository.java
@@ -1,0 +1,13 @@
+package com.smartrent.infra.repository;
+
+import com.smartrent.infra.repository.entity.ContactRevealLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ContactRevealLogRepository extends JpaRepository<ContactRevealLog, Long> {
+
+    long countBySeller_UserId(String sellerUserId);
+
+    long countByViewer_UserId(String viewerUserId);
+}

--- a/smart-rent/src/main/java/com/smartrent/infra/repository/entity/ContactRevealLog.java
+++ b/smart-rent/src/main/java/com/smartrent/infra/repository/entity/ContactRevealLog.java
@@ -1,0 +1,77 @@
+package com.smartrent.infra.repository.entity;
+
+import com.smartrent.enums.ContactRevealChannel;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.FieldDefaults;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+/**
+ * Audit record of a single contact reveal: who ({@link #viewer}) revealed which
+ * {@link #seller}'s contact, over which {@link #channel}, optionally from a
+ * {@link #listing}, and when. Written on every authenticated reveal so contact
+ * access can be tracked per user.
+ */
+@Entity(name = "contact_reveal_log")
+@Table(name = "contact_reveal_log", indexes = {
+        @Index(name = "idx_contact_reveal_viewer", columnList = "viewer_user_id, revealed_at"),
+        @Index(name = "idx_contact_reveal_seller", columnList = "seller_user_id, revealed_at"),
+        @Index(name = "idx_contact_reveal_listing", columnList = "listing_id")
+})
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class ContactRevealLog {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "viewer_user_id", nullable = false)
+    User viewer;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "seller_user_id", nullable = false)
+    User seller;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "listing_id")
+    Listing listing;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "channel", length = 16, nullable = false)
+    ContactRevealChannel channel;
+
+    @Column(name = "ip_address", length = 45)
+    String ipAddress;
+
+    @Column(name = "user_agent", length = 500)
+    String userAgent;
+
+    @Builder.Default
+    @CreationTimestamp
+    @Column(name = "revealed_at", updatable = false)
+    LocalDateTime revealedAt = LocalDateTime.now();
+}

--- a/smart-rent/src/main/java/com/smartrent/service/contactreveal/ContactRevealService.java
+++ b/smart-rent/src/main/java/com/smartrent/service/contactreveal/ContactRevealService.java
@@ -1,0 +1,22 @@
+package com.smartrent.service.contactreveal;
+
+import com.smartrent.dto.request.RevealContactRequest;
+import com.smartrent.dto.response.RevealContactResponse;
+
+public interface ContactRevealService {
+
+    /**
+     * Log a contact reveal and return the seller's contact details.
+     *
+     * @param sellerUserId whose contact is being revealed
+     * @param request      channel + optional listing context
+     * @param viewerUserId the authenticated user performing the reveal
+     * @param ipAddress    request IP (audit)
+     * @param userAgent    request User-Agent (audit)
+     */
+    RevealContactResponse revealContact(String sellerUserId,
+                                        RevealContactRequest request,
+                                        String viewerUserId,
+                                        String ipAddress,
+                                        String userAgent);
+}

--- a/smart-rent/src/main/java/com/smartrent/service/contactreveal/impl/ContactRevealServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/contactreveal/impl/ContactRevealServiceImpl.java
@@ -1,0 +1,87 @@
+package com.smartrent.service.contactreveal.impl;
+
+import com.smartrent.dto.request.RevealContactRequest;
+import com.smartrent.dto.response.RevealContactResponse;
+import com.smartrent.enums.ContactRevealChannel;
+import com.smartrent.infra.repository.ContactRevealLogRepository;
+import com.smartrent.infra.repository.ListingRepository;
+import com.smartrent.infra.repository.UserRepository;
+import com.smartrent.infra.repository.entity.ContactRevealLog;
+import com.smartrent.infra.repository.entity.Listing;
+import com.smartrent.infra.repository.entity.User;
+import com.smartrent.service.contactreveal.ContactRevealService;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.FieldDefaults;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
+@Slf4j
+public class ContactRevealServiceImpl implements ContactRevealService {
+
+    ContactRevealLogRepository contactRevealLogRepository;
+    UserRepository userRepository;
+    ListingRepository listingRepository;
+
+    @Override
+    @Transactional
+    public RevealContactResponse revealContact(String sellerUserId,
+                                               RevealContactRequest request,
+                                               String viewerUserId,
+                                               String ipAddress,
+                                               String userAgent) {
+        User seller = userRepository.findById(sellerUserId)
+                .orElseThrow(() -> new RuntimeException("Seller not found with ID: " + sellerUserId));
+
+        User viewer = userRepository.findById(viewerUserId)
+                .orElseThrow(() -> new RuntimeException("Viewer not found with ID: " + viewerUserId));
+
+        // Listing is optional context — a reveal on the seller profile page has none.
+        Listing listing = null;
+        if (request.getListingId() != null) {
+            listing = listingRepository.findById(request.getListingId()).orElse(null);
+        }
+
+        ContactRevealLog logEntry = ContactRevealLog.builder()
+                .viewer(viewer)
+                .seller(seller)
+                .listing(listing)
+                .channel(request.getChannel())
+                .ipAddress(ipAddress)
+                .userAgent(userAgent)
+                .build();
+
+        contactRevealLogRepository.save(logEntry);
+        log.info("Contact reveal logged: viewer={} seller={} channel={} listing={}",
+                viewerUserId, sellerUserId, request.getChannel(), request.getListingId());
+
+        return buildContactResponse(seller, request.getChannel());
+    }
+
+    private RevealContactResponse buildContactResponse(User seller, ContactRevealChannel channel) {
+        String contactPhone = seller.getContactPhoneNumber();
+        if (contactPhone == null || contactPhone.isBlank()) {
+            String code = seller.getPhoneCode() == null ? "" : seller.getPhoneCode();
+            String number = seller.getPhoneNumber() == null ? "" : seller.getPhoneNumber();
+            contactPhone = (code + number).trim();
+        }
+        boolean hasPhone = contactPhone != null && !contactPhone.isBlank();
+        String digits = hasPhone ? contactPhone.replaceAll("\\D", "") : "";
+        String zaloLink = digits.isEmpty() ? null : "https://zalo.me/" + digits;
+
+        String contactName = ((seller.getLastName() == null ? "" : seller.getLastName()) + " "
+                + (seller.getFirstName() == null ? "" : seller.getFirstName())).trim();
+
+        return RevealContactResponse.builder()
+                .contactName(contactName.isEmpty() ? null : contactName)
+                .phoneNumber(hasPhone ? contactPhone : null)
+                .email(seller.getEmail())
+                .zaloLink(zaloLink)
+                .channel(channel)
+                .build();
+    }
+}

--- a/smart-rent/src/main/resources/db/migration/V122__Create_contact_reveal_log_table.sql
+++ b/smart-rent/src/main/resources/db/migration/V122__Create_contact_reveal_log_table.sql
@@ -1,0 +1,26 @@
+-- Create contact_reveal_log table.
+--
+-- Unified audit trail of contact reveals: records WHO (viewer) revealed WHICH
+-- seller's contact, through which CHANNEL (phone / email / zalo), optionally
+-- from which listing, and WHEN. Written by the authenticated
+-- POST /v1/users/{sellerUserId}/reveal-contact endpoint so contact access can
+-- be tracked per user going forward.
+--
+-- Complements the existing phone_clicks table (which only covers phone clicks
+-- and powers owner analytics) by covering every contact channel in one place.
+CREATE TABLE IF NOT EXISTS contact_reveal_log (
+    id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    viewer_user_id VARCHAR(36) NOT NULL,
+    seller_user_id VARCHAR(36) NOT NULL,
+    listing_id BIGINT NULL,
+    channel VARCHAR(16) NOT NULL,
+    ip_address VARCHAR(45),
+    user_agent VARCHAR(500),
+    revealed_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    INDEX idx_contact_reveal_viewer (viewer_user_id, revealed_at),
+    INDEX idx_contact_reveal_seller (seller_user_id, revealed_at),
+    INDEX idx_contact_reveal_listing (listing_id),
+    CONSTRAINT fk_contact_reveal_viewer FOREIGN KEY (viewer_user_id) REFERENCES users(user_id) ON DELETE CASCADE,
+    CONSTRAINT fk_contact_reveal_seller FOREIGN KEY (seller_user_id) REFERENCES users(user_id) ON DELETE CASCADE,
+    CONSTRAINT fk_contact_reveal_listing FOREIGN KEY (listing_id) REFERENCES listings(listing_id) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;


### PR DESCRIPTION
## What & why

Public listing/seller pages exposed seller contact (phone/email/zalo) to anyone, and contact access was **not tracked**. This adds an authenticated **contact-reveal endpoint with an audit trail** so we can track who accessed which seller's contact.

Pairs with the frontend PR that gates all contact-reveal buttons behind login and fires this endpoint on each reveal.

## Endpoint

`POST /v1/users/{sellerUserId}/reveal-contact` — **auth required** (not in the `application.yml` public POST allowlist, so anonymous callers get `401`).

- Body: `{ "channel": "PHONE" | "EMAIL" | "ZALO", "listingId": 123? }`
- Returns the seller's `contactName`, `phoneNumber`, `email`, `zaloLink`, `channel`.
- Writes a `contact_reveal_log` row: `viewer_user_id`, `seller_user_id`, `listing_id?`, `channel`, `ip_address`, `user_agent`, `revealed_at`.

## Changes

- **V122** `contact_reveal_log` table (viewer/seller FK `ON DELETE CASCADE`, nullable listing FK `ON DELETE SET NULL`, indexed by viewer/seller/listing).
- `ContactRevealLog` entity + `ContactRevealLogRepository`, `ContactRevealChannel` enum.
- `RevealContactRequest` / `RevealContactResponse` DTOs.
- `ContactRevealService(Impl)` + `ContactRevealController` (follows existing `PhoneClickDetail*` patterns: `SecurityContextHolder` for the viewer id, `extractIpAddress`, `ApiResponse<T>` envelope).

## Notes

- **Additive only** — no existing responses change. Complements the existing `phone_clicks` table (phone-only, powers owner analytics) with a unified phone+email+zalo audit.
- Withholding contact from anonymous API responses (payload strip) is a deliberate follow-up (would ripple to the AI/chatbot + mobile consumers; needs coordination + verification).

## Verification

`./gradlew compileJava` — green against `origin/main`. (No `@SpringBootTest`/`@DataJpaTest` harness in this repo — H2 can't build the MySQL-specific schema — so verified by compile + code trace.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
