### PR TITLE
Add dynamic filter-bucket options endpoint for listings sidebar

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/config/Constants.java
+++ b/smart-rent/src/main/java/com/smartrent/config/Constants.java
@@ -46,6 +46,12 @@ public class Constants {
      * so even a 60s TTL absorbs most repeat hits while keeping pins fresh.
      */
     public static final String LISTING_MAP = LISTING + "map";
+    /**
+     * Dynamic filter-bucket counts (POST /v1/listings/filter-options) for the
+     * public listings sidebar (price/area/bedrooms). Keyed by the same shape as
+     * {@link #LISTING_SEARCH} — see application.yml for the TTL.
+     */
+    public static final String LISTING_FILTER_OPTIONS = LISTING + "filter-options";
     public static final String LISTING_RECOMMENDATION_SIMILAR = LISTING + "recommendation.similar";
     public static final String LISTING_RECOMMENDATION_PERSONALIZED = LISTING + "recommendation.personalized";
   }

--- a/smart-rent/src/main/java/com/smartrent/controller/ListingSearchController.java
+++ b/smart-rent/src/main/java/com/smartrent/controller/ListingSearchController.java
@@ -308,6 +308,33 @@ public class ListingSearchController {
         return ApiResponse.<ListingCardListResponse>builder().data(response).build();
     }
 
+    @PostMapping("/filter-options")
+    @Operation(
+        summary = "[PUBLIC API] Dynamic filter bucket options with live counts",
+        description = """
+            **PUBLIC API - Không cần authentication**
+
+            Trả về các khoảng lọc động (bucket, tối đa 5 mỗi nhóm) cho **giá**,
+            **diện tích** và **số phòng ngủ** hiển thị ở sidebar lọc trang tìm kiếm —
+            mỗi bucket kèm số lượng tin đăng còn khớp (`count`), để frontend có thể
+            ẩn/làm mờ bucket không còn dữ liệu thay vì để người dùng bấm vào ngõ cụt.
+
+            Body giống hệt `POST /search` (`ListingFilterRequest`). Field
+            `price`/`area`/`bedroomsRange`/`bedrooms` trong body bị BỎ QUA cho
+            chính nhóm bucket tương ứng (chúng mô tả nhóm đang tính, không phải một
+            ràng buộc lên nó) — mọi field còn lại (vị trí, `productType`,
+            `categoryId`, ...) được giữ nguyên làm ngữ cảnh lọc cho cả 3 nhóm.
+            """
+    )
+    public ApiResponse<ListingFilterOptionsResponse> getListingFilterOptions(
+            @RequestBody(required = false) ListingFilterRequest filter) {
+        if (filter == null) {
+            filter = ListingFilterRequest.builder().build();
+        }
+        ListingFilterOptionsResponse response = listingService.getFilterOptions(filter);
+        return ApiResponse.<ListingFilterOptionsResponse>builder().data(response).build();
+    }
+
     @GetMapping("/autocomplete")
     @Operation(
         summary = "Autocomplete listing titles",

--- a/smart-rent/src/main/java/com/smartrent/dto/request/ListingFilterRequest.java
+++ b/smart-rent/src/main/java/com/smartrent/dto/request/ListingFilterRequest.java
@@ -16,7 +16,7 @@ import java.util.List;
 
 @Getter
 @Setter
-@Builder
+@Builder(toBuilder = true)
 @NoArgsConstructor
 @AllArgsConstructor
 @FieldDefaults(level = AccessLevel.PRIVATE)

--- a/smart-rent/src/main/java/com/smartrent/dto/response/FilterBucketOption.java
+++ b/smart-rent/src/main/java/com/smartrent/dto/response/FilterBucketOption.java
@@ -1,0 +1,31 @@
+package com.smartrent.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.FieldDefaults;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@FieldDefaults(level = AccessLevel.PRIVATE)
+@Schema(description = "One selectable bucket of a dynamic filter (price/area/bedrooms), "
+        + "with the live count of listings it would match under the current filter context")
+public class FilterBucketOption {
+
+    @Schema(description = "Stable identifier matching a frontend i18n label", example = "3to7M")
+    String key;
+
+    @Schema(description = "Lower bound (inclusive), null = no lower bound", example = "3000000")
+    Double min;
+
+    @Schema(description = "Upper bound (inclusive), null = no upper bound", example = "7000000")
+    Double max;
+
+    @Schema(description = "Number of listings matching this bucket, given every other active filter", example = "128")
+    long count;
+}

--- a/smart-rent/src/main/java/com/smartrent/dto/response/ListingFilterOptionsResponse.java
+++ b/smart-rent/src/main/java/com/smartrent/dto/response/ListingFilterOptionsResponse.java
@@ -1,0 +1,27 @@
+package com.smartrent.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.FieldDefaults;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@FieldDefaults(level = AccessLevel.PRIVATE)
+@Schema(description = "Dynamic filter bucket options for the public listings sidebar "
+        + "(price / area / bedrooms), each annotated with a live count under the current filter context")
+public class ListingFilterOptionsResponse {
+
+    List<FilterBucketOption> priceOptions;
+
+    List<FilterBucketOption> areaOptions;
+
+    List<FilterBucketOption> bedroomOptions;
+}

--- a/smart-rent/src/main/java/com/smartrent/service/listing/ListingFilterBucketDefinitions.java
+++ b/smart-rent/src/main/java/com/smartrent/service/listing/ListingFilterBucketDefinitions.java
@@ -1,0 +1,50 @@
+package com.smartrent.service.listing;
+
+import java.util.List;
+
+/**
+ * Canonical bucket boundaries for the public listings sidebar's dynamic filters
+ * (price / area / bedrooms). Single source of truth: the frontend's i18n labels
+ * are keyed by {@link Bucket#key()}, so a bucket can only be renamed here and in
+ * the frontend message files together — never in only one place.
+ */
+public final class ListingFilterBucketDefinitions {
+
+    private ListingFilterBucketDefinitions() {
+    }
+
+    public record Bucket(String key, Long min, Long max) {
+    }
+
+    /**
+     * VND (any {@code priceUnit}). Either bound may be {@code null} for an open
+     * range. 3M-5M gets its own bucket (not folded into a wider 3-7M band) since
+     * it's the single most common room-rental ("phòng trọ") budget in Vietnam.
+     */
+    public static final List<Bucket> PRICE = List.of(
+            new Bucket("under3M", null, 3_000_000L),
+            new Bucket("3to5M", 3_000_000L, 5_000_000L),
+            new Bucket("5to10M", 5_000_000L, 10_000_000L),
+            new Bucket("10to20M", 10_000_000L, 20_000_000L),
+            new Bucket("over20M", 20_000_000L, null)
+    );
+
+    /**
+     * m². Skewed toward the small end (phòng trọ are typically 15-40m²,
+     * distinct from mini-apartments and houses) rather than an even split.
+     */
+    public static final List<Bucket> AREA = List.of(
+            new Bucket("under20", null, 20L),
+            new Bucket("20to35", 20L, 35L),
+            new Bucket("35to60", 35L, 60L),
+            new Bucket("60to100", 60L, 100L),
+            new Bucket("over100", 100L, null)
+    );
+
+    public static final List<Bucket> BEDROOM = List.of(
+            new Bucket("1", 1L, 1L),
+            new Bucket("2to3", 2L, 3L),
+            new Bucket("4to5", 4L, 5L),
+            new Bucket("6plus", 6L, null)
+    );
+}

--- a/smart-rent/src/main/java/com/smartrent/service/listing/ListingService.java
+++ b/smart-rent/src/main/java/com/smartrent/service/listing/ListingService.java
@@ -108,6 +108,18 @@ public interface ListingService {
             ListingFilterRequest filter, String cursor, int size);
 
     /**
+     * Dynamic bucket options (price / area / bedrooms) for the public listings
+     * sidebar filters. Each bucket is annotated with a live count of listings
+     * matching every OTHER active filter — so the frontend can grey out /
+     * hide buckets with zero results instead of letting users click into a
+     * dead-end filter. {@code filter.price}/{@code area}/{@code bedroomsRange}/
+     * {@code bedrooms} on the incoming request are ignored (they describe the
+     * dimension being computed, not a constraint on it); every other field
+     * (location, productType, categoryId, ...) is used as filter context.
+     */
+    com.smartrent.dto.response.ListingFilterOptionsResponse getFilterOptions(ListingFilterRequest filter);
+
+    /**
      * Public endpoint data source: get top saved listings for a specific seller.
      * Sorted by number of saves descending.
      *

--- a/smart-rent/src/main/java/com/smartrent/service/listing/impl/ListingServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/listing/impl/ListingServiceImpl.java
@@ -16,9 +16,11 @@ import com.smartrent.dto.request.VipListingCreationRequest;
 import com.smartrent.dto.response.CategoryListingStatsResponse;
 import com.smartrent.dto.response.AddressConversionResponse;
 import com.smartrent.dto.response.DraftListingResponse;
+import com.smartrent.dto.response.FilterBucketOption;
 import com.smartrent.dto.response.ListingCreationResponse;
 import com.smartrent.dto.response.ListingCardListResponse;
 import com.smartrent.dto.response.ListingCardResponse;
+import com.smartrent.dto.response.ListingFilterOptionsResponse;
 import com.smartrent.dto.response.ListingListResponse;
 import com.smartrent.dto.response.ListingResponse;
 import com.smartrent.dto.response.ListingResponseWithAdmin;
@@ -54,7 +56,9 @@ import com.smartrent.infra.repository.UserRepository;
 import com.smartrent.infra.repository.VipTierDetailRepository;
 import com.smartrent.infra.repository.entity.*;
 import com.smartrent.infra.repository.entity.enums.VerificationStatus;
+import com.smartrent.infra.repository.specification.ListingSpecification;
 import com.smartrent.mapper.ListingMapper;
+import com.smartrent.service.listing.ListingFilterBucketDefinitions;
 import com.smartrent.service.listing.ListingService;
 import com.smartrent.service.listing.ListingQueryService;
 import com.smartrent.service.listing.PostingAccessGuard;
@@ -96,6 +100,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -1636,6 +1641,65 @@ public class ListingServiceImpl implements ListingService {
                 .hasNext(hasNext)
                 .size(safeSize)
                 .build();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    @Cacheable(cacheNames = com.smartrent.config.Constants.CacheNames.LISTING_FILTER_OPTIONS,
+            key = "T(com.smartrent.util.CacheKeyBuilder).listingSearchKey(#filter)",
+            unless = "#result == null")
+    public ListingFilterOptionsResponse getFilterOptions(ListingFilterRequest filter) {
+        // Resolve legacy<->new address mappings ONCE on the shared filter — each
+        // of the three toBuilder() copies below inherits the resolved fields, so
+        // the (DB-backed) resolution never re-runs per bucket.
+        resolveAddressMappings(filter);
+
+        return ListingFilterOptionsResponse.builder()
+                .priceOptions(countFilterBuckets(
+                        filter.toBuilder().price(null).build(),
+                        ListingFilterBucketDefinitions.PRICE,
+                        ListingFilterRequest::setPrice))
+                .areaOptions(countFilterBuckets(
+                        filter.toBuilder().area(null).build(),
+                        ListingFilterBucketDefinitions.AREA,
+                        ListingFilterRequest::setArea))
+                .bedroomOptions(countFilterBuckets(
+                        filter.toBuilder().bedroomsRange(null).bedrooms(null).build(),
+                        ListingFilterBucketDefinitions.BEDROOM,
+                        ListingFilterRequest::setBedroomsRange))
+                .build();
+    }
+
+    /**
+     * Counts listings per bucket for one dimension (price/area/bedrooms). Every
+     * OTHER active filter on {@code contextFilter} (location, productType,
+     * category, ...) is kept, so a bucket with {@code count == 0} genuinely has
+     * no matching listings under the user's current selection — the frontend
+     * can grey it out instead of letting the user click into a dead end.
+     * {@code contextFilter} is mutated and reused across buckets (each
+     * {@code count(spec)} call fully evaluates before the next mutation), which
+     * avoids re-copying ~60 fields per bucket.
+     */
+    private List<FilterBucketOption> countFilterBuckets(
+            ListingFilterRequest contextFilter,
+            List<ListingFilterBucketDefinitions.Bucket> buckets,
+            BiConsumer<ListingFilterRequest, String> rangeSetter) {
+        List<FilterBucketOption> options = new ArrayList<>(buckets.size());
+        for (ListingFilterBucketDefinitions.Bucket bucket : buckets) {
+            rangeSetter.accept(contextFilter, bucketRangeString(bucket.min(), bucket.max()));
+            long count = listingRepository.count(ListingSpecification.fromFilterRequest(contextFilter));
+            options.add(FilterBucketOption.builder()
+                    .key(bucket.key())
+                    .min(bucket.min() != null ? bucket.min().doubleValue() : null)
+                    .max(bucket.max() != null ? bucket.max().doubleValue() : null)
+                    .count(count)
+                    .build());
+        }
+        return options;
+    }
+
+    private static String bucketRangeString(Long min, Long max) {
+        return (min != null ? min : "") + ".." + (max != null ? max : "");
     }
 
             @Override

--- a/smart-rent/src/main/resources/application.yml
+++ b/smart-rent/src/main/resources/application.yml
@@ -158,6 +158,7 @@ spring:
       - "listing.detail"
       - "listing.suggestions"
       - "listing.map"
+      - "listing.filter-options"
       - "listing.stats.categories"
       - "listing.stats.provinces"
       - "listing.stats.admin"
@@ -176,6 +177,12 @@ spring:
         "[listing.detail]": 3m
         "[listing.suggestions]": 2m
         "[listing.map]": 1m
+        # Sidebar filter-bucket counts (price/area/bedrooms): each request runs up
+        # to ~14 COUNT(*) queries (one per bucket across 3 dimensions), so a short
+        # TTL matters more here than for a single-query endpoint — repeated calls
+        # for the same filter context (e.g. re-render, browser back/forward) reuse
+        # one computed result instead of re-running the whole batch.
+        "[listing.filter-options]": 3m
         # Homepage stats: permanent (0s = no TTL). Refreshed daily at 00:00
         # Asia/Ho_Chi_Minh by HomepageStatsCacheScheduler.
         "[listing.stats.categories]": 0s

--- a/smart-rent/src/main/resources/db/migration/V123__Add_listings_filter_bucket_indexes.sql
+++ b/smart-rent/src/main/resources/db/migration/V123__Add_listings_filter_bucket_indexes.sql
@@ -1,0 +1,16 @@
+-- Indexes supporting the dynamic filter-bucket endpoint
+-- (POST /v1/listings/filter-options), which counts listings per price/area/
+-- bedrooms bucket to drive the public listings sidebar filters.
+--
+-- Each bucket count runs the same "public visibility" WHERE prefix as every
+-- other public listing query (moderation_status/is_shadow/is_draft/expired),
+-- then range-filters on ONE of price/area/bedrooms.
+--
+-- Price is already covered by idx_listings_public_price_sort (moderation_status,
+-- is_shadow, is_draft, expired, price) — no new index needed there. area and
+-- bedrooms have no equivalent, so add the same shape for both.
+CREATE INDEX idx_listings_public_area_filter
+    ON listings (moderation_status, is_shadow, is_draft, expired, area);
+
+CREATE INDEX idx_listings_public_bedrooms_filter
+    ON listings (moderation_status, is_shadow, is_draft, expired, bedrooms);


### PR DESCRIPTION
POST /v1/listings/filter-options returns live-counted price/area/bedroom buckets (5 each, tuned to the VN rental market) for the public listings sidebar, so the frontend can grey out buckets with zero matching listings instead of letting users click into a dead-end filter. Adds two supporting indexes (price is already covered by an existing index) and a short-TTL cache since each call runs a batch of COUNT queries.