### PR TITLE
feat(contact): withhold seller contact from anonymous listing responses (flag, default off)

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/controller/ListingController.java
+++ b/smart-rent/src/main/java/com/smartrent/controller/ListingController.java
@@ -51,6 +51,7 @@ public class ListingController {
 
     private final ListingService listingService;
     private final VipTierDetailService vipTierDetailService;
+    private final com.smartrent.service.listing.ContactVisibility contactVisibility;
 
     @Operation(
         summary = "Create a new listing with transactional address",
@@ -197,7 +198,7 @@ public class ListingController {
     @GetMapping("/{id}")
     public ApiResponse<ListingResponse> getListingById(@PathVariable Long id) {
         ListingResponse response = listingService.getListingById(id);
-        return ApiResponse.<ListingResponse>builder().data(response).build();
+        return ApiResponse.<ListingResponse>builder().data(contactVisibility.apply(response)).build();
     }
 
     @GetMapping
@@ -224,10 +225,10 @@ public class ListingController {
     ) {
         if (ids != null && !ids.isEmpty()) {
             List<ListingResponse> responses = listingService.getListingsByIds(ids);
-            return ApiResponse.<List<ListingResponse>>builder().data(responses).build();
+            return ApiResponse.<List<ListingResponse>>builder().data(contactVisibility.applyDetails(responses)).build();
         }
         List<ListingResponse> responses = listingService.getListings(page, size);
-        return ApiResponse.<List<ListingResponse>>builder().data(responses).build();
+        return ApiResponse.<List<ListingResponse>>builder().data(contactVisibility.applyDetails(responses)).build();
     }
 
     @Operation(

--- a/smart-rent/src/main/java/com/smartrent/controller/ListingSearchController.java
+++ b/smart-rent/src/main/java/com/smartrent/controller/ListingSearchController.java
@@ -42,6 +42,7 @@ public class ListingSearchController {
 
     private final ListingService listingService;
     private final SearchSuggestionService searchSuggestionService;
+    private final com.smartrent.service.listing.ContactVisibility contactVisibility;
 
     @PostMapping("/search")
     @Operation(
@@ -171,7 +172,7 @@ public class ListingSearchController {
         }
 
         ListingCardListResponse response = listingService.searchListings(filter);
-        return ApiResponse.<ListingCardListResponse>builder().data(response).build();
+        return ApiResponse.<ListingCardListResponse>builder().data(contactVisibility.apply(response)).build();
     }
 
     @PostMapping("/search/cursor")
@@ -200,7 +201,7 @@ public class ListingSearchController {
                 : (filter.getSize() != null ? filter.getSize() : 20);
 
         ListingCursorResponse response = listingService.searchListingsByCursor(filter, cursor, effectiveSize);
-        return ApiResponse.<ListingCursorResponse>builder().data(response).build();
+        return ApiResponse.<ListingCursorResponse>builder().data(contactVisibility.apply(response)).build();
     }
 
     @GetMapping("/homepage-tier")
@@ -222,7 +223,7 @@ public class ListingSearchController {
             @RequestParam("vipType") String vipType,
             @RequestParam(value = "limit", defaultValue = "10") int limit) {
         List<ListingCardResponse> listings = listingService.getHomepageTierListings(vipType, limit);
-        return ApiResponse.<List<ListingCardResponse>>builder().data(listings).build();
+        return ApiResponse.<List<ListingCardResponse>>builder().data(contactVisibility.applyCards(listings)).build();
     }
 
     @GetMapping("/sellers/{userId}/diamond")
@@ -287,7 +288,7 @@ public class ListingSearchController {
             @RequestParam(defaultValue = "5") Integer limit) {
         int safeLimit = limit != null && limit > 0 ? Math.min(limit, 20) : 5;
         ListingCardListResponse response = listingService.getTopSavedListingsByUser(userId, safeLimit);
-        return ApiResponse.<ListingCardListResponse>builder().data(response).build();
+        return ApiResponse.<ListingCardListResponse>builder().data(contactVisibility.apply(response)).build();
     }
 
     private ApiResponse<ListingCardListResponse> searchSellerListingsByVipType(
@@ -305,7 +306,7 @@ public class ListingSearchController {
                 .build();
 
         ListingCardListResponse response = listingService.searchListings(filter);
-        return ApiResponse.<ListingCardListResponse>builder().data(response).build();
+        return ApiResponse.<ListingCardListResponse>builder().data(contactVisibility.apply(response)).build();
     }
 
     @GetMapping("/autocomplete")

--- a/smart-rent/src/main/java/com/smartrent/service/listing/ContactVisibility.java
+++ b/smart-rent/src/main/java/com/smartrent/service/listing/ContactVisibility.java
@@ -1,0 +1,133 @@
+package com.smartrent.service.listing;
+
+import com.smartrent.dto.response.ListingCardListResponse;
+import com.smartrent.dto.response.ListingCardResponse;
+import com.smartrent.dto.response.ListingCursorResponse;
+import com.smartrent.dto.response.ListingResponse;
+import com.smartrent.dto.response.UserCreationResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+/**
+ * Withholds a seller's real contact details (phone / email / zalo) from
+ * listing responses served to <b>anonymous</b> callers, so contact info is not
+ * scrapeable without logging in. Names, avatars and broker status are kept.
+ *
+ * <p>Gated by {@code application.contact.strip-anonymous-contact} (default
+ * {@code false}). It is shipped OFF because enabling it requires two coupled
+ * changes to be in place first:
+ * <ul>
+ *   <li>the web frontend must render its "log in to view contact" affordance
+ *       from an availability signal rather than the value's presence (today it
+ *       keys off the value, so a stripped payload would show "no contact"); and</li>
+ *   <li>the AI service must forward the user's token on its listing calls so
+ *       authenticated chat users still receive contact (guests are stripped,
+ *       which the gated chat card already handles).</li>
+ * </ul>
+ * Flip the flag to {@code true} once those are deployed and verified.
+ */
+@Component
+@Slf4j
+public class ContactVisibility {
+
+    private final boolean stripEnabled;
+
+    public ContactVisibility(
+            @Value("${application.contact.strip-anonymous-contact:false}") boolean stripEnabled) {
+        this.stripEnabled = stripEnabled;
+    }
+
+    /** True when the current request has no authenticated (non-anonymous) user. */
+    private boolean isAnonymous() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        return authentication == null
+                || !authentication.isAuthenticated()
+                || "anonymousUser".equals(authentication.getName());
+    }
+
+    private boolean shouldStrip() {
+        return stripEnabled && isAnonymous();
+    }
+
+    public ListingResponse apply(ListingResponse response) {
+        if (response != null && shouldStrip()) {
+            scrub(response);
+        }
+        return response;
+    }
+
+    public List<ListingResponse> applyDetails(List<ListingResponse> responses) {
+        if (responses != null && shouldStrip()) {
+            responses.forEach(this::scrub);
+        }
+        return responses;
+    }
+
+    public ListingCardListResponse apply(ListingCardListResponse response) {
+        if (response != null && shouldStrip()) {
+            scrubCards(response.getListings());
+        }
+        return response;
+    }
+
+    public List<ListingCardResponse> applyCards(List<ListingCardResponse> cards) {
+        if (cards != null && shouldStrip()) {
+            scrubCards(cards);
+        }
+        return cards;
+    }
+
+    public ListingCursorResponse apply(ListingCursorResponse response) {
+        if (response != null && shouldStrip()) {
+            scrubCards(response.getItems());
+        }
+        return response;
+    }
+
+    private void scrub(ListingResponse response) {
+        response.setOwnerContactPhoneNumber(null);
+        response.setOwnerZaloLink(null);
+        response.setContactPhone(null);
+
+        UserCreationResponse user = response.getUser();
+        if (user != null) {
+            user.setPhoneCode(null);
+            user.setPhoneNumber(null);
+            user.setEmail(null);
+            user.setContactPhoneNumber(null);
+        }
+    }
+
+    private void scrubCards(List<ListingCardResponse> cards) {
+        if (cards == null) {
+            return;
+        }
+        cards.forEach(this::scrubCard);
+    }
+
+    private void scrubCard(ListingCardResponse card) {
+        if (card == null || card.getUser() == null) {
+            return;
+        }
+        // UserCard is builder-only (no setters), so rebuild it without the
+        // contact-bearing fields.
+        ListingCardResponse.UserCard user = card.getUser();
+        card.setUser(
+                ListingCardResponse.UserCard.builder()
+                        .userId(user.getUserId())
+                        .firstName(user.getFirstName())
+                        .lastName(user.getLastName())
+                        .email(null)
+                        .contactPhoneNumber(null)
+                        .contactPhoneVerified(user.getContactPhoneVerified())
+                        .avatarUrl(user.getAvatarUrl())
+                        .isBroker(user.getIsBroker())
+                        .brokerVerificationStatus(user.getBrokerVerificationStatus())
+                        .build());
+    }
+}

--- a/smart-rent/src/main/resources/application.yml
+++ b/smart-rent/src/main/resources/application.yml
@@ -205,6 +205,13 @@ application:
     allowed-origins: "${CORS_ALLOWED_ORIGINS:http://localhost:3000}"
   admin:
     contact-phone-number: "${ADMIN_CONTACT_PHONE}"
+  contact:
+    # Withhold seller contact (phone/email/zalo) from listing responses served to
+    # anonymous callers. Shipped OFF: enabling it requires the web frontend to
+    # render its "log in to view contact" affordance from an availability flag
+    # (today it keys off the value) and the AI service to forward the user token
+    # so authenticated chat still gets contact. See ContactVisibility.
+    strip-anonymous-contact: ${STRIP_ANONYMOUS_CONTACT:false}
   authorize-ignored:
     methods:
       get:


### PR DESCRIPTION
## What

`ContactVisibility` withholds a seller's **phone / email / zalo** from listing responses served to **anonymous** callers, so contact can't be scraped without logging in. Names, avatars and broker status are kept.

Wired into the public listing endpoints:
- `GET /v1/listings/{id}` (detail) and `GET /v1/listings` (by ids / paginated)
- `POST /v1/listings/search`, `POST /v1/listings/search/cursor`
- `GET /v1/listings/homepage-tier`
- `GET /v1/listings/sellers/{userId}/{diamond,gold,silver,normal,top-saved}`

Anonymous is detected via `SecurityContextHolder` (null / not-authenticated / `anonymousUser`).

## ⚠️ Gated OFF by default

`application.contact.strip-anonymous-contact` (env `STRIP_ANONYMOUS_CONTACT`) — **default `false`**. While off, behaviour is unchanged. It is shipped off because enabling it requires two coupled changes to land + be verified first:

1. **Frontend** — the seller card / listing detail / chat card currently render the "log in to view contact" affordance from the *presence of the value*. With a stripped payload a guest would see "no contact available" instead of the login prompt, so the FE must switch to an **availability flag**. (The login gating itself already shipped in FATU29/smartrent-fe#497.)
2. **AI service** — the chatbot calls the BE listing endpoints **anonymously** today, so a strip would blank the chat contact card even for logged-in users. Fixed by forwarding the user token: **smartrent-ai `feat/forward-token-listing-calls`** (guests stay stripped, which the gated chat card handles).

Once both are deployed and verified, flip `STRIP_ANONYMOUS_CONTACT=true`.

## Verification

`./gradlew compileJava` — green against `origin/main`. No behaviour change while the flag is off; no existing response is altered until enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
