### PR TITLE
Fix filter-options auth allowlist and warm its cache daily

### DIFF
--- a/smart-rent/src/main/java/com/smartrent/config/Constants.java
+++ b/smart-rent/src/main/java/com/smartrent/config/Constants.java
@@ -52,6 +52,16 @@ public class Constants {
      * {@link #LISTING_SEARCH} — see application.yml for the TTL.
      */
     public static final String LISTING_FILTER_OPTIONS = LISTING + "filter-options";
+    /**
+     * Permanent (no-TTL) subset of {@link #LISTING_FILTER_OPTIONS} for the
+     * bounded "first load, no filters yet" (province × productType) baseline —
+     * refreshed daily by {@code FilterOptionsCacheScheduler}, same pattern as
+     * {@link #LISTING_STATS_CATEGORIES}/{@link #LISTING_STATS_PROVINCES}. Only
+     * ever read/written for requests matching
+     * {@code ListingFilterBucketDefinitions.BASELINE_WARM_PROVINCE_IDS} — see
+     * {@code ListingSearchController#isBaselineFilterOptionsRequest}.
+     */
+    public static final String LISTING_FILTER_OPTIONS_BASELINE = LISTING + "filter-options.baseline";
     public static final String LISTING_RECOMMENDATION_SIMILAR = LISTING + "recommendation.similar";
     public static final String LISTING_RECOMMENDATION_PERSONALIZED = LISTING + "recommendation.personalized";
   }

--- a/smart-rent/src/main/java/com/smartrent/controller/ListingSearchController.java
+++ b/smart-rent/src/main/java/com/smartrent/controller/ListingSearchController.java
@@ -331,8 +331,46 @@ public class ListingSearchController {
         if (filter == null) {
             filter = ListingFilterRequest.builder().build();
         }
-        ListingFilterOptionsResponse response = listingService.getFilterOptions(filter);
+        ListingFilterOptionsResponse response = isBaselineFilterOptionsRequest(filter)
+                ? listingService.getFilterOptionsBaseline(filter)
+                : listingService.getFilterOptions(filter);
         return ApiResponse.<ListingFilterOptionsResponse>builder().data(response).build();
+    }
+
+    /**
+     * True only for the bounded "first load, no filters yet" shape the daily
+     * {@code FilterOptionsCacheScheduler} pre-warms: a legacy-structure
+     * {@code provinceId} from {@code BASELINE_WARM_PROVINCE_IDS}, an optional
+     * {@code productType}, and nothing else set. Membership in that exact
+     * province list (not just "shape") matters — routing an unwarmed province
+     * into the permanent cache would cache it cold and never refresh it again.
+     */
+    private static boolean isBaselineFilterOptionsRequest(ListingFilterRequest filter) {
+        if (!Boolean.TRUE.equals(filter.getIsLegacy())
+                || filter.getProvinceId() == null
+                || !com.smartrent.service.listing.ListingFilterBucketDefinitions
+                        .BASELINE_WARM_PROVINCE_IDS.contains(filter.getProvinceId())
+                || filter.getProvinceCode() != null
+                || (filter.getProvinceCodes() != null && !filter.getProvinceCodes().isEmpty())) {
+            return false;
+        }
+
+        ListingFilterRequest cleared = clearBaselineContextFields(filter);
+        ListingFilterRequest empty = clearBaselineContextFields(ListingFilterRequest.builder().build());
+        return com.smartrent.util.CacheKeyBuilder.listingSearchKey(cleared)
+                .equals(com.smartrent.util.CacheKeyBuilder.listingSearchKey(empty));
+    }
+
+    private static ListingFilterRequest clearBaselineContextFields(ListingFilterRequest filter) {
+        return filter.toBuilder()
+                .provinceId(null)
+                .isLegacy(null)
+                .productType(null)
+                .page(null)
+                .size(null)
+                .sortBy(null)
+                .sortDirection(null)
+                .build();
     }
 
     @GetMapping("/autocomplete")

--- a/smart-rent/src/main/java/com/smartrent/cronjob/FilterOptionsCacheScheduler.java
+++ b/smart-rent/src/main/java/com/smartrent/cronjob/FilterOptionsCacheScheduler.java
@@ -1,0 +1,82 @@
+package com.smartrent.cronjob;
+
+import com.smartrent.dto.request.ListingFilterRequest;
+import com.smartrent.infra.repository.entity.Listing;
+import com.smartrent.service.listing.ListingFilterBucketDefinitions;
+import com.smartrent.service.listing.ListingService;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.FieldDefaults;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Keeps the "first load, no filters yet" sidebar filter-bucket counts warm
+ * (listing.filter-options.baseline — permanent TTL, see application.yml).
+ * POST /v1/listings/filter-options runs up to ~14 COUNT(*) queries; without
+ * this, every visitor landing on /properties for a (province, productType)
+ * combo pays that cost synchronously on their first request.
+ *
+ * <p>Mirrors {@link HomepageStatsCacheScheduler}: refreshed once a day (offset
+ * 15 minutes later so the two jobs don't contend for the DB at the same
+ * instant), plus warmed on startup so a Redis flush/fresh deploy doesn't leave
+ * the first visitor cold. The warm set — every (province, productType) pair
+ * from {@link ListingFilterBucketDefinitions#BASELINE_WARM_PROVINCE_IDS}, plus
+ * one "no productType" entry per province — MUST stay exhaustive: it is the
+ * only thing standing between a request and a permanently-stale cache entry
+ * (see {@code ListingSearchController#isBaselineFilterOptionsRequest}, which
+ * only routes requests that are guaranteed to be in this exact set).
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
+public class FilterOptionsCacheScheduler {
+
+    ListingService listingService;
+
+    @Scheduled(cron = "0 15 0 * * *", zone = "Asia/Ho_Chi_Minh")
+    public void refreshBaseline() {
+        List<ListingFilterRequest> warmSet = buildWarmSet();
+        log.info("=== Refreshing filter-options baseline cache ({} entries, daily 00:15) ===", warmSet.size());
+        warmSet.forEach(listingService::refreshFilterOptionsBaseline);
+        log.info("=== Filter-options baseline cache refreshed ===");
+    }
+
+    @EventListener(ApplicationReadyEvent.class)
+    public void warmOnStartup() {
+        try {
+            List<ListingFilterRequest> warmSet = buildWarmSet();
+            log.info("Warming filter-options baseline cache on startup ({} entries)", warmSet.size());
+            warmSet.forEach(listingService::getFilterOptionsBaseline);
+        } catch (Exception e) {
+            log.warn("Startup warm of filter-options baseline cache failed (will populate lazily): {}",
+                    e.getMessage());
+        }
+    }
+
+    private static List<ListingFilterRequest> buildWarmSet() {
+        List<ListingFilterRequest> requests = new ArrayList<>();
+        for (String provinceId : ListingFilterBucketDefinitions.BASELINE_WARM_PROVINCE_IDS) {
+            requests.add(baselineRequest(provinceId, null));
+            for (Listing.ProductType productType : Listing.ProductType.values()) {
+                requests.add(baselineRequest(provinceId, productType.name()));
+            }
+        }
+        return requests;
+    }
+
+    private static ListingFilterRequest baselineRequest(String provinceId, String productType) {
+        return ListingFilterRequest.builder()
+                .provinceId(provinceId)
+                .isLegacy(true)
+                .productType(productType)
+                .build();
+    }
+}

--- a/smart-rent/src/main/java/com/smartrent/service/listing/ListingFilterBucketDefinitions.java
+++ b/smart-rent/src/main/java/com/smartrent/service/listing/ListingFilterBucketDefinitions.java
@@ -47,4 +47,18 @@ public final class ListingFilterBucketDefinitions {
             new Bucket("4to5", 4L, 5L),
             new Bucket("6plus", 6L, null)
     );
+
+    /**
+     * Legacy-structure province IDs pre-warmed into the permanent
+     * {@code listing.filter-options.baseline} cache by
+     * {@code FilterOptionsCacheScheduler} — same top provinces as
+     * {@code HomepageStatsCacheScheduler}. Shared constant so the scheduler
+     * (what gets warmed) and the controller (what gets routed to that cache)
+     * can never drift apart: a request only ever reads from the permanent
+     * cache if its province is in THIS list, and the scheduler warms every
+     * (province, productType) pair from THIS list — so nothing routed there
+     * can go stale forever unrefreshed.
+     */
+    public static final List<String> BASELINE_WARM_PROVINCE_IDS =
+            List.of("1", "49", "32", "47", "48");
 }

--- a/smart-rent/src/main/java/com/smartrent/service/listing/ListingService.java
+++ b/smart-rent/src/main/java/com/smartrent/service/listing/ListingService.java
@@ -120,6 +120,24 @@ public interface ListingService {
     com.smartrent.dto.response.ListingFilterOptionsResponse getFilterOptions(ListingFilterRequest filter);
 
     /**
+     * Same computation as {@link #getFilterOptions}, but reads/writes the
+     * permanent, daily-refreshed cache reserved for the bounded
+     * "first load, no filters yet" (province × productType) baseline — see
+     * {@code ListingFilterBucketDefinitions#BASELINE_WARM_PROVINCE_IDS}.
+     * Callers must only pass requests that actually match that bounded shape
+     * (checked by the caller); anything else would permanently cache a key
+     * the daily scheduler never refreshes.
+     */
+    com.smartrent.dto.response.ListingFilterOptionsResponse getFilterOptionsBaseline(ListingFilterRequest filter);
+
+    /**
+     * Recomputes one baseline filter-options entry and OVERWRITES the
+     * permanent cache in place — mirrors {@link #refreshProvinceStats}. Called
+     * only by the daily scheduler, never from a request path.
+     */
+    com.smartrent.dto.response.ListingFilterOptionsResponse refreshFilterOptionsBaseline(ListingFilterRequest filter);
+
+    /**
      * Public endpoint data source: get top saved listings for a specific seller.
      * Sorted by number of saves descending.
      *

--- a/smart-rent/src/main/java/com/smartrent/service/listing/impl/ListingServiceImpl.java
+++ b/smart-rent/src/main/java/com/smartrent/service/listing/impl/ListingServiceImpl.java
@@ -1649,6 +1649,28 @@ public class ListingServiceImpl implements ListingService {
             key = "T(com.smartrent.util.CacheKeyBuilder).listingSearchKey(#filter)",
             unless = "#result == null")
     public ListingFilterOptionsResponse getFilterOptions(ListingFilterRequest filter) {
+        return computeFilterOptions(filter);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    @Cacheable(cacheNames = com.smartrent.config.Constants.CacheNames.LISTING_FILTER_OPTIONS_BASELINE,
+            key = "T(com.smartrent.util.CacheKeyBuilder).listingSearchKey(#filter)",
+            unless = "#result == null")
+    public ListingFilterOptionsResponse getFilterOptionsBaseline(ListingFilterRequest filter) {
+        return computeFilterOptions(filter);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    @CachePut(cacheNames = com.smartrent.config.Constants.CacheNames.LISTING_FILTER_OPTIONS_BASELINE,
+            key = "T(com.smartrent.util.CacheKeyBuilder).listingSearchKey(#filter)",
+            unless = "#result == null")
+    public ListingFilterOptionsResponse refreshFilterOptionsBaseline(ListingFilterRequest filter) {
+        return computeFilterOptions(filter);
+    }
+
+    private ListingFilterOptionsResponse computeFilterOptions(ListingFilterRequest filter) {
         // Resolve legacy<->new address mappings ONCE on the shared filter — each
         // of the three toBuilder() copies below inherits the resolved fields, so
         // the (DB-backed) resolution never re-runs per bucket.

--- a/smart-rent/src/main/resources/application.yml
+++ b/smart-rent/src/main/resources/application.yml
@@ -159,6 +159,7 @@ spring:
       - "listing.suggestions"
       - "listing.map"
       - "listing.filter-options"
+      - "listing.filter-options.baseline"
       - "listing.stats.categories"
       - "listing.stats.provinces"
       - "listing.stats.admin"
@@ -183,6 +184,12 @@ spring:
         # for the same filter context (e.g. re-render, browser back/forward) reuse
         # one computed result instead of re-running the whole batch.
         "[listing.filter-options]": 3m
+        # Bounded (province × productType) "first load" subset of the above:
+        # permanent (0s = no TTL), refreshed daily at 00:15 by
+        # FilterOptionsCacheScheduler — same rationale as the homepage stats
+        # below, so the very first visitor for a warmed province never pays
+        # the cold ~14-query cost.
+        "[listing.filter-options.baseline]": 0s
         # Homepage stats: permanent (0s = no TTL). Refreshed daily at 00:00
         # Asia/Ho_Chi_Minh by HomepageStatsCacheScheduler.
         "[listing.stats.categories]": 0s
@@ -253,6 +260,7 @@ application:
         - "/v1/listings/*/reports"
         - "/v1/listings/search"
         - "/v1/listings/search/cursor"
+        - "/v1/listings/filter-options"
         - "/api/v1/advanced-search"
         - "/v1/listings/stats/provinces"
         - "/v1/listings/stats/categories"


### PR DESCRIPTION
POST /v1/listings/filter-options was missing from the public POST allowlist in application.yml, so every call returned 5001 Unauthenticated instead of running as the public endpoint it's documented to be.

Also add a permanent, daily-refreshed cache tier
(listing.filter-options.baseline) for the bounded "first load, no filters yet" (province x productType) case, mirroring the existing homepage stats scheduler — so the first visitor for a warmed province never pays the cold ~14-COUNT-query cost. Routing into that permanent tier is gated on exact membership in the warmed province/productType set, so nothing can get cached there and go stale forever unrefreshed; every other filter combination keeps using the short-TTL (3m) general cache added in the previous commit.