### PR TITLE
feat(admin): surface AI quick-approve suggestion in admin listing sum…

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/dto/response/AdminListingSummary.java
+++ b/smart-rent/src/main/java/com/smartrent/dto/response/AdminListingSummary.java
@@ -96,6 +96,32 @@ public class AdminListingSummary {
             "Redundant with moderationStatus=REMOVED now; kept for backward compatibility.")
     Boolean permanentlyRemoved;
 
+    @Schema(description = "Present only when the AI background moderation job already suggests this listing " +
+            "is safe to approve and no admin has acted on it yet — drives the admin table's quick-approve affordance. " +
+            "Null for every other state (still pending, AI flagged it, or an admin already reviewed it).")
+    AiModerationSummary aiModeration;
+
+    @Getter
+    @Setter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @FieldDefaults(level = AccessLevel.PRIVATE)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @Schema(description = "AI auto-moderation suggestion summary for the admin quick-approve affordance")
+    public static class AiModerationSummary {
+
+        @Schema(description = "AI confidence score, 0-1", example = "0.92")
+        Double score;
+
+        @Schema(description = "Short human-readable reason the AI gave for its suggestion")
+        String reason;
+
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+        @Schema(description = "When the AI analysis was last run")
+        LocalDateTime analyzedAt;
+    }
+
     @Getter
     @Setter
     @Builder

--- a/smart-rent/src/main/java/com/smartrent/mapper/ListingMapper.java
+++ b/smart-rent/src/main/java/com/smartrent/mapper/ListingMapper.java
@@ -56,8 +56,10 @@ public interface ListingMapper {
      * @param owner Listing owner entity (nullable). Used to build the slim OwnerSummary.
      * @param verificationStatus Verification status (PENDING/APPROVED/REJECTED/NOT_SUBMITTED)
      * @param images Pre-resolved image URLs for the listing (primary first, then sortOrder).
+     * @param aiModeration Pre-built AI quick-approve summary (null unless the AI already suggests approval and no admin has acted yet).
      */
-    AdminListingSummary toAdminSummary(Listing entity, User owner, String verificationStatus, List<String> images);
+    AdminListingSummary toAdminSummary(Listing entity, User owner, String verificationStatus, List<String> images,
+            AdminListingSummary.AiModerationSummary aiModeration);
 
     /**
      * Map Listing entity to ListingResponseForOwner with owner-specific information

--- a/smart-rent/src/main/java/com/smartrent/mapper/impl/ListingMapperImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/mapper/impl/ListingMapperImpl.java
@@ -363,7 +363,8 @@ public class ListingMapperImpl implements ListingMapper {
     }
 
     @Override
-    public AdminListingSummary toAdminSummary(Listing entity, User owner, String verificationStatus, List<String> images) {
+    public AdminListingSummary toAdminSummary(Listing entity, User owner, String verificationStatus, List<String> images,
+            AdminListingSummary.AiModerationSummary aiModeration) {
         AdminListingSummary.OwnerSummary ownerSummary = owner == null ? null
                 : AdminListingSummary.OwnerSummary.builder()
                         .userId(owner.getUserId())
@@ -401,6 +402,7 @@ public class ListingMapperImpl implements ListingMapper {
                 .lastModerationReasonCode(entity.getLastModerationReasonCode())
                 .lastModerationReasonText(entity.getLastModerationReasonText())
                 .permanentlyRemoved(entity.getPermanentlyRemoved())
+                .aiModeration(aiModeration)
                 .build();
     }
 

--- a/smart-rent/src/main/java/com/smartrent/service/listing/impl/ListingServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/listing/impl/ListingServiceImpl.java
@@ -53,6 +53,7 @@ import com.smartrent.infra.repository.TransactionRepository;
 import com.smartrent.infra.repository.UserRepository;
 import com.smartrent.infra.repository.VipTierDetailRepository;
 import com.smartrent.infra.repository.entity.*;
+import com.smartrent.infra.repository.entity.enums.VerificationStatus;
 import com.smartrent.mapper.ListingMapper;
 import com.smartrent.service.listing.ListingService;
 import com.smartrent.service.listing.ListingQueryService;
@@ -68,6 +69,7 @@ import com.smartrent.service.payment.PaymentService;
 import com.smartrent.service.transaction.TransactionService;
 import com.smartrent.service.address.AddressCreationService;
 import com.smartrent.service.address.AddressService;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
@@ -143,6 +145,7 @@ public class ListingServiceImpl implements ListingService {
     org.springframework.context.ApplicationEventPublisher eventPublisher;
     com.smartrent.infra.repository.ListingAiModerationRepository listingAiModerationRepository;
     com.smartrent.service.pricing.PricingHistoryService pricingHistoryService;
+    ObjectMapper objectMapper;
 
     @Override
     @Transactional
@@ -2263,6 +2266,14 @@ public class ListingServiceImpl implements ListingService {
                             LinkedHashMap::new,
                             Collectors.mapping(Media::getUrl, Collectors.toList())));
 
+            // ---- Batch-load AI moderation rows for the page — 1 query ----
+            // Drives the quick-approve affordance: only listings the AI already
+            // suggested approving, and that no admin has acted on yet, get a
+            // non-null aiModeration summary below.
+            Map<Long, ListingAiModeration> aiModerationByListingId =
+                    listingAiModerationRepository.findAllById(listingIds).stream()
+                            .collect(Collectors.toMap(ListingAiModeration::getListingId, Function.identity()));
+
             // ---- Map to slim AdminListingSummary DTOs ----
             // (No amenity/address fetch — list view does not need them.)
             // The moderationStatus itself (REJECTED / SUSPENDED / REMOVED) now carries
@@ -2279,7 +2290,9 @@ public class ListingServiceImpl implements ListingService {
                         }
                         com.smartrent.infra.repository.entity.User owner = userMap.get(listing.getUserId());
                         List<String> images = imagesByListingId.getOrDefault(listing.getListingId(), Collections.emptyList());
-                        return listingMapper.toAdminSummary(listing, owner, verificationStatus, images);
+                        com.smartrent.dto.response.AdminListingSummary.AiModerationSummary aiModeration =
+                                buildAiModerationSummary(aiModerationByListingId.get(listing.getListingId()));
+                        return listingMapper.toAdminSummary(listing, owner, verificationStatus, images, aiModeration);
                     })
                     .collect(Collectors.toList());
         } else {
@@ -2299,6 +2312,41 @@ public class ListingServiceImpl implements ListingService {
                 .totalPages(page.getTotalPages())
                 .filterCriteria(filter)
                 .statistics(statistics)
+                .build();
+    }
+
+    /**
+     * Builds the admin table's quick-approve summary for a single listing, or
+     * null when quick-approve doesn't apply. Only listings the AI's background
+     * moderation job already suggested approving ({@link VerificationStatus#VERIFIED})
+     * AND that no admin has since acted on ({@code manualOverride == false}) are
+     * eligible — ListingModerationServiceImpl flips manualOverride to true (and
+     * re-stamps verificationStatus) the moment an admin approves, rejects, or
+     * requests revision, so this naturally stops surfacing once a human has
+     * reviewed the listing.
+     */
+    private com.smartrent.dto.response.AdminListingSummary.AiModerationSummary buildAiModerationSummary(
+            ListingAiModeration moderation) {
+        if (moderation == null
+                || moderation.getVerificationStatus() != VerificationStatus.VERIFIED
+                || Boolean.TRUE.equals(moderation.getManualOverride())) {
+            return null;
+        }
+
+        String reason = null;
+        if (moderation.getAiReason() != null) {
+            try {
+                reason = objectMapper.readTree(moderation.getAiReason())
+                        .path("verification").path("reason").path("details").asText(null);
+            } catch (Exception e) {
+                log.warn("Failed to parse ai_reason for listing {}: {}", moderation.getListingId(), e.getMessage());
+            }
+        }
+
+        return com.smartrent.dto.response.AdminListingSummary.AiModerationSummary.builder()
+                .score(moderation.getAiScore())
+                .reason(reason)
+                .analyzedAt(moderation.getUpdatedAt())
                 .build();
     }
 


### PR DESCRIPTION
…mary

The admin listing table only showed AI moderation results inside the per-listing review dialog, requiring an admin to open every post to see whether the background AI job already vetted it. Batch-load each page's listing_ai_moderation rows alongside the existing owner/media batch loads and expose a slim aiModeration summary (score, short reason, analyzedAt) on AdminListingSummary — populated only when the AI suggested approval and no admin has acted on the listing yet, so the frontend can render a quick-approve affordance without an extra request per row.